### PR TITLE
Updated Speech to Text for consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,7 +382,7 @@ File audio = new File("src/test/resources/sample1.wav");
 RecognizeOptions options = new RecognizeOptions.Builder()
   .continuous(true)
   .interimResults(true)
-  .contentType(HttpMediaType.AUDIO_WAV)
+  .contentType(audio/wav)
   .build();
 
   service.recognizeUsingWebSocket(audio, options, new BaseRecognizeCallback() {


### PR DESCRIPTION
### Summary

Speech to text instructions inconsistent with API Reference. While previous version would work for wav, that would not work for raw or ogg data, as further specification is necessary to use those file formats, which is incompatible with the information with the Github guide. This update is now consistent with the API Reference

### Other Information

Thank you for the help with IBM STT at TechCrunch Disrupt NY