### PR TITLE
Update Concept Insights models and tests cases based on a code review with nizar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,3 @@ gradlew
 gradlew.bat
 target
 src/test/resources/config.properties
-src/test/java/com/ibm/watson/developer_cloud/visual_insigths

--- a/src/main/java/com/ibm/watson/developer_cloud/concept_insights/v2/ConceptInsights.java
+++ b/src/main/java/com/ibm/watson/developer_cloud/concept_insights/v2/ConceptInsights.java
@@ -15,22 +15,44 @@
  */
 package com.ibm.watson.developer_cloud.concept_insights.v2;
 
-import com.google.gson.JsonArray;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonPrimitive;
-import com.ibm.watson.developer_cloud.concept_insights.v2.model.*;
-import com.ibm.watson.developer_cloud.concept_insights.v2.util.IDValidator;
-import com.ibm.watson.developer_cloud.service.Request;
-import com.ibm.watson.developer_cloud.service.WatsonService;
-import com.ibm.watson.developer_cloud.util.*;
-import org.apache.http.HttpResponse;
-import org.apache.http.client.methods.HttpRequestBase;
-
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.MissingFormatArgumentException;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.HttpRequestBase;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+import com.ibm.watson.developer_cloud.concept_insights.v2.model.Accounts;
+import com.ibm.watson.developer_cloud.concept_insights.v2.model.Annotations;
+import com.ibm.watson.developer_cloud.concept_insights.v2.model.Concept;
+import com.ibm.watson.developer_cloud.concept_insights.v2.model.ConceptMetadata;
+import com.ibm.watson.developer_cloud.concept_insights.v2.model.Concepts;
+import com.ibm.watson.developer_cloud.concept_insights.v2.model.Corpora;
+import com.ibm.watson.developer_cloud.concept_insights.v2.model.Corpus;
+import com.ibm.watson.developer_cloud.concept_insights.v2.model.CorpusProcessingState;
+import com.ibm.watson.developer_cloud.concept_insights.v2.model.CorpusStats;
+import com.ibm.watson.developer_cloud.concept_insights.v2.model.Document;
+import com.ibm.watson.developer_cloud.concept_insights.v2.model.DocumentAnnotations;
+import com.ibm.watson.developer_cloud.concept_insights.v2.model.DocumentProcessingStatus;
+import com.ibm.watson.developer_cloud.concept_insights.v2.model.Documents;
+import com.ibm.watson.developer_cloud.concept_insights.v2.model.Graph;
+import com.ibm.watson.developer_cloud.concept_insights.v2.model.Graphs;
+import com.ibm.watson.developer_cloud.concept_insights.v2.model.Matches;
+import com.ibm.watson.developer_cloud.concept_insights.v2.model.QueryConcepts;
+import com.ibm.watson.developer_cloud.concept_insights.v2.model.RequestedFields;
+import com.ibm.watson.developer_cloud.concept_insights.v2.model.Scores;
+import com.ibm.watson.developer_cloud.concept_insights.v2.util.IDHelper;
+import com.ibm.watson.developer_cloud.service.Request;
+import com.ibm.watson.developer_cloud.service.WatsonService;
+import com.ibm.watson.developer_cloud.util.GsonSingleton;
+import com.ibm.watson.developer_cloud.util.HttpHeaders;
+import com.ibm.watson.developer_cloud.util.MediaType;
+import com.ibm.watson.developer_cloud.util.ResponseUtil;
+import com.ibm.watson.developer_cloud.util.Validate;
 
 /**
  * The IBM Watson™ Concept Insights service provides APIs that enable you to work with
@@ -39,7 +61,7 @@ import java.util.MissingFormatArgumentException;
  * representation of the relationship(s) between concepts. The concept graph used by the
  * Concept Insights service is based on content that has been ingested from the English
  * language Wikipedia.
- *
+ * 
  * @author Nizar Alseddeg (nmalsedd@us.ibm.com)
  * @version v2
  * @see <a
@@ -92,7 +114,6 @@ public class ConceptInsights extends WatsonService {
 	 * The Constant CURSOR. (value is "cursor")
 	 */
 	public static final String CURSOR = "cursor";
