### PR TITLE
Use Strings to parse Solr cluster size in Retrieve and Rank

### DIFF
--- a/src/main/java/com/ibm/watson/developer_cloud/retrieve_and_rank/v1/model/SolrCluster.java
+++ b/src/main/java/com/ibm/watson/developer_cloud/retrieve_and_rank/v1/model/SolrCluster.java
@@ -38,7 +38,7 @@ public class SolrCluster extends GenericModel {
   @SerializedName(CLUSTER_NAME)
   private final String solrClusterName;
   @SerializedName(CLUSTER_SIZE)
-  private final Integer solrClusterSize;
+  private final String solrClusterSize;
   @SerializedName(SOLR_CLUSTER_STATUS)
   private final Status solrClusterStatus;
 
@@ -51,7 +51,7 @@ public class SolrCluster extends GenericModel {
    * @param solrClusterStatus the Solr cluster status
    */
   public SolrCluster(final String solrClusterId, final String solrClusterName,
-      final Integer solrClusterSize, final Status solrClusterStatus) {
+      final String solrClusterSize, final Status solrClusterStatus) {
     this.solrClusterId = solrClusterId;
     this.solrClusterName = solrClusterName;
     this.solrClusterSize = solrClusterSize;
@@ -77,11 +77,12 @@ public class SolrCluster extends GenericModel {
   }
 
   /**
-   * Gets the size.
-   * 
+   * Gets the size of the cluster. Size will either be an integer number of units or the empty
+   * string in the case of a free cluster.
+   *
    * @return the size
    */
-  public Integer getSize() {
+  public String getSize() {
     return solrClusterSize;
   }
 

--- a/src/main/java/com/ibm/watson/developer_cloud/retrieve_and_rank/v1/model/SolrClusterOptions.java
+++ b/src/main/java/com/ibm/watson/developer_cloud/retrieve_and_rank/v1/model/SolrClusterOptions.java
@@ -22,10 +22,12 @@ import com.google.gson.annotations.SerializedName;
  * A value type for the JSON body provided when creating a Solr cluster.
  */
 public class SolrClusterOptions {
+  private static final String FREE_CLUSTER_SIZE = "";
+
   @SerializedName(CLUSTER_NAME)
   private final String clusterName;
   @SerializedName(CLUSTER_SIZE)
-  private final Integer clusterSize;
+  private final String clusterSize;
 
   /**
    * Instantiates options to create a new Solr cluster of the specified size
@@ -35,7 +37,11 @@ public class SolrClusterOptions {
    */
   public SolrClusterOptions(String clusterName, Integer clusterSize) {
     this.clusterName = clusterName;
-    this.clusterSize = clusterSize;
+    if (clusterSize == null) {
+      this.clusterSize = FREE_CLUSTER_SIZE;
+    } else {
+      this.clusterSize = clusterSize.toString();
+    }
   }
 
   /**
@@ -45,7 +51,7 @@ public class SolrClusterOptions {
    */
   public SolrClusterOptions(String clusterName) {
     this.clusterName = clusterName;
-    this.clusterSize = null;
+    this.clusterSize = FREE_CLUSTER_SIZE;
   }
 
   /**
@@ -58,12 +64,15 @@ public class SolrClusterOptions {
   }
 
   /**
-   * Gets String representation of the cluster size.
-   * 
+   * Gets the cluster size. Null implies a free cluster.
+   *
    * @return the cluster size
    */
   public Integer getClusterSize() {
-    return clusterSize;
+    if (FREE_CLUSTER_SIZE.equals(clusterSize)) {
+      return null;
+    }
+    return Integer.valueOf(clusterSize);
   }
 
 }

--- a/src/test/java/com/ibm/watson/developer_cloud/retrieve_and_rank/v1/RetrieveAndRankIntegrationTest.java
+++ b/src/test/java/com/ibm/watson/developer_cloud/retrieve_and_rank/v1/RetrieveAndRankIntegrationTest.java
@@ -41,6 +41,7 @@ import com.ibm.watson.developer_cloud.service.BadRequestException;
 public class RetrieveAndRankIntegrationTest extends WatsonServiceTest {
 
   private static final Integer CREATED_CLUSTER_SIZE_ONE = 1;
+  private static final String CREATED_CLUSTER_SIZE_FREE = "";
   private static final String CREATED_CLUSTER_DEFAULT_NAME = "";
   private static final String CREATED_CLUSTER_NAME = "itest-cluster";
   private static final String CONFIG_NAME = "itest-config";
@@ -95,7 +96,7 @@ public class RetrieveAndRankIntegrationTest extends WatsonServiceTest {
     final SolrCluster solrCluster = service.createSolrCluster();
     final SolrCluster expectedSolrCluster =
         new SolrCluster(solrCluster.getId(), CREATED_CLUSTER_DEFAULT_NAME,
-            CREATED_CLUSTER_SIZE_ONE, Status.NOT_AVAILABLE);
+            CREATED_CLUSTER_SIZE_FREE, Status.NOT_AVAILABLE);
     try {
       assertTrue(service.getSolrClusters().getSolrClusters().contains(expectedSolrCluster));
     } finally {
@@ -109,9 +110,8 @@ public class RetrieveAndRankIntegrationTest extends WatsonServiceTest {
     final SolrClusterOptions options =
         new SolrClusterOptions(CREATED_CLUSTER_NAME, CREATED_CLUSTER_SIZE_ONE);
     final SolrCluster solrCluster = service.createSolrCluster(options);
-    final SolrCluster expectedSolrCluster =
-        new SolrCluster(solrCluster.getId(), CREATED_CLUSTER_NAME, CREATED_CLUSTER_SIZE_ONE,
-            Status.NOT_AVAILABLE);
+    final SolrCluster expectedSolrCluster = new SolrCluster(solrCluster.getId(),
+        CREATED_CLUSTER_NAME, CREATED_CLUSTER_SIZE_ONE.toString(), Status.NOT_AVAILABLE);
     try {
       assertTrue(service.getSolrClusters().getSolrClusters().contains(expectedSolrCluster));
     } finally {


### PR DESCRIPTION
The Retrieve and Rank service uses a String tp represent a Solr cluster's
size in its JSON responses. As a result, our Gson objects have to also
use Strings otherwise serialization will fail.