### PR TITLE
Resolve inputstream incorrect content length

### DIFF
--- a/src/main/java/com/ibm/watson/developer_cloud/http/InputStreamRequestBody.java
+++ b/src/main/java/com/ibm/watson/developer_cloud/http/InputStreamRequestBody.java
@@ -65,20 +65,6 @@ public class InputStreamRequestBody extends RequestBody {
   /*
    * (non-Javadoc)
    * 
-   * @see com.squareup.okhttp.RequestBody#contentLength()
-   */
-  @Override
-  public long contentLength() {
-    try {
-      return inputStream.available();
-    } catch (IOException e) {
-      return 0;
-    }
-  }
-
-  /*
-   * (non-Javadoc)
-   * 
    * @see com.squareup.okhttp.RequestBody#writeTo(okio.BufferedSink)
    */
   @Override


### PR DESCRIPTION
It isn't good practice to use inputstream.available() as the content length. By default RequestBody has -1, which means content length is unknown. It is my understanding that this is common practice. So, I have removed the override contentLength() method. The RequestBody version will work.

Resolve issue #180 