### PR TITLE
Handles missing testing properties safely

### DIFF
--- a/src/test/java/com/ibm/watson/developer_cloud/MultiThreadTest.java
+++ b/src/test/java/com/ibm/watson/developer_cloud/MultiThreadTest.java
@@ -86,10 +86,10 @@ public class MultiThreadTest extends WatsonServiceTest{
 		super.setUp();
 		service = new LanguageTranslation();
 		service.setUsernameAndPassword(
-				prop.getProperty("language_translation.username"),
-				prop.getProperty("language_translation.password")
+				getValidProperty("language_translation.username"),
+				getValidProperty("language_translation.password")
 				);
-		service.setEndPoint(prop.getProperty("language_translation.url"));
+		service.setEndPoint(getValidProperty("language_translation.url"));
 	}
 
 	/**

--- a/src/test/java/com/ibm/watson/developer_cloud/WatsonServiceTest.java
+++ b/src/test/java/com/ibm/watson/developer_cloud/WatsonServiceTest.java
@@ -71,6 +71,17 @@ public abstract class WatsonServiceTest {
 	/** The prop. */
 	protected Properties prop = new Properties();
 
+	public String getExistingProperty(String property) {
+		String value = prop.getProperty(property);
+		if(value == null) throw new IllegalStateException("A property expected to exist does not exist: " + property);
+		return value;
+	}
+	public String getValidProperty(String property) {
+		String value = getExistingProperty(property);
+		if("".equals(value)) throw new IllegalStateException("Property " + property + " is empty. It's probably unset.");
+		return value;
+	}
+
 	/**
 	 * Sets the up.
 	 *

--- a/src/test/java/com/ibm/watson/developer_cloud/WatsonServiceTest.java
+++ b/src/test/java/com/ibm/watson/developer_cloud/WatsonServiceTest.java
@@ -73,13 +73,25 @@ public abstract class WatsonServiceTest {
 
 	public String getExistingProperty(String property) {
 		String value = prop.getProperty(property);
-		if(value == null) throw new IllegalStateException("A property expected to exist does not exist: " + property);
+		if(value == null) throw new MissingPropertyException(property);
 		return value;
 	}
 	public String getValidProperty(String property) {
 		String value = getExistingProperty(property);
-		if("".equals(value)) throw new IllegalStateException("Property " + property + " is empty. It's probably unset.");
+		if("".equals(value)) throw new EmptyPropertyException(property);
 		return value;
+	}
+
+	private class MissingPropertyException extends IllegalStateException {
+		MissingPropertyException(String property) {
+			super("A property expected to exist does not exist: " + property);
+		}
+	}
+
+	private class EmptyPropertyException extends IllegalStateException {
+		EmptyPropertyException(String property) {
+			super("Property " + property + " is empty. It's probably unset.");
+		}
 	}
 
 	/**

--- a/src/test/java/com/ibm/watson/developer_cloud/alchemy/v1/AlchemyDataNewsTest.java
+++ b/src/test/java/com/ibm/watson/developer_cloud/alchemy/v1/AlchemyDataNewsTest.java
@@ -46,7 +46,7 @@ public class AlchemyDataNewsTest extends WatsonServiceTest {
     public void setUp() throws Exception {
         super.setUp();
         service = new AlchemyDataNews();
-        service.setApiKey(prop.getProperty("alchemy.alchemy"));
+        service.setApiKey(getValidProperty("alchemy.alchemy"));
 
     }
 

--- a/src/test/java/com/ibm/watson/developer_cloud/alchemy/v1/AlchemyLanguageTest.java
+++ b/src/test/java/com/ibm/watson/developer_cloud/alchemy/v1/AlchemyLanguageTest.java
@@ -59,7 +59,7 @@ public class AlchemyLanguageTest extends WatsonServiceTest {
 	public void setUp() throws Exception {
 		super.setUp();
 		service = new AlchemyLanguage();
-		service.setApiKey(prop.getProperty("alchemy.alchemy"));
+		service.setApiKey(getValidProperty("alchemy.alchemy"));
 		htmlExample = getStringFromInputStream(new FileInputStream("src/test/resources/example.html"));
 
 	}

--- a/src/test/java/com/ibm/watson/developer_cloud/alchemy/v1/AlchemyVisionTest.java
+++ b/src/test/java/com/ibm/watson/developer_cloud/alchemy/v1/AlchemyVisionTest.java
@@ -52,7 +52,7 @@ public class AlchemyVisionTest extends WatsonServiceTest {
 	public void setUp() throws Exception {
 		super.setUp();
 		service = new AlchemyVision();
-		service.setApiKey(prop.getProperty("alchemy.alchemy"));
+		service.setApiKey(getValidProperty("alchemy.alchemy"));
 		htmlExample = getStringFromInputStream(new FileInputStream("src/test/resources/example.html"));
 	}
 

--- a/src/test/java/com/ibm/watson/developer_cloud/concept_expansion/v1/ConceptExpansionTest.java
+++ b/src/test/java/com/ibm/watson/developer_cloud/concept_expansion/v1/ConceptExpansionTest.java
@@ -44,10 +44,10 @@ public class ConceptExpansionTest extends WatsonServiceTest {
 		super.setUp();
 		service = new ConceptExpansion();
 		service.setUsernameAndPassword(
-				prop.getProperty("concept_expansion.username"),
-				prop.getProperty("concept_expansion.password")
+				getValidProperty("concept_expansion.username"),
+				getValidProperty("concept_expansion.password")
 				);
-		service.setEndPoint(prop.getProperty("concept_expansion.url"));
+		service.setEndPoint(getValidProperty("concept_expansion.url"));
 	}
 
 	/**

--- a/src/test/java/com/ibm/watson/developer_cloud/concept_insights/v2/ConceptInsightsTest.java
+++ b/src/test/java/com/ibm/watson/developer_cloud/concept_insights/v2/ConceptInsightsTest.java
@@ -313,9 +313,9 @@ public class ConceptInsightsTest extends WatsonServiceTest {
 	public void setUp() throws Exception {
 		super.setUp();
 		service = new ConceptInsights();
-		service.setUsernameAndPassword(prop.getProperty("concept_insights.username"),
-				prop.getProperty("concept_insights.password"));
-		service.setEndPoint(prop.getProperty("concept_insights.url"));
+		service.setUsernameAndPassword(getValidProperty("concept_insights.username"),
+				getValidProperty("concept_insights.password"));
+		service.setEndPoint(getValidProperty("concept_insights.url"));
 	}
 
 	/**

--- a/src/test/java/com/ibm/watson/developer_cloud/dialog/v1/DialogServiceTest.java
+++ b/src/test/java/com/ibm/watson/developer_cloud/dialog/v1/DialogServiceTest.java
@@ -56,11 +56,11 @@ public class DialogServiceTest extends WatsonServiceTest {
 		super.setUp();
 		service = new DialogService();
 		service.setUsernameAndPassword(
-				prop.getProperty("dialog.username"),
-				prop.getProperty("dialog.password"));
-		service.setEndPoint(prop.getProperty("dialog.url"));
+				getValidProperty("dialog.username"),
+				getValidProperty("dialog.password"));
+		service.setEndPoint(getValidProperty("dialog.url"));
 
-		dialogId = prop.getProperty("dialog.dialog_id");
+		dialogId = getValidProperty("dialog.dialog_id");
 	}
 
 	/**

--- a/src/test/java/com/ibm/watson/developer_cloud/document_conversion/v1/DocumentConversionTest.java
+++ b/src/test/java/com/ibm/watson/developer_cloud/document_conversion/v1/DocumentConversionTest.java
@@ -85,11 +85,11 @@ public class DocumentConversionTest extends WatsonServiceTest {
     @Before
     public void startMockServer() {
         try {
-            mockServer = startClientAndServer(Integer.parseInt(prop.getProperty("mock.server.port")));
+            mockServer = startClientAndServer(Integer.parseInt(getValidProperty("mock.server.port")));
             service = new DocumentConversion();
             service.setApiKey("");
-            service.setEndPoint("http://" + prop.getProperty("mock.server.host") + ":"
-                    + prop.getProperty("mock.server.port"));
+            service.setEndPoint("http://" + getValidProperty("mock.server.host") + ":"
+                    + getValidProperty("mock.server.port"));
         } catch (NumberFormatException e) {
             log.log(Level.SEVERE, "Error mocking the service", e);
         }

--- a/src/test/java/com/ibm/watson/developer_cloud/language_translation/v2/LanguageTranslationTest.java
+++ b/src/test/java/com/ibm/watson/developer_cloud/language_translation/v2/LanguageTranslationTest.java
@@ -89,11 +89,11 @@ public class LanguageTranslationTest extends WatsonServiceTest {
 	@Before
 	public void startMockServer() {
 		try {
-			mockServer = startClientAndServer(Integer.parseInt(prop.getProperty("mock.server.port")));
+			mockServer = startClientAndServer(Integer.parseInt(getValidProperty("mock.server.port")));
 			service = new LanguageTranslation();
 			service.setApiKey("");
-			service.setEndPoint("http://" + prop.getProperty("mock.server.host") + ":"
-					+ prop.getProperty("mock.server.port"));
+			service.setEndPoint("http://" + getValidProperty("mock.server.host") + ":"
+					+ getValidProperty("mock.server.port"));
 		} catch (NumberFormatException e) {
 			log.log(Level.SEVERE, "Error mocking the service", e);
 		}
@@ -116,7 +116,7 @@ public class LanguageTranslationTest extends WatsonServiceTest {
 	@Before
 	public void setUp() throws Exception {
 		super.setUp();
-		modelId = prop.getProperty("language_translation.model_id");
+		modelId = getValidProperty("language_translation.model_id");
 		text = "The IBM Watson team is awesome";
 	}
 

--- a/src/test/java/com/ibm/watson/developer_cloud/message_resonance/v1/MessageResonanceTest.java
+++ b/src/test/java/com/ibm/watson/developer_cloud/message_resonance/v1/MessageResonanceTest.java
@@ -49,10 +49,10 @@ public class MessageResonanceTest extends WatsonServiceTest {
 		super.setUp();
 		service = new MessageResonance();
 		service.setUsernameAndPassword(
-				prop.getProperty("message_resonance.username"),
-				prop.getProperty("message_resonance.password")
+				getValidProperty("message_resonance.username"),
+				getValidProperty("message_resonance.password")
 				);
-		service.setEndPoint(prop.getProperty("message_resonance.url"));
+		service.setEndPoint(getValidProperty("message_resonance.url"));
 	}
 
 

--- a/src/test/java/com/ibm/watson/developer_cloud/natural_language_classifier/v1/NaturalLanguageClassifierTest.java
+++ b/src/test/java/com/ibm/watson/developer_cloud/natural_language_classifier/v1/NaturalLanguageClassifierTest.java
@@ -76,11 +76,11 @@ public class NaturalLanguageClassifierTest extends WatsonServiceTest {
     @Before
     public void startMockServer() {
         try {
-            mockServer = startClientAndServer(Integer.parseInt(prop.getProperty("mock.server.port")));
+            mockServer = startClientAndServer(Integer.parseInt(getValidProperty("mock.server.port")));
             service = new NaturalLanguageClassifier();
             service.setApiKey("");
-            service.setEndPoint("http://" + prop.getProperty("mock.server.host") + ":"
-                    + prop.getProperty("mock.server.port"));
+            service.setEndPoint("http://" + getValidProperty("mock.server.host") + ":"
+                    + getValidProperty("mock.server.port"));
 
         } catch (NumberFormatException e) {
             log.log(Level.SEVERE, "Error mocking the service", e);
@@ -103,7 +103,7 @@ public class NaturalLanguageClassifierTest extends WatsonServiceTest {
     @Before
     public void setUp() throws Exception {
         super.setUp();
-        classifierId = prop.getProperty("natural_language_classifier.classifier_id");
+        classifierId = getValidProperty("natural_language_classifier.classifier_id");
     }
 
     /**

--- a/src/test/java/com/ibm/watson/developer_cloud/personality_insights/v2/PersonalityInsightsTest.java
+++ b/src/test/java/com/ibm/watson/developer_cloud/personality_insights/v2/PersonalityInsightsTest.java
@@ -75,11 +75,11 @@ public class PersonalityInsightsTest extends WatsonServiceTest{
 	@Before
 	public void startMockServer() {
 		try {
-			mockServer = startClientAndServer(Integer.parseInt(prop.getProperty("mock.server.port")));
+			mockServer = startClientAndServer(Integer.parseInt(getValidProperty("mock.server.port")));
 			service = new PersonalityInsights();
 			service.setApiKey("");
-			service.setEndPoint("http://" + prop.getProperty("mock.server.host") + ":"
-					+ prop.getProperty("mock.server.port"));
+			service.setEndPoint("http://" + getValidProperty("mock.server.host") + ":"
+					+ getValidProperty("mock.server.port"));
 		} catch (NumberFormatException e) {
 			log.log(Level.SEVERE, "Error mocking the service", e);
 		}

--- a/src/test/java/com/ibm/watson/developer_cloud/question_and_answer/v1/QuestionAndAnswerTest.java
+++ b/src/test/java/com/ibm/watson/developer_cloud/question_and_answer/v1/QuestionAndAnswerTest.java
@@ -53,10 +53,10 @@ public class QuestionAndAnswerTest extends WatsonServiceTest {
 		super.setUp();
 		service = new QuestionAndAnswer();
 		service.setUsernameAndPassword(
-				prop.getProperty("question_and_answer.username"),
-				prop.getProperty("question_and_answer.password")
+				getValidProperty("question_and_answer.username"),
+				getValidProperty("question_and_answer.password")
 				);
-		service.setEndPoint(prop.getProperty("question_and_answer.url"));
+		service.setEndPoint(getValidProperty("question_and_answer.url"));
 	}
 
 	/**

--- a/src/test/java/com/ibm/watson/developer_cloud/relationship_extraction/v1/RelationshipExtractionTest.java
+++ b/src/test/java/com/ibm/watson/developer_cloud/relationship_extraction/v1/RelationshipExtractionTest.java
@@ -43,10 +43,10 @@ public class RelationshipExtractionTest extends WatsonServiceTest {
 		super.setUp();
 		service = new RelationshipExtraction();
 		service.setUsernameAndPassword(
-				prop.getProperty("relationship_extraction.username"),
-				prop.getProperty("relationship_extraction.password")
+				getValidProperty("relationship_extraction.username"),
+				getValidProperty("relationship_extraction.password")
 				);
-		service.setEndPoint(prop.getProperty("relationship_extraction.url"));
+		service.setEndPoint(getValidProperty("relationship_extraction.url"));
 	}
 
 	/**

--- a/src/test/java/com/ibm/watson/developer_cloud/service/GenericServiceTest.java
+++ b/src/test/java/com/ibm/watson/developer_cloud/service/GenericServiceTest.java
@@ -39,11 +39,11 @@ public class GenericServiceTest extends WatsonServiceTest {
 	@Before
 	public void startMockServer() {
 		try {
-			mockServer = startClientAndServer(Integer.parseInt(prop.getProperty("mock.server.port")));
+			mockServer = startClientAndServer(Integer.parseInt(getValidProperty("mock.server.port")));
 			service = new PersonalityInsights();
 			service.setApiKey("");
-			service.setEndPoint("http://" + prop.getProperty("mock.server.host") + ":"
-					+ prop.getProperty("mock.server.port"));
+			service.setEndPoint("http://" + getValidProperty("mock.server.host") + ":"
+					+ getValidProperty("mock.server.port"));
 		} catch (NumberFormatException e) {
 			log.log(Level.SEVERE, "Error mocking the service", e);
 		}

--- a/src/test/java/com/ibm/watson/developer_cloud/speech_to_text/v1/SpeechToTextTest.java
+++ b/src/test/java/com/ibm/watson/developer_cloud/speech_to_text/v1/SpeechToTextTest.java
@@ -77,11 +77,11 @@ public class SpeechToTextTest extends WatsonServiceTest {
 	@Before
 	public void startMockServer() {
 		try {
-			mockServer = startClientAndServer(Integer.parseInt(prop.getProperty("mock.server.port")));
+			mockServer = startClientAndServer(Integer.parseInt(getValidProperty("mock.server.port")));
 			service = new SpeechToText();
 			service.setApiKey("");
-			service.setEndPoint("http://" + prop.getProperty("mock.server.host") + ":"
-					+ prop.getProperty("mock.server.port"));
+			service.setEndPoint("http://" + getValidProperty("mock.server.host") + ":"
+					+ getValidProperty("mock.server.port"));
 		} catch (NumberFormatException e) {
 			log.log(Level.SEVERE, "Error mocking the service", e);
 		}

--- a/src/test/java/com/ibm/watson/developer_cloud/text_to_speech/v1/TextToSpeechTest.java
+++ b/src/test/java/com/ibm/watson/developer_cloud/text_to_speech/v1/TextToSpeechTest.java
@@ -78,11 +78,11 @@ public class TextToSpeechTest extends WatsonServiceTest {
 	@Before
 	public void startMockServer() {
 		try {
-			mockServer = startClientAndServer(Integer.parseInt(prop.getProperty("mock.server.port")));
+			mockServer = startClientAndServer(Integer.parseInt(getValidProperty("mock.server.port")));
 			service = new TextToSpeech();
 			service.setApiKey("");
-			service.setEndPoint("http://" + prop.getProperty("mock.server.host") + ":"
-					+ prop.getProperty("mock.server.port"));
+			service.setEndPoint("http://" + getValidProperty("mock.server.host") + ":"
+					+ getValidProperty("mock.server.port"));
 		} catch (NumberFormatException e) {
 			log.log(Level.SEVERE, "Error mocking the service", e);
 		}

--- a/src/test/java/com/ibm/watson/developer_cloud/tone_analyzer/v1/ToneAnalyzerTest.java
+++ b/src/test/java/com/ibm/watson/developer_cloud/tone_analyzer/v1/ToneAnalyzerTest.java
@@ -75,11 +75,11 @@ public class ToneAnalyzerTest extends WatsonServiceTest {
 	@Before
 	public void startMockServer() {
 		try {
-			mockServer = startClientAndServer(Integer.parseInt(prop.getProperty("mock.server.port")));
+			mockServer = startClientAndServer(Integer.parseInt(getValidProperty("mock.server.port")));
 			service = new ToneAnalyzer();
 			service.setApiKey("");
-			service.setEndPoint("http://" + prop.getProperty("mock.server.host") + ":"
-					+ prop.getProperty("mock.server.port"));
+			service.setEndPoint("http://" + getValidProperty("mock.server.host") + ":"
+					+ getValidProperty("mock.server.port"));
 		} catch (NumberFormatException e) {
 			log.log(Level.SEVERE, "Error mocking the service", e);
 		}

--- a/src/test/java/com/ibm/watson/developer_cloud/tradeoff_analytics/v1/TradeoffAnalyticsTest.java
+++ b/src/test/java/com/ibm/watson/developer_cloud/tradeoff_analytics/v1/TradeoffAnalyticsTest.java
@@ -56,9 +56,9 @@ public class TradeoffAnalyticsTest extends WatsonServiceTest {
 		super.setUp();
 		service = new TradeoffAnalytics();
 		service.setUsernameAndPassword(
-				prop.getProperty("tradeoff_analytics.username"),
-				prop.getProperty("tradeoff_analytics.password"));
-		service.setEndPoint(prop.getProperty("tradeoff_analytics.url"));
+				getValidProperty("tradeoff_analytics.username"),
+				getValidProperty("tradeoff_analytics.password"));
+		service.setEndPoint(getValidProperty("tradeoff_analytics.url"));
 
 		InputStream in = this.getClass().getClassLoader()
 				.getResourceAsStream("problem.json");

--- a/src/test/java/com/ibm/watson/developer_cloud/visual_insights/v1/VisualInsightsTest.java
+++ b/src/test/java/com/ibm/watson/developer_cloud/visual_insights/v1/VisualInsightsTest.java
@@ -48,10 +48,10 @@ public class VisualInsightsTest extends WatsonServiceTest {
         super.setUp();
         service = new VisualInsights();
         service.setUsernameAndPassword(
-                prop.getProperty("visual_insights.username"),
-                prop.getProperty("visual_insights.password")
+                getValidProperty("visual_insights.username"),
+                getValidProperty("visual_insights.password")
         );
-        service.setEndPoint(prop.getProperty("visual_insights.url"));
+        service.setEndPoint(getValidProperty("visual_insights.url"));
     }
 
     /**

--- a/src/test/java/com/ibm/watson/developer_cloud/visual_recognition/v1/VisualRecognitionTest.java
+++ b/src/test/java/com/ibm/watson/developer_cloud/visual_recognition/v1/VisualRecognitionTest.java
@@ -46,10 +46,10 @@ public class VisualRecognitionTest extends WatsonServiceTest {
 		super.setUp();
 		service = new VisualRecognition();
 		service.setUsernameAndPassword(
-				prop.getProperty("visual_recognition.username"),
-				prop.getProperty("visual_recognition.password")
+				getValidProperty("visual_recognition.username"),
+				getValidProperty("visual_recognition.password")
 				);
-		service.setEndPoint(prop.getProperty("visual_recognition.url"));
+		service.setEndPoint(getValidProperty("visual_recognition.url"));
 		image = new File(getClass().getClassLoader().getResource("car.png").toURI());
 
 	}


### PR DESCRIPTION
Checks for nulls and empty strings in properties when retrieved, then throws a rather explicit exception when something is wrong.

Backstory:

I checked out the code to use the R&R branch, but didn't understand what was wrong when I ran tests and got a bunch of NPEs. I dug a little more and found that there's a developer-specific configuration file necessary. Put the file in place, but still couldn't figure out what goes into it. This was a result, as I could easily find all of the properties needed through this and through some grepping.

A sample config is forthcoming.