### PR TITLE
New AuthenticationStrategy

### DIFF
--- a/src/main/java/com/ibm/watson/developer_cloud/service/AuthenticationStrategy.java
+++ b/src/main/java/com/ibm/watson/developer_cloud/service/AuthenticationStrategy.java
@@ -1,0 +1,30 @@
+package com.ibm.watson.developer_cloud.service;
+
+public abstract class AuthenticationStrategy {
+	private String token;
+	private String apiKey;
+	private String serviceName;
+	
+	public void setApiKey(String a) {
+		apiKey = a;
+	}
+	public String getApiKey() {
+		return apiKey;
+	}
+	
+	public void setToken(String t) {
+		token = t;
+	}
+	public String getToken() {
+		return token;
+	}
+	
+	public void setServiceName(String n) {
+		serviceName = n;
+	}
+	public String getServiceName() {
+		return serviceName;
+	}
+	
+	public abstract String refreshToken();
+}


### PR DESCRIPTION
### Summary

Allow custom Authentication strategy (i.e. custom method to provide token)

### Other Information

By default, BasicAuthentication is used. No tests have been done with custom auth strategies

Thanks for contributing to the Watson Developer Cloud!