### PR TITLE
Added Timestamp / Word Confidence / Confidence Serialization/Deserialization to STT

### DIFF
--- a/src/main/java/com/ibm/watson/developer_cloud/speech_to_text/v1/deserializer/SpeechTimestampDeserializer.java
+++ b/src/main/java/com/ibm/watson/developer_cloud/speech_to_text/v1/deserializer/SpeechTimestampDeserializer.java
@@ -17,6 +17,7 @@ package com.ibm.watson.developer_cloud.speech_to_text.v1.deserializer;
 import com.ibm.watson.developer_cloud.speech_to_text.v1.model.SpeechTimestamp;
 
 import java.lang.reflect.Type;
+import java.util.ArrayList;
 
 import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonDeserializer;
@@ -24,16 +25,22 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonParseException;
 
 
-public class SpeechTimestampDeserializer implements JsonDeserializer<List<SpeechTimestamp>> {
+public class SpeechTimestampDeserializer implements JsonDeserializer<ArrayList<SpeechTimestamp>> {
   @Override
-  public List<SpeechTimestamp> deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
-    List<SpeechTimestamp> list = new List<SpeechTimestamp>(){};
+  public ArrayList<SpeechTimestamp> deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
+    ArrayList<SpeechTimestamp> list = new ArrayList<SpeechTimestamp>(){};
 
     for(JsonElement element : json.getAsJsonArray()) {
       String word = element.getAsJsonArray().get(0).getAsString();
       float start = element.getAsJsonArray().get(1).getAsFloat();
       float end = element.getAsJsonArray().get(2).getAsFloat();
-      list.add(new SpeechTimestamp(word, start, end));
+
+      SpeechTimestamp timestamp = new SpeechTimestamp();
+      timestamp.setWord(word);
+      timestamp.setStart(start);
+      timestamp.setEnd(end);
+
+      list.add(timestamp);
     }
 
     return list;

--- a/src/main/java/com/ibm/watson/developer_cloud/speech_to_text/v1/deserializer/SpeechTimestampDeserializer.java
+++ b/src/main/java/com/ibm/watson/developer_cloud/speech_to_text/v1/deserializer/SpeechTimestampDeserializer.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2015 IBM Corp. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.ibm.watson.developer_cloud.speech_to_text.v1.deserializer;
+
+import com.ibm.watson.developer_cloud.speech_to_text.v1.model.SpeechTimestamp;
+
+import java.lang.reflect.Type;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParseException;
+
+
+public class SpeechTimestampDeserializer implements JsonDeserializer<List<SpeechTimestamp>> {
+  @Override
+  public List<SpeechTimestamp> deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
+    List<SpeechTimestamp> list = new List<SpeechTimestamp>(){};
+
+    for(JsonElement element : json.getAsJsonArray()) {
+      String word = element.getAsJsonArray().get(0).getAsString();
+      float start = element.getAsJsonArray().get(1).getAsFloat();
+      float end = element.getAsJsonArray().get(2).getAsFloat();
+      list.add(new SpeechTimestamp(word, start, end));
+    }
+
+    return list;
+  }
+}

--- a/src/main/java/com/ibm/watson/developer_cloud/speech_to_text/v1/deserializer/SpeechWordConfidenceDeserializer.java
+++ b/src/main/java/com/ibm/watson/developer_cloud/speech_to_text/v1/deserializer/SpeechWordConfidenceDeserializer.java
@@ -17,6 +17,7 @@ package com.ibm.watson.developer_cloud.speech_to_text.v1.deserializer;
 import com.ibm.watson.developer_cloud.speech_to_text.v1.model.SpeechWordConfidence;
 
 import java.lang.reflect.Type;
+import java.util.ArrayList;
 
 import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonDeserializer;
@@ -24,15 +25,20 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonParseException;
 
 
-public class SpeechWordConfidenceDeserializer implements JsonDeserializer<List<SpeechWordConfidence>> {
+public class SpeechWordConfidenceDeserializer implements JsonDeserializer<ArrayList<SpeechWordConfidence>> {
   @Override
-  public List<SpeechWordConfidence> deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
-    List<SpeechWordConfidence> list = new List<SpeechWordConfidence>(){};
+  public ArrayList<SpeechWordConfidence> deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
+    ArrayList<SpeechWordConfidence> list = new ArrayList<SpeechWordConfidence>(){};
 
     for(JsonElement element : json.getAsJsonArray()) {
       String word = element.getAsJsonArray().get(0).getAsString();
       float confidence = element.getAsJsonArray().get(1).getAsFloat();
-      list.add(new SpeechWordConfidence(word, confidence));
+
+      SpeechWordConfidence wordConfidence = new SpeechWordConfidence();
+      wordConfidence.setWord(word);
+      wordConfidence.setConfidence(confidence);
+      
+      list.add(wordConfidence);
     }
 
     return list;

--- a/src/main/java/com/ibm/watson/developer_cloud/speech_to_text/v1/deserializer/SpeechWordConfidenceDeserializer.java
+++ b/src/main/java/com/ibm/watson/developer_cloud/speech_to_text/v1/deserializer/SpeechWordConfidenceDeserializer.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2015 IBM Corp. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.ibm.watson.developer_cloud.speech_to_text.v1.deserializer;
+
+import com.ibm.watson.developer_cloud.speech_to_text.v1.model.SpeechWordConfidence;
+
+import java.lang.reflect.Type;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParseException;
+
+
+public class SpeechWordConfidenceDeserializer implements JsonDeserializer<List<SpeechWordConfidence>> {
+  @Override
+  public List<SpeechWordConfidence> deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
+    List<SpeechWordConfidence> list = new List<SpeechWordConfidence>(){};
+
+    for(JsonElement element : json.getAsJsonArray()) {
+      String word = element.getAsJsonArray().get(0).getAsString();
+      float confidence = element.getAsJsonArray().get(1).getAsFloat();
+      list.add(new SpeechWordConfidence(word, confidence));
+    }
+
+    return list;
+  }
+}

--- a/src/main/java/com/ibm/watson/developer_cloud/speech_to_text/v1/model/SpeechAlternative.java
+++ b/src/main/java/com/ibm/watson/developer_cloud/speech_to_text/v1/model/SpeechAlternative.java
@@ -1,11 +1,11 @@
 /**
  * Copyright 2015 IBM Corp. All Rights Reserved.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
@@ -14,6 +14,7 @@
 
 package com.ibm.watson.developer_cloud.speech_to_text.v1.model;
 
+import com.google.gson.annotations.SerializedName;
 import com.ibm.watson.developer_cloud.service.model.GenericModel;
 
 /**
@@ -24,9 +25,19 @@ public class SpeechAlternative extends GenericModel {
   /** The transcript. */
   private String transcript;
 
+  /** The confidence. */
+  private float confidence;
+
+  /** The word confidences. */
+  @SerializedName("word_confidence")
+  private List<SpeechWordConfidence> wordConfidences;
+
+  /** The timestampts. */
+  private List<SpeechTimestamp> timestamps;
+
   /**
    * Gets the transcript.
-   * 
+   *
    * @return The transcript
    */
   public String getTranscript() {
@@ -35,11 +46,86 @@ public class SpeechAlternative extends GenericModel {
 
   /**
    * Sets the transcript.
-   * 
+   *
    * @param transcript The transcript
    */
   public void setTranscript(final String transcript) {
     this.transcript = transcript;
   }
 
+  /**
+   * Gets the confidence.
+   *
+   * @return The confidence
+   */
+  public float getConfidence() {
+    return confidence;
+  }
+
+  /**
+   * Sets the confidence.
+   *
+   * @param confidence The confidence
+   */
+  public void setConfidence(final float confidence) {
+    this.confidence = confidence;
+  }
+
+  /**
+   * Gets the word confidences.
+   *
+   * @return The word confidences
+   */
+  public List<SpeechWordConfidence> getWordConfidences() {
+    return wordConfidences;
+  }
+
+  /**
+   * Sets the word confidences.
+   *
+   * @param wordConfidences The word confidences
+   */
+  public void setWordConfidences(final List<SpeechWordConfidence> wordConfidences) {
+    this.wordConfidences = wordConfidences;
+  }
+
+  /**
+   * With word confidences.
+   *
+   * @param wordConfidences the word confidences
+   * @return the speech
+   */
+  public Transcript withWordConfidences(final List<SpeechWordConfidence> wordConfidences) {
+    this.wordConfidences = wordConfidences;
+    return this;
+  }
+
+  /**
+   * Gets the timestamps.
+   *
+   * @return The timestamps
+   */
+  public List<SpeechTimestamp> getTimestamps() {
+    return timestamps;
+  }
+
+  /**
+   * Sets the timestamps.
+   *
+   * @param timestamps The timestamps
+   */
+  public void setTimestamps(final List<SpeechTimestamp> timestamps) {
+    this.timestamps = timestamps;
+  }
+
+  /**
+   * With timestamps.
+   *
+   * @param timestamps the timestamps
+   * @return the speech
+   */
+  public Transcript withTimestamps(final List<SpeechTimestamp> timestamps) {
+    this.timestamps = timestamps;
+    return this;
+  }
 }

--- a/src/main/java/com/ibm/watson/developer_cloud/speech_to_text/v1/model/SpeechAlternative.java
+++ b/src/main/java/com/ibm/watson/developer_cloud/speech_to_text/v1/model/SpeechAlternative.java
@@ -14,6 +14,8 @@
 
 package com.ibm.watson.developer_cloud.speech_to_text.v1.model;
 
+import java.util.ArrayList;
+
 import com.google.gson.annotations.SerializedName;
 import com.ibm.watson.developer_cloud.service.model.GenericModel;
 
@@ -30,10 +32,10 @@ public class SpeechAlternative extends GenericModel {
 
   /** The word confidences. */
   @SerializedName("word_confidence")
-  private List<SpeechWordConfidence> wordConfidences;
+  private ArrayList<SpeechWordConfidence> wordConfidences;
 
   /** The timestampts. */
-  private List<SpeechTimestamp> timestamps;
+  private ArrayList<SpeechTimestamp> timestamps;
 
   /**
    * Gets the transcript.
@@ -76,7 +78,7 @@ public class SpeechAlternative extends GenericModel {
    *
    * @return The word confidences
    */
-  public List<SpeechWordConfidence> getWordConfidences() {
+  public ArrayList<SpeechWordConfidence> getWordConfidences() {
     return wordConfidences;
   }
 
@@ -85,7 +87,7 @@ public class SpeechAlternative extends GenericModel {
    *
    * @param wordConfidences The word confidences
    */
-  public void setWordConfidences(final List<SpeechWordConfidence> wordConfidences) {
+  public void setWordConfidences(final ArrayList<SpeechWordConfidence> wordConfidences) {
     this.wordConfidences = wordConfidences;
   }
 
@@ -95,7 +97,7 @@ public class SpeechAlternative extends GenericModel {
    * @param wordConfidences the word confidences
    * @return the speech
    */
-  public Transcript withWordConfidences(final List<SpeechWordConfidence> wordConfidences) {
+  public SpeechAlternative withWordConfidences(final ArrayList<SpeechWordConfidence> wordConfidences) {
     this.wordConfidences = wordConfidences;
     return this;
   }
@@ -105,7 +107,7 @@ public class SpeechAlternative extends GenericModel {
    *
    * @return The timestamps
    */
-  public List<SpeechTimestamp> getTimestamps() {
+  public ArrayList<SpeechTimestamp> getTimestamps() {
     return timestamps;
   }
 
@@ -114,7 +116,7 @@ public class SpeechAlternative extends GenericModel {
    *
    * @param timestamps The timestamps
    */
-  public void setTimestamps(final List<SpeechTimestamp> timestamps) {
+  public void setTimestamps(final ArrayList<SpeechTimestamp> timestamps) {
     this.timestamps = timestamps;
   }
 
@@ -124,7 +126,7 @@ public class SpeechAlternative extends GenericModel {
    * @param timestamps the timestamps
    * @return the speech
    */
-  public Transcript withTimestamps(final List<SpeechTimestamp> timestamps) {
+  public SpeechAlternative withTimestamps(final ArrayList<SpeechTimestamp> timestamps) {
     this.timestamps = timestamps;
     return this;
   }

--- a/src/main/java/com/ibm/watson/developer_cloud/speech_to_text/v1/model/SpeechTimestamp.java
+++ b/src/main/java/com/ibm/watson/developer_cloud/speech_to_text/v1/model/SpeechTimestamp.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright 2015 IBM Corp. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.ibm.watson.developer_cloud.speech_to_text.v1.model;
+
+import com.ibm.watson.developer_cloud.service.model.GenericModel;
+
+/**
+ * The Class SpeechWordConfidence.
+ */
+public class SpeechWordConfidence extends GenericModel {
+
+  /** The word. */
+  private String word;
+
+  /** The start time. */
+  private float start;
+
+  /** The end time. */
+  private float end;
+
+  /**
+   * Gets the word.
+   *
+   * @return The word
+   */
+  public String getWord() {
+    return word;
+  }
+
+  /**
+   * Sets the word.
+   *
+   * @param word The word
+   */
+  public void setWord(final String word) {
+    this.word = word;
+  }
+
+  /**
+   * Gets the start.
+   *
+   * @return The start
+   */
+  public float getStart() {
+    return start;
+  }
+
+  /**
+   * Sets the start.
+   *
+   * @param start The start
+   */
+  public void setStart(final float start) {
+    this.start = start;
+  }
+
+  /**
+   * Gets the end.
+   *
+   * @return The end
+   */
+  public float getEnd() {
+    return end;
+  }
+
+  /**
+   * Sets the end.
+   *
+   * @param end The end
+   */
+  public void setEnd(final float end) {
+    this.end = end;
+  }
+
+}

--- a/src/main/java/com/ibm/watson/developer_cloud/speech_to_text/v1/model/SpeechTimestamp.java
+++ b/src/main/java/com/ibm/watson/developer_cloud/speech_to_text/v1/model/SpeechTimestamp.java
@@ -19,7 +19,7 @@ import com.ibm.watson.developer_cloud.service.model.GenericModel;
 /**
  * The Class SpeechWordConfidence.
  */
-public class SpeechWordConfidence extends GenericModel {
+public class SpeechTimestamp extends GenericModel {
 
   /** The word. */
   private String word;

--- a/src/main/java/com/ibm/watson/developer_cloud/speech_to_text/v1/model/SpeechWordConfidence.java
+++ b/src/main/java/com/ibm/watson/developer_cloud/speech_to_text/v1/model/SpeechWordConfidence.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright 2015 IBM Corp. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.ibm.watson.developer_cloud.speech_to_text.v1.model;
+
+import com.ibm.watson.developer_cloud.service.model.GenericModel;
+
+/**
+ * The Class SpeechWordConfidence.
+ */
+public class SpeechWordConfidence extends GenericModel {
+
+  /** The word. */
+  private String word;
+
+  /** The confidence. */
+  private float confidence;
+
+  /**
+   * Gets the word.
+   *
+   * @return The word
+   */
+  public String getWord() {
+    return word;
+  }
+
+  /**
+   * Sets the word.
+   *
+   * @param word The word
+   */
+  public void setWord(final String word) {
+    this.word = word;
+  }
+
+  /**
+   * Gets the confidence.
+   *
+   * @return The confidence
+   */
+  public float getConfidence() {
+    return confidence;
+  }
+
+  /**
+   * Sets the confidence.
+   *
+   * @param confidence The confidence
+   */
+  public void setConfidence(final float confidence) {
+    this.confidence = confidence;
+  }
+
+}

--- a/src/main/java/com/ibm/watson/developer_cloud/util/GsonSingleton.java
+++ b/src/main/java/com/ibm/watson/developer_cloud/util/GsonSingleton.java
@@ -18,6 +18,8 @@ import com.google.gson.GsonBuilder;
 
 import com.google.gson.reflect.TypeToken;
 
+import java.util.ArrayList;
+
 import com.ibm.watson.developer_cloud.speech_to_text.v1.deserializer.SpeechTimestampDeserializer;
 import com.ibm.watson.developer_cloud.speech_to_text.v1.deserializer.SpeechWordConfidenceDeserializer;
 
@@ -43,8 +45,8 @@ public class GsonSingleton {
   private static Gson createGson() {
     return new GsonBuilder().setPrettyPrinting()
                             .setDateFormat(DATE_FORMAT_UTC)
-                            .registerTypeAdapter(new TypeToken<List<SpeechTimestamp>>(){}.getType(), new SpeechTimestampDeserializer());
-                            .registerTypeAdapter(new TypeToken<List<SpeechWordConfidence>>(){}.getType(), new SpeechWordConfidenceDeserializer());
+                            .registerTypeAdapter(new TypeToken<ArrayList<SpeechTimestamp>>(){}.getType(), new SpeechTimestampDeserializer())
+                            .registerTypeAdapter(new TypeToken<ArrayList<SpeechWordConfidence>>(){}.getType(), new SpeechWordConfidenceDeserializer())
                             .create();
   }
 

--- a/src/main/java/com/ibm/watson/developer_cloud/util/GsonSingleton.java
+++ b/src/main/java/com/ibm/watson/developer_cloud/util/GsonSingleton.java
@@ -1,11 +1,11 @@
 /**
  * Copyright 2015 IBM Corp. All Rights Reserved.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
@@ -15,6 +15,14 @@ package com.ibm.watson.developer_cloud.util;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+
+import com.google.gson.reflect.TypeToken;
+
+import com.ibm.watson.developer_cloud.speech_to_text.v1.deserializer.SpeechTimestampDeserializer;
+import com.ibm.watson.developer_cloud.speech_to_text.v1.deserializer.SpeechWordConfidenceDeserializer;
+
+import com.ibm.watson.developer_cloud.speech_to_text.v1.model.SpeechTimestamp;
+import com.ibm.watson.developer_cloud.speech_to_text.v1.model.SpeechWordConfidence;
 
 /**
  * The Class GsonSingleton.
@@ -29,16 +37,20 @@ public class GsonSingleton {
   /**
    * Creates a {@link com.google.gson.Gson} object that can be use to serialize and deserialize Java
    * objects}
-   * 
+   *
    * @return the gson
    */
   private static Gson createGson() {
-    return new GsonBuilder().setPrettyPrinting().setDateFormat(DATE_FORMAT_UTC).create();
+    return new GsonBuilder().setPrettyPrinting()
+                            .setDateFormat(DATE_FORMAT_UTC)
+                            .registerTypeAdapter(new TypeToken<List<SpeechTimestamp>>(){}.getType(), new SpeechTimestampDeserializer());
+                            .registerTypeAdapter(new TypeToken<List<SpeechWordConfidence>>(){}.getType(), new SpeechWordConfidenceDeserializer());
+                            .create();
   }
 
   /**
    * Gets the gson.
-   * 
+   *
    * @return the gson
    */
   public static Gson getGson() {

--- a/src/test/java/com/ibm/watson/developer_cloud/speech_to_text/v1/SpeechToTextIT.java
+++ b/src/test/java/com/ibm/watson/developer_cloud/speech_to_text/v1/SpeechToTextIT.java
@@ -1,11 +1,11 @@
 /**
  * Copyright 2015 IBM Corp. All Rights Reserved.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
@@ -118,9 +118,11 @@ public class SpeechToTextIT extends WatsonServiceTest {
     final File audio = new File("src/test/resources/speech_to_text/sample1.wav");
     final String contentType = HttpMediaType.AUDIO_WAV;
     final RecognizeOptions options = new RecognizeOptions();
-    options.continuous(true).model(EN_BROADBAND16K);
+    options.continuous(true).timestamps(true).wordConfidence(true).model(EN_BROADBAND16K);
     final SpeechResults results = service.recognize(audio, contentType, options);
     assertNotNull(results.getResults().get(0).getAlternatives().get(0).getTranscript());
+    assertNotNull(results.getResults().get(0).getAlternatives().get(0).getTimestamps());
+    assertNotNull(results.getResults().get(0).getAlternatives().get(0).getWordConfidences());
   }
 
 }


### PR DESCRIPTION
Added GSON serializer/deserializers for the `timestamps`, `word_confidence` & `confidence` attribute within the `SpeechAlternative` class. This needs to be integration tested, as my `config.properties` was empty and therefore had no ability to make API calls.