### PR TITLE
renaming Insigths to Insights(typo fix)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ gradlew
 gradlew.bat
 target
 src/test/resources/config.properties
+bin/

--- a/src/test/java/com/ibm/watson/developer_cloud/visual_insights/v1/VisualInsightsTest.java
+++ b/src/test/java/com/ibm/watson/developer_cloud/visual_insights/v1/VisualInsightsTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.ibm.watson.developer_cloud.visual_insigths.v1;
+package com.ibm.watson.developer_cloud.visual_insights.v1;
 
 import java.io.File;
 


### PR DESCRIPTION
Renamed dir path for Visual Insights as it had a typo.  Also fixed the package name in test class VisualInsightsTest.java to match new dir path 