### PR TITLE
[java-sdk] Fix idea build and ignore idea .ipr file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,6 @@ gradlew.bat
 target
 bin/
 *.iml
+*.ipr
+*.iws
 src/test/resources/config.properties

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'java'
 apply plugin: 'maven'
 apply plugin: 'eclipse'
+apply plugin: 'idea'
 
 sourceCompatibility = 1.6
 targetCompatibility = 1.6


### PR DESCRIPTION
### Summary

The purpose of this PR is making the idea IDE buid work and ignore idea files. You can review it, thanks.


Thanks for contributing to the Watson Developer Cloud!