-
 
 	/**
 	 * The Constant DOCUMENT_FIELDS. (value is "document_fields")
@@ -188,7 +209,7 @@ public class ConceptInsights extends WatsonService {
 
 	/**
 	 * Identifies concepts in a piece of text.
-	 *
+	 * 
 	 * @param graph
 	 *            - The graph object.
 	 * @param text
@@ -196,7 +217,7 @@ public class ConceptInsights extends WatsonService {
 	 * @return {@link Annotations}
 	 */
 	public Annotations annotateText(final Graph graph, final String text) {
-		IDValidator.getGraphId(graph, getAccountId());
+		IDHelper.getGraphId(graph, getAccountId());
 		Validate.notNull(text, "text can't be null");
 
 		HttpRequestBase request = Request.Post(API_VERSION + graph.getId() + ANNOTATE_TEXT_PATH)
@@ -213,7 +234,7 @@ public class ConceptInsights extends WatsonService {
 
 	/**
 	 * Performs a conceptual search within a corpus.
-	 *
+	 * 
 	 * @param corpus
 	 *            the corpus
 	 * @param parameters
@@ -231,7 +252,7 @@ public class ConceptInsights extends WatsonService {
 	 */
 	public QueryConcepts conceptualSearch(Corpus corpus, Map<String, Object> parameters) {
 		Validate.notNull(parameters.get(IDS), "ids can't be null");
-		String corpusId = IDValidator.getCorpusId(corpus, getAccountId());
+		String corpusId = IDHelper.getCorpusId(corpus, getAccountId());
 
 		Map<String, Object> queryParams = new HashMap<String, Object>();
 		String[] queryParameters = new String[] { CURSOR, LIMIT };
@@ -266,12 +287,12 @@ public class ConceptInsights extends WatsonService {
 
 	/**
 	 * Creates an empty corpus.
-	 *
+	 * 
 	 * @param corpus
 	 *            Corpus the corpus object.
 	 */
 	public void createCorpus(final Corpus corpus) {
-		String corpusId = IDValidator.getCorpusId(corpus, getAccountId());
+		String corpusId = IDHelper.getCorpusId(corpus, getAccountId());
 		HttpRequestBase request = Request.Put(API_VERSION + corpusId)
 				.withContent(GsonSingleton.getGson().toJson(corpus), MediaType.APPLICATION_JSON).build();
 		executeWithoutResponse(request);
@@ -279,12 +300,12 @@ public class ConceptInsights extends WatsonService {
 
 	/**
 	 * Creates a document in a given corpus.
-	 *
+	 * 
 	 * @param document
 	 *            {@link Document} The document to create.
 	 */
 	public void createDocument(final Document document) {
-		IDValidator.getDocumentId(document);
+		IDHelper.getDocumentId(document);
 		HttpRequestBase request = Request.Put(API_VERSION + document.getId())
 				.withContent(GsonSingleton.getGson().toJson(document), MediaType.APPLICATION_JSON).build();
 
@@ -293,32 +314,32 @@ public class ConceptInsights extends WatsonService {
 
 	/**
 	 * Deletes a corpus by ID.
-	 *
+	 * 
 	 * @param corpus
 	 *            Corpus the corpus object.
 	 */
 	public void deleteCorpus(final Corpus corpus) {
-		String corpusId = IDValidator.getCorpusId(corpus, getAccountId());
+		String corpusId = IDHelper.getCorpusId(corpus, getAccountId());
 		HttpRequestBase request = Request.Delete(API_VERSION + corpusId).build();
 		executeWithoutResponse(request);
 	}
 
 	/**
 	 * Deletes a document in a given corpus.
-	 *
+	 * 
 	 * @param document
 	 *            Document the document.
 	 */
 
 	public void deleteDocument(final Document document) {
-		IDValidator.getDocumentId(document);
+		IDHelper.getDocumentId(document);
 		HttpRequestBase request = Request.Delete(API_VERSION + document.getId()).build();
 		executeWithoutResponse(request);
 	}
 
 	/**
 	 * Execute the request and return the POJO that represent the response.
-	 *
+	 * 
 	 * @param <T>
 	 *            The POJO that represents the response object
 	 * @param resourcePath
@@ -348,7 +369,7 @@ public class ConceptInsights extends WatsonService {
 
 	/**
 	 * Gets the account id.
-	 *
+	 * 
 	 * @return the account id
 	 */
 	private String getAccountId() {
@@ -363,7 +384,7 @@ public class ConceptInsights extends WatsonService {
 
 	/**
 	 * Retrieves the account identifiers.
-	 *
+	 * 
 	 * @return the {@link Accounts}
 	 */
 	public Accounts getAccountsInfo() {
@@ -372,43 +393,43 @@ public class ConceptInsights extends WatsonService {
 
 	/**
 	 * Returns information for a specific concept node in a graph.
-	 *
+	 * 
 	 * @param concept
 	 *            Concept the concept object.
 	 * @return {@link ConceptMetadata}
 	 */
 	public ConceptMetadata getConcept(final Concept concept) {
-		IDValidator.getConceptId(concept);
+		IDHelper.getConceptId(concept);
 		return executeRequest(API_VERSION + concept.getId(), null, ConceptMetadata.class);
 	}
 
 	/**
 	 * Retrieves corpus object to a list of individual concepts.
-	 *
+	 * 
 	 * @param corpus
 	 *            Corpus the corpus object.
 	 * @return the Corpus
 	 */
 	public Corpus getCorpus(final Corpus corpus) {
-		String corpusId = IDValidator.getCorpusId(corpus, getAccountId());
+		String corpusId = IDHelper.getCorpusId(corpus, getAccountId());
 		return executeRequest(API_VERSION + corpusId, null, Corpus.class);
 	}
 
 	/**
 	 * Gets processing state of a Corpus.
-	 *
+	 * 
 	 * @param corpus
 	 *            Corpus the corpus object.
 	 * @return {@link CorpusProcessingState} The processing state of a given corpus.
 	 */
 	public CorpusProcessingState getCorpusProcessingState(final Corpus corpus) {
-		String corpusId = IDValidator.getCorpusId(corpus, getAccountId());
+		String corpusId = IDHelper.getCorpusId(corpus, getAccountId());
 		return executeRequest(API_VERSION + corpusId + PROCESSING_STATE_PATH, null, CorpusProcessingState.class);
 	}
 
 	/**
 	 * Retrieves concepts that are related to an entire corpus.
-	 *
+	 * 
 	 * @param corpus
 	 *            the corpus
 	 * @param parameters
@@ -423,7 +444,7 @@ public class ConceptInsights extends WatsonService {
 	 * @return {@link Concepts}
 	 */
 	public Concepts getCorpusRelatedConcepts(final Corpus corpus, final Map<String, Object> parameters) {
-		String corpusId = IDValidator.getCorpusId(corpus, getAccountId());
+		String corpusId = IDHelper.getCorpusId(corpus, getAccountId());
 
 		Map<String, Object> queryParameters = new HashMap<String, Object>();
 		String[] params = new String[] { LEVEL, LIMIT };
@@ -442,7 +463,7 @@ public class ConceptInsights extends WatsonService {
 	/**
 	 * Returns a list of scores that denotes how related an entire corpus is to a list of
 	 * individual concepts.
-	 *
+	 * 
 	 * @param corpus
 	 *            The corpus object
 	 * @param concepts
@@ -450,7 +471,7 @@ public class ConceptInsights extends WatsonService {
 	 * @return {@link Scores}
 	 */
 	public Scores getCorpusRelationScores(final Corpus corpus, final List<Concept> concepts) {
-		String corpusId = IDValidator.getCorpusId(corpus, getAccountId());
+		String corpusId = IDHelper.getCorpusId(corpus, getAccountId());
 		Validate.notNull(concepts, "concepts can't be null");
 
 		Map<String, Object> queryParameters = new HashMap<String, Object>();
@@ -466,55 +487,55 @@ public class ConceptInsights extends WatsonService {
 
 	/**
 	 * Gets processing state of a Corpus.
-	 *
+	 * 
 	 * @param corpus
 	 *            The corpus object
 	 * @return the {@link CorpusStats}
 	 */
 	public CorpusStats getCorpusStats(final Corpus corpus) {
-		String corpusId = IDValidator.getCorpusId(corpus, getAccountId());
+		String corpusId = IDHelper.getCorpusId(corpus, getAccountId());
 		return executeRequest(API_VERSION + corpusId + STATS_PATH, null, CorpusStats.class);
 	}
 
 	/**
 	 * Retrieves a document from a corpus.
-	 *
+	 * 
 	 * @param document
 	 *            Document the document object,
 	 * @return {@link Document}
 	 */
 	public Document getDocument(final Document document) {
-		String documentId = IDValidator.getDocumentId(document);
+		String documentId = IDHelper.getDocumentId(document);
 		return executeRequest(API_VERSION + documentId, null, Document.class);
 	}
 
 	/**
 	 * Retrieves conceptual view of document (including annotations).
-	 *
+	 * 
 	 * @param document
 	 *            Document the document object,
 	 * @return {@link DocumentAnnotations}
 	 */
 	public DocumentAnnotations getDocumentAnnotations(final Document document) {
-		String documentId = IDValidator.getDocumentId(document);
+		String documentId = IDHelper.getDocumentId(document);
 		return executeRequest(API_VERSION + documentId + ANNOTATIONS_PATH, null, DocumentAnnotations.class);
 	}
 
 	/**
 	 * Retrieves processing state of document.
-	 *
+	 * 
 	 * @param document
 	 *            Document the document object,
 	 * @return {@link DocumentProcessingStatus}
 	 */
 	public DocumentProcessingStatus getDocumentProcessingState(final Document document) {
-		String documentId = IDValidator.getDocumentId(document);
+		String documentId = IDHelper.getDocumentId(document);
 		return executeRequest(API_VERSION + documentId + PROCESSING_STATE_PATH, null, DocumentProcessingStatus.class);
 	}
 
 	/**
 	 * Retrieves concepts that are related (in conceptual sense) to a given document.
-	 *
+	 * 
 	 * @param document
 	 *            the document
 	 * @param parameters
@@ -529,7 +550,7 @@ public class ConceptInsights extends WatsonService {
 	 * @return {@link Concepts}
 	 */
 	public Concepts getDocumentRelatedConcepts(final Document document, final Map<String, Object> parameters) {
-		String documentId = IDValidator.getDocumentId(document);
+		String documentId = IDHelper.getDocumentId(document);
 		String[] queryParameters = new String[] { LEVEL, LIMIT };
 		Map<String, Object> queryParams = new HashMap<String, Object>();
 		for (String param : queryParameters) {
@@ -546,7 +567,7 @@ public class ConceptInsights extends WatsonService {
 
 	/**
 	 * Retrieves concepts that are related (in conceptual sense) to a given document.
-	 *
+	 * 
 	 * @param document
 	 *            Document the document object,
 	 * @param concepts
@@ -554,7 +575,7 @@ public class ConceptInsights extends WatsonService {
 	 * @return {@link Scores}
 	 */
 	public Scores getDocumentRelationScores(final Document document, final List<Concept> concepts) {
-		String documentId = IDValidator.getDocumentId(document);
+		String documentId = IDHelper.getDocumentId(document);
 		Validate.notNull(concepts, "concepts can't be null");
 
 		Map<String, Object> queryParams = new HashMap<String, Object>();
@@ -571,27 +592,27 @@ public class ConceptInsights extends WatsonService {
 
 	/**
 	 * Searches for graph concepts by using partial matches.
-	 *
+	 * 
 	 * @param graph
 	 *            the graph
+	 * @param concepts
+	 *            the concepts
 	 * @param parameters
-	 *            The parameters to be used in the service call, account_id, graph are
+	 *            The parameters to be used in the service call, graph and concepts are
 	 *            required.
 	 *            <ul>
-	 *            <li>List&lt;String&gt; concepts - Array of concept IDs, each identifying
-	 *            a concept.<br>
-	 *            <li>String concept - the concept name.<br>
+	 *            <li>RequestedFields concept_fields - Additional fields to be included in
+	 *            the concept objects.<br>
 	 *            <li>Integer level - A number in the range 0 - 3 that represents the
 	 *            level of popularity of related concepts.<br>
 	 *            <li>Integer limit - The maximum number of concepts to be returned.<br>
 	 *            </ul>
 	 * @return {@link Concepts}
 	 */
-	public Concepts getGraphsRelatedConcepts(final Graph graph, final Map<String, Object> parameters) {
-		String graphId = IDValidator.getGraphId(graph, getAccountId());
-		// TODO: we may need to divide this into 2 methods
-		if (parameters.get(CONCEPTS) == null && parameters.get(CONCEPT) == null)
-			throw new MissingFormatArgumentException("concept or concepts should be identified");
+	public Concepts getGraphRelatedConcepts(final Graph graph, final List<Concept> concepts,
+			final Map<String, Object> parameters) {
+		String graphId = IDHelper.getGraphId(graph, getAccountId());
+		Validate.notNull(concepts, "concepts should be specified");
 
 		Map<String, Object> queryParameters = new HashMap<String, Object>();
 		String[] queryParms = new String[] { LEVEL, LIMIT };
@@ -604,37 +625,62 @@ public class ConceptInsights extends WatsonService {
 			if (fields != null && !fields.isEmpty())
 				queryParameters.put(CONCEPT_FIELDS, fields.toString());
 		}
-		if (parameters.get(CONCEPTS) != null) {
-			JsonObject contentJson = new JsonObject();
-			JsonArray conceptsJson = new JsonArray();
-			@SuppressWarnings("unchecked")
-			List<String> concepts = (List<String>) parameters.get(CONCEPTS);
-			for (String value : concepts) {
-				conceptsJson.add(new JsonPrimitive(value));
-			}
-			contentJson.add(CONCEPTS, conceptsJson);
-			queryParameters.put(CONCEPTS, conceptsJson.toString());
-			return executeRequest(API_VERSION + graphId + RELATED_CONCEPTS_PATH, queryParameters, Concepts.class);
-		} else {
-			Concept concept = new Concept(graph, (String) parameters.get(CONCEPT));
-			return executeRequest(API_VERSION + concept.getId() + RELATED_CONCEPTS_PATH + RELATED_CONCEPTS_PATH,
-					queryParameters, Concepts.class);
+		JsonObject contentJson = new JsonObject();
+		JsonArray conceptsJson = new JsonArray();
+		for (Concept concept : concepts) {
+			conceptsJson.add(new JsonPrimitive(concept.getId()));
 		}
+		contentJson.add(CONCEPTS, conceptsJson);
+		queryParameters.put(CONCEPTS, conceptsJson.toString());
+		return executeRequest(API_VERSION + graphId + RELATED_CONCEPTS_PATH, queryParameters, Concepts.class);
+	}
+
+	/**
+	 * Searches for graph concepts from a Concept by using partial matches.
+	 * 
+	 * @param concept
+	 *            the concept
+	 * @param parameters
+	 *            The parameters to be used in the service call.
+	 *            <ul>
+	 *            <li>RequestedFields concept_fields - Additional fields to be included in
+	 *            the concept objects.<br>
+	 *            <li>Integer level - A number in the range 0 - 3 that represents the
+	 *            level of popularity of related concepts.<br>
+	 *            <li>Integer limit - The maximum number of concepts to be returned.<br>
+	 *            </ul>
+	 * @return {@link Concepts}
+	 */
+	public Concepts getConceptRelatedConcepts(final Concept concept, final Map<String, Object> parameters) {
+		String conceptId = IDHelper.getConceptId(concept);
+
+		Map<String, Object> queryParameters = new HashMap<String, Object>();
+		String[] queryParms = new String[] { LEVEL, LIMIT };
+		for (String param : queryParms) {
+			if (parameters.containsKey(param))
+				queryParameters.put(param, parameters.get(param));
+		}
+		if (parameters.get(CONCEPT_FIELDS) != null) {
+			RequestedFields fields = (RequestedFields) parameters.get(CONCEPT_FIELDS);
+			if (fields != null && !fields.isEmpty())
+				queryParameters.put(CONCEPT_FIELDS, fields.toString());
+		}
+		return executeRequest(API_VERSION + conceptId + RELATED_CONCEPTS_PATH, queryParameters, Concepts.class);
 	}
 
 	/**
 	 * Returns a list of scores that denotes how related a source concept is to a list of
 	 * individual concepts.
-	 *
+	 * 
 	 * @param concept
 	 *            Concept the concept object,
 	 * @param concepts
 	 *            Array of concept IDs, each identifying a concept.
-	 *
+	 * 
 	 * @return {@link Scores}
 	 */
-	public Scores getGraphsRelationScores(final Concept concept, final List<String> concepts) {
-		String conceptId = IDValidator.getConceptId(concept);
+	public Scores getGraphRelationScores(final Concept concept, final List<String> concepts) {
+		String conceptId = IDHelper.getConceptId(concept);
 		Validate.notNull(concepts, "concepts can't be null");
 
 		Map<String, Object> queryParameters = new HashMap<String, Object>();
@@ -652,7 +698,7 @@ public class ConceptInsights extends WatsonService {
 
 	/**
 	 * Retrieves the available corpus objects.
-	 *
+	 * 
 	 * @return {@link Corpora}
 	 */
 	public Corpora listCorpora() {
@@ -661,7 +707,7 @@ public class ConceptInsights extends WatsonService {
 
 	/**
 	 * Retrieves the available corpus objects associated with an account identifier.
-	 *
+	 * 
 	 * @param accountId
 	 *            The account identifier.
 	 * @return {@link Corpora}
@@ -673,7 +719,7 @@ public class ConceptInsights extends WatsonService {
 
 	/**
 	 * Retrieves the document ids of a corpus.
-	 *
+	 * 
 	 * @param corpus
 	 *            the corpus
 	 * @param parameters
@@ -693,7 +739,7 @@ public class ConceptInsights extends WatsonService {
 	 * @return {@link Documents}
 	 */
 	public Documents listDocuments(final Corpus corpus, final Map<String, Object> parameters) {
-		String corpusId = IDValidator.getCorpusId(corpus, getAccountId());
+		String corpusId = IDHelper.getCorpusId(corpus, getAccountId());
 
 		Map<String, Object> queryParameters = new HashMap<String, Object>();
 		String[] queryParams = new String[] { CURSOR, LIMIT };
@@ -713,7 +759,7 @@ public class ConceptInsights extends WatsonService {
 
 	/**
 	 * Retrieves the available {@link Graphs}.
-	 *
+	 * 
 	 * @return the {@link Graphs}
 	 */
 	public Graphs listGraphs() {
@@ -723,7 +769,7 @@ public class ConceptInsights extends WatsonService {
 	/**
 	 * Searches for documents and concepts by using partial matches on the label(s)
 	 * fields.
-	 *
+	 * 
 	 * @param corpus
 	 *            the corpus
 	 * @param parameters
@@ -743,7 +789,7 @@ public class ConceptInsights extends WatsonService {
 	 * @return {@link Matches}
 	 */
 	public Matches searchCorpusByLabel(final Corpus corpus, final Map<String, Object> parameters) {
-		String corpusId = IDValidator.getCorpusId(corpus, getAccountId());
+		String corpusId = IDHelper.getCorpusId(corpus, getAccountId());
 		Validate.notNull(parameters.get(QUERY), "query can't be null");
 
 		Map<String, Object> queryParameters = new HashMap<String, Object>();
@@ -769,7 +815,7 @@ public class ConceptInsights extends WatsonService {
 
 	/**
 	 * Searches for graph concepts by using partial matches.<br>
-	 *
+	 * 
 	 * @param graph
 	 *            the graph
 	 * @param parameters
@@ -788,7 +834,7 @@ public class ConceptInsights extends WatsonService {
 	 * @return {@link Matches}
 	 */
 	public Matches searchGraphsConceptByLabel(final Graph graph, final Map<String, Object> parameters) {
-		String graphId = IDValidator.getGraphId(graph, getAccountId());
+		String graphId = IDHelper.getGraphId(graph, getAccountId());
 		Validate.notNull(parameters.get(QUERY), "query can't be null");
 
 		Map<String, Object> queryParameters = new HashMap<String, Object>();
@@ -808,12 +854,12 @@ public class ConceptInsights extends WatsonService {
 
 	/**
 	 * Updates existing corpus meta-data (access and permissions).
-	 *
+	 * 
 	 * @param corpus
 	 *            {@link Corpus} the corpus to update.
 	 */
 	public void updateCorpus(final Corpus corpus) {
-		String corpusId = IDValidator.getCorpusId(corpus, getAccountId());
+		String corpusId = IDHelper.getCorpusId(corpus, getAccountId());
 		HttpRequestBase request = Request.Post(API_VERSION + corpusId)
 				.withContent(GsonSingleton.getGson().toJson(corpus), MediaType.APPLICATION_JSON).build();
 		executeWithoutResponse(request);
@@ -821,12 +867,12 @@ public class ConceptInsights extends WatsonService {
 
 	/**
 	 * Updates a document in a given corpus.
-	 *
+	 * 
 	 * @param document
 	 *            {@link Document} The document to update.
 	 */
 	public void updateDocument(final Document document) {
-		String documentId = IDValidator.getDocumentId(document);
+		String documentId = IDHelper.getDocumentId(document);
 		HttpRequestBase request = Request.Post(API_VERSION + documentId)
 				.withContent(GsonSingleton.getGson().toJson(document), MediaType.APPLICATION_JSON).build();
 		executeWithoutResponse(request);

--- a/src/main/java/com/ibm/watson/developer_cloud/concept_insights/v2/model/Concept.java
+++ b/src/main/java/com/ibm/watson/developer_cloud/concept_insights/v2/model/Concept.java
@@ -17,6 +17,7 @@ package com.ibm.watson.developer_cloud.concept_insights.v2.model;
 
 import com.ibm.watson.developer_cloud.concept_insights.v2.ConceptInsights;
 import com.ibm.watson.developer_cloud.service.model.GenericModel;
+import com.ibm.watson.developer_cloud.util.Validate;
 
 /**
  * Concept returned by the {@link ConceptInsights} service.
@@ -36,7 +37,19 @@ public class Concept extends GenericModel {
 	/**
 	 * Instantiates a new concept.
 	 */
-	public Concept() {
+	public Concept() {}
+
+	/**
+	 * Instantiates a new concept.
+	 *
+	 * @param accountId the account id
+	 * @param graphName the graph name
+	 * @param concept   the concept
+	 */
+	public Concept(final String accountId, final String graphName, final String concept) {
+		Validate.notNull(concept, "concept can't be null");
+		setName(concept);
+		setId(new Graph(accountId, graphName).getId() + "/concepts/" + concept);
 	}
 
 	/**
@@ -47,25 +60,13 @@ public class Concept extends GenericModel {
 	 * @param concept
 	 *            the concept
 	 */
-	public Concept(Graph graph, String concept) {
+	public Concept(final Graph graph, final String concept) {
+		Validate.notNull(graph, "graph can't be null");
+		Validate.notNull(graph.getId(), "graph.id can't be null");
 		setName(concept);
 		setId(graph.getId() + "/concepts/" + concept);
 	}
-
-	/**
-	 * Instantiates a new concept.
-	 * 
-	 * @param accountId
-	 *            the account id
-	 * @param graphName
-	 *            the graph name
-	 * @param conceptId
-	 *            the concept id
-	 */
-	public Concept(String accountId, String graphName, String conceptId) {
-		setId(new Graph(accountId, graphName).getId() + "/concepts/" + conceptId);
-	}
-
+	
 	/**
 	 * Gets the id.
 	 * 

--- a/src/main/java/com/ibm/watson/developer_cloud/concept_insights/v2/model/Corpus.java
+++ b/src/main/java/com/ibm/watson/developer_cloud/concept_insights/v2/model/Corpus.java
@@ -20,6 +20,7 @@ import java.util.List;
 import com.google.gson.annotations.SerializedName;
 import com.ibm.watson.developer_cloud.concept_insights.v2.ConceptInsights;
 import com.ibm.watson.developer_cloud.service.model.GenericModel;
+import com.ibm.watson.developer_cloud.util.Validate;
 
 /**
  * Graphs returned by the {@link ConceptInsights} service.
@@ -50,11 +51,14 @@ public class Corpus extends GenericModel {
 	 * 
 	 * @param accountId
 	 *            the account id
-	 * @param corpusName
+	 * @param name
 	 *            the corpus name
 	 */
-	public Corpus(String accountId, String corpusName) {
-		setId("/corpora/" + accountId + "/" + corpusName);
+	public Corpus(String accountId, String name) {
+		Validate.notNull(accountId,"accountId can't be null");
+		Validate.notNull(name,"name can't be null");
+		setName(name);
+		setId("/corpora/" + accountId + "/" + name);
 	}
 
 	/** The accountPermissions. */

--- a/src/main/java/com/ibm/watson/developer_cloud/concept_insights/v2/model/Document.java
+++ b/src/main/java/com/ibm/watson/developer_cloud/concept_insights/v2/model/Document.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import com.google.gson.annotations.SerializedName;
 import com.ibm.watson.developer_cloud.concept_insights.v2.ConceptInsights;
 import com.ibm.watson.developer_cloud.service.model.GenericModel;
+import com.ibm.watson.developer_cloud.util.Validate;
 
 /**
  * Document returned by the {@link ConceptInsights} service.
@@ -38,11 +39,27 @@ public class Document extends GenericModel {
 	/** The document name. */
 	private String name;
 
-	public Document() {
+	public Document() {}
+
+	public Document(final String accountId, final String corpusName, final String document) {
+		Validate.notNull(document, "document can't be null");
+		setName(document);
+		setId(new Corpus(accountId, corpusName).getId() + "/documents/" + document);
 	}
 
-	public Document(Corpus corpus, String document) {
-		setId(corpus.getId()+"/documents/"+document);
+	/**
+	 * Instantiates a new document.
+	 * 
+	 * @param corpus
+	 *            the corpus
+	 * @param concept
+	 *            the concept
+	 */
+	public Document(final Corpus corpus, final String concept) {
+		Validate.notNull(corpus, "corpus can't be null");
+		Validate.notNull(corpus.getId(), "corpus.id can't be null");
+		setName(concept);
+		setId(corpus.getId() + "/documents/" + concept);
 	}
 
 	/** The last modified. */
@@ -67,7 +84,7 @@ public class Document extends GenericModel {
 
 	/**
 	 * Gets the name.
-	 *
+	 * 
 	 * @return The name
 	 */
 	public String getName() {
@@ -162,7 +179,7 @@ public class Document extends GenericModel {
 
 	/**
 	 * Sets the name.
-	 *
+	 * 
 	 * @param name
 	 *            The name
 	 */

--- a/src/main/java/com/ibm/watson/developer_cloud/concept_insights/v2/model/Graph.java
+++ b/src/main/java/com/ibm/watson/developer_cloud/concept_insights/v2/model/Graph.java
@@ -16,6 +16,7 @@
 package com.ibm.watson.developer_cloud.concept_insights.v2.model;
 
 import com.ibm.watson.developer_cloud.concept_insights.v2.ConceptInsights;
+import com.ibm.watson.developer_cloud.util.Validate;
 
 /**
  * Graph returned by the {@link ConceptInsights} service.
@@ -35,8 +36,7 @@ public class Graph {
 	/**
 	 * Instantiates a new graph.
 	 */
-	public Graph() {
-	}
+	public Graph() {}
 
 	/**
 	 * Instantiates a new graph using the account id and graph name
@@ -47,6 +47,9 @@ public class Graph {
 	 *            the name
 	 */
 	public Graph(String accountId, String name) {
+		Validate.notNull(accountId, "accountId can't be null");
+		Validate.notNull(name, "name can't be null");
+		setName(name);
 		setId("/graphs/" + accountId + "/" + name);
 	}
 
@@ -87,14 +90,15 @@ public class Graph {
 	public void setName(String name) {
 		this.name = name;
 	}
-	
+
 	/**
 	 * With name.
-	 *
-	 * @param name the name
+	 * 
+	 * @param name
+	 *            the name
 	 * @return the graph
 	 */
-	public Graph withName(String name){
+	public Graph withName(String name) {
 		setName(name);
 		return this;
 	}

--- a/src/main/java/com/ibm/watson/developer_cloud/concept_insights/v2/util/IDHelper.java
+++ b/src/main/java/com/ibm/watson/developer_cloud/concept_insights/v2/util/IDHelper.java
@@ -26,7 +26,7 @@ import com.ibm.watson.developer_cloud.concept_insights.v2.model.Graph;
 import com.ibm.watson.developer_cloud.util.Validate;
 
 /**
- * Helper to validate and format resource ids such us corpus_id, graph_id, concept_id, and
+ * Helper to validate and format resource ids such as corpus_id, graph_id, concept_id, and
  * document_id for {@link ConceptInsights},
  * 
  * @author Nizar Alseddeg (nmalsedd@us.ibm.com)

--- a/src/main/java/com/ibm/watson/developer_cloud/concept_insights/v2/util/IDHelper.java
+++ b/src/main/java/com/ibm/watson/developer_cloud/concept_insights/v2/util/IDHelper.java
@@ -26,12 +26,12 @@ import com.ibm.watson.developer_cloud.concept_insights.v2.model.Graph;
 import com.ibm.watson.developer_cloud.util.Validate;
 
 /**
- * Validate resource ids such us corpus_id, graph_id, concept_id, and document_id for
- * {@link ConceptInsights},
- *
+ * Helper to validate and format resource ids such us corpus_id, graph_id, concept_id, and
+ * document_id for {@link ConceptInsights},
+ * 
  * @author Nizar Alseddeg (nmalsedd@us.ibm.com)
  */
-public class IDValidator {
+public class IDHelper {
 
 	/**
 	 * The CORPUS_ID_REGEX. (format is "/corpora/{account_id}/{corpus}")
@@ -57,12 +57,14 @@ public class IDValidator {
 	/**
 	 * This method validate the id if it has been populated in the corpus object,
 	 * otherwise it will generated it.
-	 *
-	 * @param corpus            Corpus the corpus object,
-	 * @param accoundId            String the account id.
+	 * 
+	 * @param corpus
+	 *            Corpus the corpus object,
+	 * @param accoundId
+	 *            String the account id.
 	 * @return the corpus id
 	 */
-	public static String getCorpusId(final Corpus corpus,final String accoundId) {
+	public static String getCorpusId(final Corpus corpus, final String accoundId) {
 		Validate.notNull(corpus, "corpus can't be null");
 		if (corpus.getId() != null) {
 			validate(CORPUS_ID_REGEX, corpus.getId(), "Provide a valid corpus.id (format is " + '"'
@@ -77,12 +79,14 @@ public class IDValidator {
 	/**
 	 * This method validate the id if it has been populated in the graph object, otherwise
 	 * it will generated it.
-	 *
-	 * @param graph            Graph the graph object,
-	 * @param accoundId            String the account id.
+	 * 
+	 * @param graph
+	 *            Graph the graph object,
+	 * @param accoundId
+	 *            String the account id.
 	 * @return the graph id
 	 */
-	public static String getGraphId(final Graph graph,final String accoundId) {
+	public static String getGraphId(final Graph graph, final String accoundId) {
 		Validate.notNull(graph, "graph object can't be null");
 		if (graph.getId() != null) {
 			validate(GRAPH_ID_REGEX, graph.getId(), "Provide a valid graph.id (format is " + '"'
@@ -96,8 +100,9 @@ public class IDValidator {
 
 	/**
 	 * The purpose of this method to validate / generate the document.id.
-	 *
-	 * @param document            Document the document object,
+	 * 
+	 * @param document
+	 *            Document the document object,
 	 * @return the document id
 	 */
 	public static String getDocumentId(final Document document) {
@@ -111,8 +116,9 @@ public class IDValidator {
 
 	/**
 	 * The purpose of this method to validate / generate the concept.id.
-	 *
-	 * @param concept            the concept object,
+	 * 
+	 * @param concept
+	 *            the concept object,
 	 * @return the concept id
 	 */
 	public static String getConceptId(final Concept concept) {
@@ -120,13 +126,13 @@ public class IDValidator {
 		Validate.notNull(concept.getId(), "concept.id can't be null");
 
 		validate(CONCEPT_ID_REGEX, concept.getId(), "Provide a valid concept.id (format is " + '"'
-					+ " (/graphs/{account_id}/{graph}/concepts/{concept})+" + '"' + ")");
+				+ " (/graphs/{account_id}/{graph}/concepts/{concept})+" + '"' + ")");
 		return concept.getId();
 	}
 
 	/**
 	 * ID validation.
-	 *
+	 * 
 	 * @param regex
 	 *            the regex the regular expression used during the validation,
 	 * @param id
@@ -134,7 +140,7 @@ public class IDValidator {
 	 * @param message
 	 *            the exception message if invalid.
 	 */
-	private static void validate(final String regex,final String id,final String message) {
+	private static void validate(final String regex, final String id, final String message) {
 		Pattern pattern = Pattern.compile(regex);
 		Matcher matcher = pattern.matcher(id);
 		if (!matcher.matches()) {

--- a/src/test/java/com/ibm/watson/developer_cloud/alchemy/v1/AlchemyVisionTest.java
+++ b/src/test/java/com/ibm/watson/developer_cloud/alchemy/v1/AlchemyVisionTest.java
@@ -108,7 +108,7 @@ public class AlchemyVisionTest extends WatsonServiceTest {
 	@Test
 	public void testRecognizeFacesFromURL() {
 		Map<String, Object> params = new HashMap<String, Object>();
-		params.put(AlchemyVision.URL, "http://farm4.staticflickr.com/3726/11043305726_fdcb7785ec_m.jpg");
+		params.put(AlchemyVision.URL, "http://visual-recognition-demo.mybluemix.net/images/4068.jpg");
 		ImageFaces image = service.recognizeFaces(params);
 
 		Assert.assertNotNull(image);

--- a/src/test/java/com/ibm/watson/developer_cloud/concept_insights/v2/ConceptInsightsTest.java
+++ b/src/test/java/com/ibm/watson/developer_cloud/concept_insights/v2/ConceptInsightsTest.java
@@ -247,39 +247,36 @@ public class ConceptInsightsTest extends WatsonServiceTest {
 	}
 
 	/**
-	 * Test get graphs related concepts.
+	 * Test get graph related concepts.
 	 */
 	@Test
-	public void testGetGraphsRelatedConcepts() {
+	public void testGetGraphRelatedConcepts() {
 		Map<String, Object> params = new HashMap<String, Object>();
-		List<String> concepts = new ArrayList<String>();
-		concepts.add(EXAMPLE_CONCEPT.getId());
-		params.put(ConceptInsights.CONCEPTS, concepts);
+		List<Concept> concepts = new ArrayList<Concept>();
+		concepts.add(EXAMPLE_CONCEPT);
 		params.put(ConceptInsights.LIMIT, 10);
 		params.put(ConceptInsights.LEVEL, 1);
 		RequestedFields fs = new RequestedFields();
 		fs.include("abstract");
 		params.put("concept_fields", fs);
-		Concepts concepts1 = service.getGraphsRelatedConcepts(Graph.WIKIPEDIA, params);
-		Assert.assertNotNull(concepts1);
+		Concepts conceptResults = service.getGraphRelatedConcepts(Graph.WIKIPEDIA, concepts, params);
+		Assert.assertNotNull(conceptResults);
 	}
 
 	/**
-	 * Test get graphs related concepts by concept id.
+	 * Test get concept related concepts.
 	 */
 	@Test
-	public void testGetGraphsRelatedConceptsByConceptId() {
+	public void testGetConceptRelatedConcepts() {
 		Map<String, Object> params = new HashMap<String, Object>();
-		List<String> concepts = new ArrayList<String>();
-		concepts.add(EXAMPLE_CONCEPT.getId());
-		params.put(ConceptInsights.CONCEPT, "IBM");
 		params.put(ConceptInsights.LIMIT, 10);
 		params.put(ConceptInsights.LEVEL, 1);
 		RequestedFields fs = new RequestedFields();
 		fs.include("abstract");
 		params.put("concept_fields", fs);
-		Concepts concepts1 = service.getGraphsRelatedConcepts(Graph.WIKIPEDIA, params);
-		Assert.assertNotNull(concepts1);
+		Concepts concepts = service.getConceptRelatedConcepts(EXAMPLE_CONCEPT, params);
+		Assert.assertNotNull(concepts);
+		
 	}
 
 	/**
@@ -289,7 +286,7 @@ public class ConceptInsightsTest extends WatsonServiceTest {
 	public void testGetGraphsRelatedScores() {
 		List<String> concepts = new ArrayList<String>();
 		concepts.add(EXAMPLE_CONCEPT.getId());
-		Scores scores = service.getGraphsRelationScores(EXAMPLE_CONCEPT, concepts);
+		Scores scores = service.getGraphRelationScores(EXAMPLE_CONCEPT, concepts);
 		Assert.assertNotNull(scores);
 	}
 

--- a/src/test/java/com/ibm/watson/developer_cloud/language_translation/v2/LanguageTranslationTest.java
+++ b/src/test/java/com/ibm/watson/developer_cloud/language_translation/v2/LanguageTranslationTest.java
@@ -221,8 +221,6 @@ public class LanguageTranslationTest extends WatsonServiceTest {
 		tm.setStatus("error");
 		tm.setName("custom-english-to-spanish");
 
-		System.out.println(GsonSingleton.getGson().toJson(tm));
-
 		mockServer.when(request().withPath(GET_MODELS_PATH + "/" + model_id)).respond(
 				response().withHeaders(new Header(HttpHeaders.Names.CONTENT_TYPE, MediaType.APPLICATION_JSON))
 						.withBody(GsonSingleton.getGson().toJson(tm)));
@@ -231,7 +229,6 @@ public class LanguageTranslationTest extends WatsonServiceTest {
 
 		mockServer.verify(request().withPath(GET_MODELS_PATH + "/" + model_id), VerificationTimes.exactly(1));
 		Assert.assertNotNull(model);
-		// Assert.assertEquals(model.getModelId(),tm.getModelId());
 	}
 
 	/**

--- a/src/test/java/com/ibm/watson/developer_cloud/natural_language_classifier/v1/NaturalLanguageClassifierTest.java
+++ b/src/test/java/com/ibm/watson/developer_cloud/natural_language_classifier/v1/NaturalLanguageClassifierTest.java
@@ -126,7 +126,6 @@ public class NaturalLanguageClassifierTest extends WatsonServiceTest {
         classes.add(c2);
 
         response.setClasses(classes);
-        System.out.println(GsonSingleton.getGson().toJson(response));
 
         StringBuilder text = new StringBuilder().append("is it sunny?");
 

--- a/src/test/java/com/ibm/watson/developer_cloud/speech_to_text/v1/SpeechToTextTest.java
+++ b/src/test/java/com/ibm/watson/developer_cloud/speech_to_text/v1/SpeechToTextTest.java
@@ -175,8 +175,6 @@ public class SpeechToTextTest extends WatsonServiceTest {
 		speechSession.setSessionId("f7332a2d7a138ea9f05ffaa8f697a788");
 		speechSession.setObserveResult("http://ibm.watson.com/speech-to-text/api/v1/sessions/f7332a2d7a138ea9f05ffaa8f697a788/observe_result");
 
-		System.out.print(GsonSingleton.getGson().toJson(speechSession));
-
 		mockServer.when(request().withMethod("POST").withPath(CREATE_DELETE_SESSIONS_PATH)).
 
 				respond(

--- a/src/test/java/com/ibm/watson/developer_cloud/text_to_speech/v1/TextToSpeechTest.java
+++ b/src/test/java/com/ibm/watson/developer_cloud/text_to_speech/v1/TextToSpeechTest.java
@@ -198,7 +198,6 @@ public class TextToSpeechTest extends WatsonServiceTest {
 		voices.add(voice1);
 
 		response.put("voices",voices);
-		System.out.print(GsonSingleton.getGson().toJson(response));
 
 		mockServer.when(request().withPath(GET_VOICES_PATH)).respond(
 				response().withHeaders(new Header(HttpHeaders.Names.CONTENT_TYPE, MediaType.APPLICATION_JSON))

--- a/src/test/java/com/ibm/watson/developer_cloud/tradeoff_analytics/v1/TradeoffAnalyticsTest.java
+++ b/src/test/java/com/ibm/watson/developer_cloud/tradeoff_analytics/v1/TradeoffAnalyticsTest.java
@@ -119,7 +119,6 @@ public class TradeoffAnalyticsTest extends WatsonServiceTest {
 
 		// Call the service and get the resolution
 		Dilemma dilemma = service.dilemmas(problem, false);
-		System.out.println(dilemma);
 		Assert.assertNotNull(dilemma);
 		Assert.assertNotNull(dilemma.getProblem());
 		Assert.assertNotNull(dilemma.getResolution());

--- a/src/test/java/com/ibm/watson/developer_cloud/visual_insigths/v1/VisualInsightsTest.java
+++ b/src/test/java/com/ibm/watson/developer_cloud/visual_insigths/v1/VisualInsightsTest.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright 2015 IBM Corp. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ibm.watson.developer_cloud.visual_insigths.v1;
+
+import java.io.File;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.ibm.watson.developer_cloud.WatsonServiceTest;
+import com.ibm.watson.developer_cloud.visual_insights.v1.VisualInsights;
+import com.ibm.watson.developer_cloud.visual_insights.v1.model.Classifiers;
+import com.ibm.watson.developer_cloud.visual_insights.v1.model.Summary;
+
+/**
+ * @author Nizar Alseddeg (nmalsedd@us.ibm.com)
+ */
+public class VisualInsightsTest extends WatsonServiceTest {
+
+    /** The service. */
+    private VisualInsights service;
+
+
+    /* (non-Javadoc)
+	 * @see com.ibm.watson.developer_cloud.WatsonServiceTest#setUp()
+	 */
+    @Override
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        service = new VisualInsights();
+        service.setUsernameAndPassword(
+                prop.getProperty("visual_insights.username"),
+                prop.getProperty("visual_insights.password")
+        );
+        service.setEndPoint(prop.getProperty("visual_insights.url"));
+    }
+
+    /**
+     * Test get GetClassifiersFilterByName.
+     */
+    @Test
+    public void testGetClassifiers() {
+        Classifiers classifiers = service.getClassifiers();
+        Assert.assertNotNull(classifiers);
+    }
+    /**
+     * Test get GetClassifiersFilterByName.
+     */
+    @Test
+    public void testGetClassifiersFilterByName() {
+        Classifiers classifiers = service.getClassifiers("animal");
+        Assert.assertNotNull(classifiers);
+    }
+    /**
+     * Test get testGetAccounts.
+     */
+    @Test
+    public void testGetSummary() {
+        File images = new File("src/test/resources/images.zip");
+        Summary summary = service.getSummary(images);
+        Assert.assertNotNull(summary);
+    }
+
+
+}


### PR DESCRIPTION
* Update CI models to allow users to specify the `accountId` and `corpusName`
* Renamed `IDValidator` to `IDHelper`
* Splitted `getRelatedConcept` into two methods that now require parameters
outside of the parameters map
* updated test cases