### PR TITLE
automatically create latest/ symlink in docs for tagged builds

### DIFF
--- a/.utility/push-javadoc-to-gh-pages.sh
+++ b/.utility/push-javadoc-to-gh-pages.sh
@@ -13,6 +13,13 @@ if [ "$TRAVIS_REPO_SLUG" == "watson-developer-cloud/java-sdk" ] && [ "$TRAVIS_PU
 
     cp -rf ../target/site/apidocs/* docs/$TRAVIS_BRANCH
     ../.utility/generate_index_html.sh > index.html
+    
+	# update the latest/ symlink
+    # on tagged builds, $TRAVIS_TAG is set to the tag, but it's blank on regular builds, unlike $TRAVIS_BRANCH
+    if [ $TRAVIS_TAG ]; then
+      rm latest
+      ln -s ./$TRAVIS_TAG latest
+    fi
 
     git add -f .
     git commit -m "Latest javadoc for $TRAVIS_BRANCH ($TRAVIS_COMMIT)"


### PR DESCRIPTION
### Summary

This is to answer the docs team's request to be able to link to the latest release's javadoc without continually having to update things. It should also make life easier on us.

### Other Information

This actually points to the latest tag, so if you, say, release v3.0.0 and then go back and publish v2.9.1 with a bugfix, the latest/ link will change to v2.9.1 until you release a new v3.x. (Or you change it manually in the `gh-pages` branch.)

I'm sending this as a PR rather than committing it so that @germanattanasio can review it and choose when to test it on a new release.