### PR TITLE
[alchemy] Bug fix for TaxonomyTypeAdapter serialization

### DIFF
--- a/src/main/java/com/ibm/watson/developer_cloud/alchemy/v1/util/TaxonomyTypeAdapter.java
+++ b/src/main/java/com/ibm/watson/developer_cloud/alchemy/v1/util/TaxonomyTypeAdapter.java
@@ -78,8 +78,8 @@ public class TaxonomyTypeAdapter extends TypeAdapter<Taxonomy> {
 
     if (value.getScore() != null)
       writer.name("score").value(value.getScore());
-    if (value.getConfident() != null)
-      writer.name("confident").value(value.getConfident());
+    if (value.getConfident() == false)
+      writer.name("confident").value("no");
     if (value.getLabel() != null)
       writer.name("label").value(value.getLabel());
 


### PR DESCRIPTION
### Summary

Fix to have TaxonomyTypeAdapter's write() method produce output that's also accepted by its read() method.

### Other Information

This bug resulted in an uncaught exception when trying to re-read a serialized POJO, e.g.:
```
java.lang.IllegalStateException: Expected a string but was BOOLEAN at line 5 column 24 path $.taxonomy[0].confident
	at com.google.gson.stream.JsonReader.nextString(JsonReader.java:831)
	at com.ibm.watson.developer_cloud.alchemy.v1.util.TaxonomyTypeAdapter.read(TaxonomyTypeAdapter.java:49)
	at com.ibm.watson.developer_cloud.alchemy.v1.util.TaxonomyTypeAdapter.read(TaxonomyTypeAdapter.java:27)
	at com.google.gson.internal.bind.TypeAdapterRuntimeTypeWrapper.read(TypeAdapterRuntimeTypeWrapper.java:40)
	at com.google.gson.internal.bind.CollectionTypeAdapterFactory$Adapter.read(CollectionTypeAdapterFactory.java:82)
	at com.google.gson.internal.bind.CollectionTypeAdapterFactory$Adapter.read(CollectionTypeAdapterFactory.java:61)
	at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$1.read(ReflectiveTypeAdapterFactory.java:116)
	at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$Adapter.read(ReflectiveTypeAdapterFactory.java:216)
	... 33 more
```