### PR TITLE
[DCS] Adds Version Date param

### DIFF
--- a/src/main/java/com/ibm/watson/developer_cloud/document_conversion/v1/DocumentConversion.java
+++ b/src/main/java/com/ibm/watson/developer_cloud/document_conversion/v1/DocumentConversion.java
@@ -30,10 +30,7 @@ import com.squareup.okhttp.*;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.text.SimpleDateFormat;
-import java.util.Calendar;
 import java.util.Map;
-import java.util.TimeZone;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -65,18 +62,14 @@ public class DocumentConversion extends WatsonService {
 
   private static final JsonObject EMPTY_CONFIG = new JsonParser().parse("{}").getAsJsonObject();
 
-  private static String getYesterday() {
-    Calendar c = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
-    c.set(Calendar.DAY_OF_MONTH, -1);
-    return new SimpleDateFormat("yyyy-MM-dd").format(c.getTime());
-  }
+  private static final String DEFAULT_VERSION_DATE = "2015-12-01";
 
   private final String versionDate;
 
   /** @deprecated See {@link DocumentConversion#DocumentConversion(String)} */
   @Deprecated
   public DocumentConversion() {
-    this(getYesterday());
+    this(DEFAULT_VERSION_DATE);
   }
 
   /**

--- a/src/test/java/com/ibm/watson/developer_cloud/document_conversion/v1/DocumentConversionTest.java
+++ b/src/test/java/com/ibm/watson/developer_cloud/document_conversion/v1/DocumentConversionTest.java
@@ -69,15 +69,19 @@ public class DocumentConversionTest extends WatsonServiceTest {
     try {
       mockServer = startClientAndServer(Integer.parseInt(getValidProperty("mock.server.port")));
       service = new DocumentConversion();
-      service.setApiKey("");
-      service.setEndPoint("http://" + getValidProperty("mock.server.host") + ":"
-          + getValidProperty("mock.server.port"));
+      configureService();
     } catch (final NumberFormatException e) {
       log.log(Level.SEVERE, "Error mocking the service", e);
     }
 
     mockServer.when(request().withMethod("POST").withPath(CONVERT_DOCUMENT_PATH))
             .respond(response().withBody(expAnswer));
+  }
+
+  private void configureService() {
+    service.setApiKey("");
+    service.setEndPoint("http://" + getValidProperty("mock.server.host") + ":"
+        + getValidProperty("mock.server.port"));
   }
 
   @After
@@ -103,6 +107,19 @@ public class DocumentConversionTest extends WatsonServiceTest {
     String entity = getRequestEntity();
     assertTrue(entity.contains("\"word\":"));
     assertTrue(entity.contains("\"conversion_target\":"));
+  }
+
+  @Test
+  public void testConvertDocument_with_version_date() throws Exception {
+    service = new DocumentConversion("2015-11-01");
+    configureService();
+
+    service.convertDocumentToAnswer(html);
+
+    mockServer.verify(request()
+            .withMethod("POST")
+            .withPath(CONVERT_DOCUMENT_PATH)
+            .withQueryStringParameter("version", "2015-11-01"));
   }
 
   private String getRequestEntity() {


### PR DESCRIPTION
The Document Conversion Service will soon require a "version" query
parameter on all requests. In the future, this will be used to avoid
breaking changes to behavior when the service is upgraded to newer
versions.