### PR TITLE
add a hierarchy property and modify the adapter to read it #235

### DIFF
--- a/src/main/java/com/ibm/watson/developer_cloud/alchemy/v1/model/ImageKeyword.java
+++ b/src/main/java/com/ibm/watson/developer_cloud/alchemy/v1/model/ImageKeyword.java
@@ -32,6 +32,9 @@ public class ImageKeyword extends GenericModel {
   /** The text. */
   private String text;
 
+  /** The hierarchy. */
+  private String hierarchy;
+
   /**
    * Gets the score.
    * 
@@ -68,4 +71,22 @@ public class ImageKeyword extends GenericModel {
     this.text = text;
   }
 
+  /**
+   * Sets the hierarchy.
+   *
+   * @param hierarchy The hierarchy.
+   */
+  public void setHierarchy(String hierarchy) {
+    this.hierarchy = hierarchy;
+  }
+
+  /**
+   * Gets the hierarchy. A value is only present if the request that produced this instance
+   * was made with {@code knowledgeGraph = true}.
+   *
+   * @return The hierarchy, if it exists.
+   */
+  public String getHierarchy() {
+    return hierarchy;
+  }
 }

--- a/src/main/java/com/ibm/watson/developer_cloud/alchemy/v1/util/ImageKeywordTypeAdapter.java
+++ b/src/main/java/com/ibm/watson/developer_cloud/alchemy/v1/util/ImageKeywordTypeAdapter.java
@@ -13,13 +13,13 @@
  */
 package com.ibm.watson.developer_cloud.alchemy.v1.util;
 
-import java.io.IOException;
-
 import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonToken;
 import com.google.gson.stream.JsonWriter;
 import com.ibm.watson.developer_cloud.alchemy.v1.model.ImageKeyword;
+
+import java.io.IOException;
 
 /**
  * Type Adapter for the {@link ImageKeyword} class.
@@ -50,6 +50,16 @@ public class ImageKeywordTypeAdapter extends TypeAdapter<ImageKeyword> {
         final String score = reader.nextString();
         if (score != null && !score.isEmpty())
           ImageKeyword.setScore(Double.valueOf(score));
+      } else if (name.equals("knowledgeGraph")) {
+        reader.beginObject();
+        if (reader.hasNext() && reader.nextName().equals("typeHierarchy")) {
+          final String hierarchy = reader.nextString();
+          ImageKeyword.setHierarchy(hierarchy);
+        }
+        while (reader.hasNext()) {
+          reader.skipValue();
+        }
+        reader.endObject();
       } else {
         reader.skipValue();
       }

--- a/src/test/java/com/ibm/watson/developer_cloud/alchemy/v1/AlchemyVisionIT.java
+++ b/src/test/java/com/ibm/watson/developer_cloud/alchemy/v1/AlchemyVisionIT.java
@@ -13,21 +13,21 @@
  */
 package com.ibm.watson.developer_cloud.alchemy.v1;
 
-import java.io.File;
-import java.io.FileInputStream;
-
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-
 import com.ibm.watson.developer_cloud.WatsonServiceTest;
 import com.ibm.watson.developer_cloud.alchemy.v1.model.ImageFaces;
+import com.ibm.watson.developer_cloud.alchemy.v1.model.ImageKeyword;
 import com.ibm.watson.developer_cloud.alchemy.v1.model.ImageKeywords;
 import com.ibm.watson.developer_cloud.alchemy.v1.model.ImageLink;
 import com.ibm.watson.developer_cloud.alchemy.v1.model.ImageSceneText;
 import com.ibm.watson.developer_cloud.alchemy.v1.model.ImageSceneTextLine;
 import com.ibm.watson.developer_cloud.alchemy.v1.model.ImageSceneTextLine.Word;
 import com.squareup.okhttp.HttpUrl;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.FileInputStream;
 
 /**
  * The Class AlchemyVisionTest.
@@ -132,7 +132,22 @@ public class AlchemyVisionIT extends WatsonServiceTest {
     final ImageKeywords image = service.getImageKeywords(imageFile, null, null);
 
     Assert.assertNotNull(image);
+  }
 
+  /**
+   * Test get ranked image keywords from image with knowledge graph data included.
+   */
+  @Test
+  public void testGetRankedImageKeywordsFromImageWithKnowledgeGraph() {
+    final File imageFile = new File(IMAGE_OBAMA);
+    final ImageKeywords image = service.getImageKeywords(imageFile, null, true);
+
+    Assert.assertNotNull(image);
+    if (image.getImageKeywords() != null && !image.getImageKeywords().isEmpty()) {
+      for (ImageKeyword keyword : image.getImageKeywords()) {
+        Assert.assertNotNull(keyword.getHierarchy());
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
### Summary

Adds the `hierarchy` field and accessors to the `ImageKeyword` class so this data from the api can be exposed. See https://github.com/watson-developer-cloud/java-sdk/issues/235

### Other Information

Did not do a full test since I do not have values for the entire `config.properties` list. I ran only the modified test using `gradle test -Dtest.single=AlchemyVisionIT` and my alchemy api key and verified it passed.