### PR TITLE
Check if JNDI is available before using

### DIFF
--- a/src/main/java/com/ibm/watson/developer_cloud/util/CredentialUtils.java
+++ b/src/main/java/com/ibm/watson/developer_cloud/util/CredentialUtils.java
@@ -74,20 +74,27 @@ public class CredentialUtils {
    * @return The encoded API Key
    */
   private static String getKeyUsingJNDI(String serviceName) {
-    try {
-      Class.forName("javax.naming.Context");
-      try {
-        Context context = new InitialContext();
-        String lookupName = "watson-developer-cloud/" + serviceName + "/credentials";
-        String apiKey = (String) context.lookup(lookupName);
-        return apiKey;
-      } catch (NamingException e) {
-        return null;
-      }
-    } catch (ClassNotFoundException exception) {
+    if (!isClassAvailable("javax.naming.Context")) {
       log.info("JNDI string lookups is not available.");
+      return null;
     }
-    return null;
+    try {
+      Context context = new InitialContext();
+      String lookupName = "watson-developer-cloud/" + serviceName + "/credentials";
+      String apiKey = (String) context.lookup(lookupName);
+      return apiKey;
+    } catch (NamingException e) {
+      return null;
+    }
+  }
+
+  private static boolean isClassAvailable(String className) {
+    try {
+      Class.forName(className);
+      return true;
+    } catch (Throwable e) {
+      return false;
+    }
   }
 
   /**


### PR DESCRIPTION
Another take at resolving the JNDI class loading problem on Android. Catch any exception or error generated by `Class.forName()` call.

