### PR TITLE
[speech-to-text] Add support for Timestamp and Word Confidence

### DIFF
--- a/src/main/java/com/ibm/watson/developer_cloud/speech_to_text/v1/model/SpeechAlternative.java
+++ b/src/main/java/com/ibm/watson/developer_cloud/speech_to_text/v1/model/SpeechAlternative.java
@@ -1,11 +1,11 @@
 /**
  * Copyright 2015 IBM Corp. All Rights Reserved.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
@@ -14,6 +14,9 @@
 
 package com.ibm.watson.developer_cloud.speech_to_text.v1.model;
 
+import java.util.List;
+
+import com.google.gson.annotations.SerializedName;
 import com.ibm.watson.developer_cloud.service.model.GenericModel;
 
 /**
@@ -24,9 +27,19 @@ public class SpeechAlternative extends GenericModel {
   /** The transcript. */
   private String transcript;
 
+  /** The confidence. */
+  private Double confidence;
+
+  /** The timestamps. */
+  private List<SpeechTimestamp> timestamps;
+
+  /** The word confidences. */
+  @SerializedName("word_confidence")
+  private List<SpeechWordConfidence> wordConfidences;
+
   /**
    * Gets the transcript.
-   * 
+   *
    * @return The transcript
    */
   public String getTranscript() {
@@ -35,11 +48,87 @@ public class SpeechAlternative extends GenericModel {
 
   /**
    * Sets the transcript.
-   * 
+   *
    * @param transcript The transcript
    */
   public void setTranscript(final String transcript) {
     this.transcript = transcript;
   }
 
+  /**
+   * Gets the confidence.
+   *
+   * @return The confidence
+   */
+  public Double getConfidence() {
+    return confidence;
+  }
+
+  /**
+   * Sets the confidence.
+   *
+   * @param confidence The confidence
+   */
+  public void setConfidence(final Double confidence) {
+    this.confidence = confidence;
+  }
+
+  /**
+   * Gets the timestamps.
+   *
+   * @return The timestamps
+   */
+  public List<SpeechTimestamp> getTimestamps() {
+    return timestamps;
+  }
+
+  /**
+   * Sets the timestamps.
+   *
+   * @param timestamps The timestamps
+   */
+  public void setTimestamps(final List<SpeechTimestamp> timestamps) {
+    this.timestamps = timestamps;
+  }
+
+  /**
+   * With timestamps.
+   *
+   * @param timestamps the timestamps
+   * @return the speech
+   */
+  public SpeechAlternative withTimestamps(final List<SpeechTimestamp> timestamps) {
+    this.timestamps = timestamps;
+    return this;
+  }
+
+
+  /**
+   * Gets the word confidences.
+   *
+   * @return The wordConfidences
+   */
+  public List<SpeechWordConfidence> getWordConfidences() {
+    return wordConfidences;
+  }
+
+  /**
+   * Sets the word confidences.
+   *
+   * @param wordConfidences The wordConfidences
+   */
+  public void setWordConfidences(final List<SpeechWordConfidence> wordConfidences) {
+    this.wordConfidences = wordConfidences;
+  }
+
+  /**
+   * With word confidences.
+   *
+   * @param wordConfidences the wordConfidences
+   * @return the speech
+   */
+  public SpeechAlternative withWordConfidences(final List<SpeechWordConfidence> wordConfidences) {
+    this.wordConfidences = wordConfidences;
+    return this;
+  }
 }

--- a/src/main/java/com/ibm/watson/developer_cloud/speech_to_text/v1/model/SpeechTimestamp.java
+++ b/src/main/java/com/ibm/watson/developer_cloud/speech_to_text/v1/model/SpeechTimestamp.java
@@ -1,0 +1,89 @@
+/**
+ * Copyright 2015 IBM Corp. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.ibm.watson.developer_cloud.speech_to_text.v1.model;
+
+import com.google.gson.annotations.JsonAdapter;
+import com.ibm.watson.developer_cloud.service.model.GenericModel;
+import com.ibm.watson.developer_cloud.speech_to_text.v1.util.SpeechTimestampTypeAdapter;
+
+/**
+ * The Class SpeechTimestamp.
+ */
+@JsonAdapter(SpeechTimestampTypeAdapter.class)
+public class SpeechTimestamp extends GenericModel {
+
+  /** The word. */
+  private String word;
+
+  /** The start time. */
+  private Double startTime;
+
+  /** The end time. */
+  private Double endTime;
+
+  /**
+   * Gets the word.
+   *
+   * @return The word
+   */
+  public String getWord() {
+    return word;
+  }
+
+  /**
+   * Sets the word.
+   *
+   * @param word The word
+   */
+  public void setWord(final String word) {
+    this.word = word;
+  }
+
+  /**
+   * Gets the start time.
+   *
+   * @return The start time
+   */
+  public Double getStartTime() {
+    return startTime;
+  }
+
+  /**
+   * Sets the start time.
+   *
+   * @param startTime The start time
+   */
+  public void setStartTime(final Double startTime) {
+    this.startTime = startTime;
+  }
+
+  /**
+   * Gets the end time.
+   *
+   * @return The end time
+   */
+  public Double getEndTime() {
+    return endTime;
+  }
+
+  /**
+   * Sets the end time.
+   *
+   * @param endTime The end time
+   */
+  public void setEndTime(final Double endTime) {
+    this.endTime = endTime;
+  }
+}

--- a/src/main/java/com/ibm/watson/developer_cloud/speech_to_text/v1/model/SpeechWordConfidence.java
+++ b/src/main/java/com/ibm/watson/developer_cloud/speech_to_text/v1/model/SpeechWordConfidence.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright 2015 IBM Corp. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.ibm.watson.developer_cloud.speech_to_text.v1.model;
+
+import com.google.gson.annotations.JsonAdapter;
+import com.ibm.watson.developer_cloud.service.model.GenericModel;
+import com.ibm.watson.developer_cloud.speech_to_text.v1.util.SpeechWordConfidenceTypeAdapter;
+
+/**
+ * The Class SpeechWordConfidence.
+ */
+@JsonAdapter(SpeechWordConfidenceTypeAdapter.class)
+public class SpeechWordConfidence extends GenericModel {
+
+  /** The word. */
+  private String word;
+
+  /** The confidence. */
+  private Double confidence;
+
+  /**
+   * Gets the word.
+   *
+   * @return The word
+   */
+  public String getWord() {
+    return word;
+  }
+
+  /**
+   * Sets the word.
+   *
+   * @param word The word
+   */
+  public void setWord(final String word) {
+    this.word = word;
+  }
+
+  /**
+   * Gets the confidence.
+   *
+   * @return The confidence
+   */
+  public Double getConfidence() {
+    return confidence;
+  }
+
+  /**
+   * Sets the confidence.
+   *
+   * @param confidence The confidence
+   */
+  public void setConfidence(final Double confidence) {
+    this.confidence = confidence;
+  }
+}

--- a/src/main/java/com/ibm/watson/developer_cloud/speech_to_text/v1/util/SpeechTimestampTypeAdapter.java
+++ b/src/main/java/com/ibm/watson/developer_cloud/speech_to_text/v1/util/SpeechTimestampTypeAdapter.java
@@ -1,0 +1,91 @@
+/**
+ * Copyright 2015 IBM Corp. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.ibm.watson.developer_cloud.speech_to_text.v1.util;
+
+import java.io.IOException;
+
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
+import com.google.gson.stream.JsonWriter;
+import com.ibm.watson.developer_cloud.speech_to_text.v1.model.SpeechTimestamp;
+
+/**
+ * SpeechTimestampTypeAdapter
+ */
+public class SpeechTimestampTypeAdapter extends TypeAdapter<SpeechTimestamp> {
+
+  /*
+   * (non-Javadoc)
+   *
+   * @see com.google.gson.TypeAdapter#read(com.google.gson.stream.JsonReader)
+   */
+  @Override
+  public SpeechTimestamp read(JsonReader reader) throws IOException {
+    if (reader.peek() == JsonToken.NULL) {
+      reader.nextNull();
+      return null;
+    }
+
+    String word = null;
+    Double startTime = null, endTime = null;
+
+    reader.beginArray();
+
+    if (reader.peek() == JsonToken.STRING) {
+      word = reader.nextString();
+    }
+    if (reader.peek() == JsonToken.NUMBER) {
+      startTime = reader.nextDouble();
+    }
+    if (reader.peek() == JsonToken.NUMBER) {
+      endTime = reader.nextDouble();
+    }
+
+    reader.endArray();
+
+    SpeechTimestamp speechTimestamp = new SpeechTimestamp();
+
+    if (word != null) {
+      speechTimestamp.setWord(word);
+    }
+
+    if (startTime != null) {
+      speechTimestamp.setStartTime(startTime);
+    }
+
+    if (endTime != null) {
+      speechTimestamp.setEndTime(endTime);
+    }
+
+    return speechTimestamp;
+  }
+
+  /*
+   * (non-Javadoc)
+   *
+   * @see com.google.gson.TypeAdapter#write(com.google.gson.stream.JsonWriter, java.lang.Object)
+   */
+  @Override
+  public void write(JsonWriter writer, SpeechTimestamp speechTimestamp) throws IOException {
+    writer.beginArray();
+
+    writer.value(speechTimestamp.getWord());
+    writer.value(speechTimestamp.getStartTime());
+    writer.value(speechTimestamp.getEndTime());
+
+    writer.endArray();
+    writer.flush();
+  }
+}

--- a/src/main/java/com/ibm/watson/developer_cloud/speech_to_text/v1/util/SpeechWordConfidenceTypeAdapter.java
+++ b/src/main/java/com/ibm/watson/developer_cloud/speech_to_text/v1/util/SpeechWordConfidenceTypeAdapter.java
@@ -1,0 +1,83 @@
+/**
+ * Copyright 2015 IBM Corp. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.ibm.watson.developer_cloud.speech_to_text.v1.util;
+
+import java.io.IOException;
+
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
+import com.google.gson.stream.JsonWriter;
+import com.ibm.watson.developer_cloud.speech_to_text.v1.model.SpeechWordConfidence;
+
+/**
+ * SpeechWordConfidenceTypeAdapter
+ */
+public class SpeechWordConfidenceTypeAdapter extends TypeAdapter<SpeechWordConfidence> {
+
+  /*
+   * (non-Javadoc)
+   *
+   * @see com.google.gson.TypeAdapter#read(com.google.gson.stream.JsonReader)
+   */
+  @Override
+  public SpeechWordConfidence read(JsonReader reader) throws IOException {
+    if (reader.peek() == JsonToken.NULL) {
+      reader.nextNull();
+      return null;
+    }
+
+    String word = null;
+    Double confidence = null;
+
+    reader.beginArray();
+
+    if (reader.peek() == JsonToken.STRING) {
+      word = reader.nextString();
+    }
+    if (reader.peek() == JsonToken.NUMBER) {
+      confidence = reader.nextDouble();
+    }
+
+    reader.endArray();
+
+    SpeechWordConfidence speechWordConfidence = new SpeechWordConfidence();
+
+    if (word != null) {
+      speechWordConfidence.setWord(word);
+    }
+
+    if (confidence != null) {
+      speechWordConfidence.setConfidence(confidence);
+    }
+
+    return speechWordConfidence;
+  }
+
+  /*
+   * (non-Javadoc)
+   *
+   * @see com.google.gson.TypeAdapter#write(com.google.gson.stream.JsonWriter, java.lang.Object)
+   */
+  @Override
+  public void write(JsonWriter writer, SpeechWordConfidence speechWordConfidence) throws IOException {
+    writer.beginArray();
+
+    writer.value(speechWordConfidence.getWord());
+    writer.value(speechWordConfidence.getConfidence());
+
+    writer.endArray();
+    writer.flush();
+  }
+}

--- a/src/test/java/com/ibm/watson/developer_cloud/speech_to_text/v1/SpeechToTextIT.java
+++ b/src/test/java/com/ibm/watson/developer_cloud/speech_to_text/v1/SpeechToTextIT.java
@@ -1,11 +1,11 @@
 /**
  * Copyright 2015 IBM Corp. All Rights Reserved.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
@@ -118,9 +118,11 @@ public class SpeechToTextIT extends WatsonServiceTest {
     final File audio = new File("src/test/resources/speech_to_text/sample1.wav");
     final String contentType = HttpMediaType.AUDIO_WAV;
     final RecognizeOptions options = new RecognizeOptions();
-    options.continuous(true).model(EN_BROADBAND16K);
+    options.continuous(true).timestamps(true).wordConfidence(true).model(EN_BROADBAND16K);
     final SpeechResults results = service.recognize(audio, contentType, options);
     assertNotNull(results.getResults().get(0).getAlternatives().get(0).getTranscript());
+    assertNotNull(results.getResults().get(0).getAlternatives().get(0).getTimestamps());
+    assertNotNull(results.getResults().get(0).getAlternatives().get(0).getWordConfidences());
   }
 
 }


### PR DESCRIPTION
Added support for Timestamps and Word Confidences utilizing GSON Annotations and TypeAdapter as per @germanattanasio suggestion in PR #146 .

Still need to run Integration Testing.