### PR TITLE
Migrate unit tests to OkHttp's MockWebServer

### DIFF
--- a/src/test/java/com/ibm/watson/developer_cloud/conversation/v1_experimental/ConversationTest.java
+++ b/src/test/java/com/ibm/watson/developer_cloud/conversation/v1_experimental/ConversationTest.java
@@ -27,8 +27,6 @@ import com.ibm.watson.developer_cloud.conversation.v1_experimental.model.Message
 import com.ibm.watson.developer_cloud.conversation.v1_experimental.model.NewMessageOptions;
 import com.ibm.watson.developer_cloud.http.HttpHeaders;
 
-import okhttp3.mockwebserver.MockResponse;
-import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
 
 public class ConversationTest extends WatsonServiceUnitTest {
@@ -51,7 +49,7 @@ public class ConversationTest extends WatsonServiceUnitTest {
     super.setUp();
     service = new ConversationService(ConversationService.VERSION_DATE_2016_05_19);
     service.setApiKey(EMPTY);
-    service.setEndPoint(MOCK_SERVER_URL);
+    service.setEndPoint(getMockWebServerUrl());
 
   }
 
@@ -65,17 +63,8 @@ public class ConversationTest extends WatsonServiceUnitTest {
   public void testSendMessage() throws IOException, InterruptedException {
     String text = "I'd like to get a quote to replace my windows";
 
-    MockWebServer server = new MockWebServer();
-
     Message mockResponse = loadFixture(FIXTURE, Message.class);
-    server.enqueue(new MockResponse().setBody(mockResponse.toString()));
-
-    server.start();
-
-    ConversationService service = new ConversationService(ConversationService.VERSION_DATE_2016_05_19);
-    service.setApiKey(EMPTY);
-    service.setEndPoint(getMockWebServerUrl(server));
-
+    server.enqueue(jsonResponse(mockResponse));
 
     NewMessageOptions options = new NewMessageOptions.Builder().inputText(text).workspaceId(WORKSPACE_ID).build();
 

--- a/src/test/java/com/ibm/watson/developer_cloud/language_translation/v2/LanguageTranslationTest.java
+++ b/src/test/java/com/ibm/watson/developer_cloud/language_translation/v2/LanguageTranslationTest.java
@@ -34,7 +34,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import com.ibm.watson.developer_cloud.WatsonServiceUnitTest;
-import com.ibm.watson.developer_cloud.http.HttpMediaType;
 import com.ibm.watson.developer_cloud.language_translation.v2.model.CreateModelOptions;
 import com.ibm.watson.developer_cloud.language_translation.v2.model.IdentifiableLanguage;
 import com.ibm.watson.developer_cloud.language_translation.v2.model.IdentifiedLanguage;
@@ -45,8 +44,6 @@ import com.ibm.watson.developer_cloud.language_translation.v2.model.TranslationR
 import com.ibm.watson.developer_cloud.service.exception.BadRequestException;
 import com.ibm.watson.developer_cloud.util.GsonSingleton;
 
-import okhttp3.mockwebserver.MockResponse;
-import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
 
 /**
@@ -74,8 +71,6 @@ public class LanguageTranslationTest extends WatsonServiceUnitTest {
   private TranslationModels models;
   private Map<String, Object> identifiableLanguages;
 
-  private MockWebServer server;
-
   /*
    * (non-Javadoc)
    * 
@@ -86,12 +81,9 @@ public class LanguageTranslationTest extends WatsonServiceUnitTest {
   public void setUp() throws Exception {
     super.setUp();
 
-    server = new MockWebServer();
-    server.start();
-
     service = new LanguageTranslation();
     service.setApiKey("");
-    service.setEndPoint(getMockWebServerUrl(server));
+    service.setEndPoint(getMockWebServerUrl());
 
     // fixtures
     String jsonString = getStringFromInputStream(new FileInputStream(RESOURCE + "identifiable_languages.json"));
@@ -298,11 +290,5 @@ public class LanguageTranslationTest extends WatsonServiceUnitTest {
     assertEquals(translationResult.getWordCount().intValue(), text.split(" ").length);
     assertNotNull(translationResult.getTranslations());
     assertNotNull(translationResult.getTranslations().get(0).getTranslation());
-  }
-
-  private static MockResponse jsonResponse(Object o) {
-    return new MockResponse()
-        .addHeader(CONTENT_TYPE, HttpMediaType.APPLICATION_JSON)
-        .setBody(GSON.toJson(o));
   }
 }

--- a/src/test/java/com/ibm/watson/developer_cloud/personality_insights/v2/PersonalityInsightsTest.java
+++ b/src/test/java/com/ibm/watson/developer_cloud/personality_insights/v2/PersonalityInsightsTest.java
@@ -13,16 +13,16 @@
  */
 package com.ibm.watson.developer_cloud.personality_insights.v2;
 
-import static org.mockserver.model.HttpRequest.request;
-import static org.mockserver.model.HttpResponse.response;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 import java.io.FileNotFoundException;
 
-import org.junit.Assert;
+import com.ibm.watson.developer_cloud.http.HttpMediaType;
+import okhttp3.mockwebserver.RecordedRequest;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.google.gson.Gson;
 import com.ibm.watson.developer_cloud.WatsonServiceUnitTest;
 import com.ibm.watson.developer_cloud.http.HttpHeaders;
 import com.ibm.watson.developer_cloud.personality_insights.v2.model.Content;
@@ -64,7 +64,7 @@ public class PersonalityInsightsTest extends WatsonServiceUnitTest {
   public void setUp() throws Exception {
     super.setUp();
     service = new PersonalityInsights();
-    service.setEndPoint(MOCK_SERVER_URL);
+    service.setEndPoint(getMockWebServerUrl());
     service.setApiKey("");
   }
 
@@ -72,55 +72,58 @@ public class PersonalityInsightsTest extends WatsonServiceUnitTest {
    * Test get profile with content.
    */
   @Test
-  public void testGetProfileWithContent() {
-    Content content = new Content();
+  public void testGetProfileWithContent() throws InterruptedException {
+    final Content content = new Content();
     content.addContentItem(contentItem);
+    final ProfileOptions options = new ProfileOptions.Builder().addContentItem(contentItem).build();
 
-    // mock
-    mockServer.when(
-        request().withMethod(POST).withPath(PROFILE_PATH).withBody(new Gson().toJson(content)))
-        .respond(response().withHeaders(APPLICATION_JSON).withBody(profile.toString()));
+    server.enqueue(jsonResponse(profile));
+    final Profile profile = service.getProfile(options).execute();
+    final RecordedRequest request = server.takeRequest();
 
-    // test
-    ProfileOptions options = new ProfileOptions.Builder().addContentItem(contentItem).build();
-    Profile profile = service.getProfile(options).execute();
-    Assert.assertNotNull(profile);
-    Assert.assertEquals(profile, this.profile);
+    assertEquals(PROFILE_PATH, request.getPath());
+    assertEquals("POST", request.getMethod());
+    assertNotNull(profile);
+    assertEquals(this.profile, profile);
   }
 
   /**
    * Test get profile with english text.
    */
   @Test
-  public void testGetProfileWithEnglishText() {
-    mockServer.when(
-        request().withMethod(POST).withPath(PROFILE_PATH).withHeader(TEXT_PLAIN)
-            .withHeader(HttpHeaders.CONTENT_LANGUAGE, "en").withBody(text)).respond(
-        response().withHeaders(APPLICATION_JSON).withBody(profile.toString()));
+  public void testGetProfileWithEnglishText() throws InterruptedException {
+    final ProfileOptions options = new ProfileOptions.Builder().text(text).language(Language.ENGLISH).build();
 
-    ProfileOptions options = new ProfileOptions.Builder().text(text).language(Language.ENGLISH).build();
-    Profile profile = service.getProfile(options).execute();
+    server.enqueue(jsonResponse(profile));
+    final Profile profile = service.getProfile(options).execute();
+    final RecordedRequest request = server.takeRequest();
 
-    Assert.assertNotNull(profile);
-    Assert.assertEquals(profile, this.profile);
+    assertEquals(PROFILE_PATH, request.getPath());
+    assertEquals("POST", request.getMethod());
+    assertEquals("en", request.getHeader(HttpHeaders.CONTENT_LANGUAGE));
+    assertEquals(HttpMediaType.TEXT.toString(), request.getHeader(HttpHeaders.CONTENT_TYPE));
+    assertEquals(text, request.getBody().readUtf8());
+    assertNotNull(profile);
+    assertEquals(this.profile, profile);
   }
 
   /**
    * Test get profile with spanish text.
    */
   @Test
-  public void testGetProfileWithSpanishText() {
-    mockServer.when(
-        request().withMethod(POST).withPath(PROFILE_PATH).withHeader(TEXT_PLAIN)
-            .withHeader(HttpHeaders.CONTENT_LANGUAGE, "es").withBody(text)).respond(
-        response().withHeaders(APPLICATION_JSON).withBody(profile.toString()));
+  public void testGetProfileWithSpanishText() throws InterruptedException {
+    final ProfileOptions options = new ProfileOptions.Builder().text(text).language(Language.SPANISH).build();
 
+    server.enqueue(jsonResponse(profile));
+    final Profile profile = service.getProfile(options).execute();
+    final RecordedRequest request = server.takeRequest();
 
-    ProfileOptions options = new ProfileOptions.Builder().text(text).language(Language.SPANISH).build();
-    Profile profile = service.getProfile(options).execute();
-
-    Assert.assertNotNull(profile);
-    Assert.assertEquals(profile, this.profile);
-
+    assertEquals(PROFILE_PATH, request.getPath());
+    assertEquals("POST", request.getMethod());
+    assertEquals("es", request.getHeader(HttpHeaders.CONTENT_LANGUAGE));
+    assertEquals(HttpMediaType.TEXT.toString(), request.getHeader(HttpHeaders.CONTENT_TYPE));
+    assertEquals(text, request.getBody().readUtf8());
+    assertNotNull(profile);
+    assertEquals(profile, this.profile);
   }
 }

--- a/src/test/java/com/ibm/watson/developer_cloud/speech_to_text/v1/SpeechToTextTest.java
+++ b/src/test/java/com/ibm/watson/developer_cloud/speech_to_text/v1/SpeechToTextTest.java
@@ -42,7 +42,6 @@ import com.ibm.watson.developer_cloud.util.GsonSingleton;
 import com.ibm.watson.developer_cloud.util.TestUtils;
 
 import okhttp3.mockwebserver.MockResponse;
-import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
 
 /**
@@ -59,7 +58,6 @@ public class SpeechToTextTest extends WatsonServiceUnitTest {
 
   private SpeechToText service;
   private SpeechSession session;
-  private MockWebServer server;
 
   /*
    * (non-Javadoc)
@@ -73,12 +71,9 @@ public class SpeechToTextTest extends WatsonServiceUnitTest {
 
     session = loadFixture("src/test/resources/speech_to_text/session.json", SpeechSession.class);
 
-    server = new MockWebServer();
-    server.start();
-
     service = new SpeechToText();
     service.setApiKey("");
-    service.setEndPoint(getMockWebServerUrl(server));
+    service.setEndPoint(getMockWebServerUrl());
   }
 
   /**

--- a/src/test/java/com/ibm/watson/developer_cloud/text_to_speech/v1/CustomizationsTest.java
+++ b/src/test/java/com/ibm/watson/developer_cloud/text_to_speech/v1/CustomizationsTest.java
@@ -49,8 +49,6 @@ public class CustomizationsTest extends WatsonServiceUnitTest {
   private static final String CUSTOMIZATIONS = "customizations";
   private static final String WORDS = "words";
 
-  private MockWebServer server;
-
   /** The service. */
   private TextToSpeech service;
 
@@ -64,24 +62,9 @@ public class CustomizationsTest extends WatsonServiceUnitTest {
   public void setUp() throws Exception {
     super.setUp();
 
-    server = new MockWebServer();
-    server.start();
-
     service = new TextToSpeech();
     service.setApiKey("");
-    service.setEndPoint(getMockWebServerUrl(server));
-  }
-
-  private static MockResponse jsonResponse(Object o) {
-    return new MockResponse()
-        .addHeader(CONTENT_TYPE, HttpMediaType.APPLICATION_JSON)
-        .setBody(GSON.toJson(o));
-  }
-
-  private static MockResponse jsonResponse(String key, Object o) {
-    return new MockResponse()
-        .addHeader(CONTENT_TYPE, HttpMediaType.APPLICATION_JSON)
-        .setBody(GSON.toJson(ImmutableMap.of(key, o)));
+    service.setEndPoint(getMockWebServerUrl());
   }
 
   private static CustomVoiceModel instantiateVoiceModel() {
@@ -101,7 +84,7 @@ public class CustomizationsTest extends WatsonServiceUnitTest {
   @Test
   public void testGetVoiceModels() throws InterruptedException {
     final List<CustomVoiceModel> expected = ImmutableList.of(instantiateVoiceModel());
-    server.enqueue(jsonResponse(CUSTOMIZATIONS, expected));
+    server.enqueue(jsonResponse(ImmutableMap.of(CUSTOMIZATIONS, expected)));
 
     final List<CustomVoiceModel> result = service.getCustomVoiceModels(MODEL_LANGUAGE).execute();
     final RecordedRequest request = server.takeRequest();
@@ -173,7 +156,7 @@ public class CustomizationsTest extends WatsonServiceUnitTest {
     final CustomVoiceModel model = instantiateVoiceModel();
     final List<CustomTranslation> expected = instantiateWords();
 
-    server.enqueue(jsonResponse(WORDS, expected));
+    server.enqueue(jsonResponse(ImmutableMap.of(WORDS, expected)));
     final List<CustomTranslation> result = service.getWords(model).execute();
     final RecordedRequest request = server.takeRequest();
 

--- a/src/test/java/com/ibm/watson/developer_cloud/text_to_speech/v1/TextToSpeechTest.java
+++ b/src/test/java/com/ibm/watson/developer_cloud/text_to_speech/v1/TextToSpeechTest.java
@@ -54,7 +54,6 @@ import com.ibm.watson.developer_cloud.util.TestUtils;
 
 import okhttp3.HttpUrl;
 import okhttp3.mockwebserver.MockResponse;
-import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
 import okio.Buffer;
 
@@ -67,8 +66,6 @@ public class TextToSpeechTest extends WatsonServiceUnitTest {
   private static final Gson GSON = GsonSingleton.getGsonWithoutPrettyPrinting();
   private final static String GET_VOICES_PATH = "/v1/voices";
   private final static String SYNTHESIZE_PATH = "/v1/synthesize";
-  
-  private MockWebServer server;
   
   /**
    * Write input stream to output stream.
@@ -115,12 +112,9 @@ public class TextToSpeechTest extends WatsonServiceUnitTest {
   public void setUp() throws Exception {
     super.setUp();
     
-    server = new MockWebServer();
-  	server.start();
-
     service = new TextToSpeech();
     service.setApiKey("");
-    service.setEndPoint(getMockWebServerUrl(server));
+    service.setEndPoint(getMockWebServerUrl());
   }
 
   /**

--- a/src/test/java/com/ibm/watson/developer_cloud/tone_analyzer/v3/ToneAnalyzerTest.java
+++ b/src/test/java/com/ibm/watson/developer_cloud/tone_analyzer/v3/ToneAnalyzerTest.java
@@ -30,8 +30,6 @@ import com.ibm.watson.developer_cloud.tone_analyzer.v3.model.Tone;
 import com.ibm.watson.developer_cloud.tone_analyzer.v3.model.ToneAnalysis;
 import com.ibm.watson.developer_cloud.tone_analyzer.v3.model.ToneOptions;
 
-import okhttp3.mockwebserver.MockResponse;
-import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
 
 /**
@@ -58,7 +56,7 @@ public class ToneAnalyzerTest extends WatsonServiceUnitTest {
     super.setUp();
     service = new ToneAnalyzer(ToneAnalyzer.VERSION_DATE_2016_05_19);
     service.setApiKey("");
-    service.setEndPoint(MOCK_SERVER_URL);
+    service.setEndPoint(getMockWebServerUrl());
 
   }
 
@@ -78,18 +76,10 @@ public class ToneAnalyzerTest extends WatsonServiceUnitTest {
         + "product suite. We have a competitive data analytics product "
         + "suite in the industry. But we need to do our job selling it! ";
 
-    MockWebServer server = new MockWebServer();
-
     ToneAnalysis mockResponse = loadFixture(FIXTURE, ToneAnalysis.class);
-    server.enqueue(new MockResponse().setBody(mockResponse.toString()));
-    server.enqueue(new MockResponse().setBody(mockResponse.toString()));
-    server.enqueue(new MockResponse().setBody(mockResponse.toString()));
-
-    server.start();
-
-    ToneAnalyzer service = new ToneAnalyzer(ToneAnalyzer.VERSION_DATE_2016_05_19);
-    service.setApiKey(EMPTY);
-    service.setEndPoint(getMockWebServerUrl(server));
+    server.enqueue(jsonResponse(mockResponse));
+    server.enqueue(jsonResponse(mockResponse));
+    server.enqueue(jsonResponse(mockResponse));
 
     // execute request
     ToneAnalysis serviceResponse = service.getTone(text, null).execute();
@@ -115,9 +105,5 @@ public class ToneAnalyzerTest extends WatsonServiceUnitTest {
     request = server.takeRequest();
     path = path + "&tones=emotion%2Clanguage%2Csocial";
     assertEquals(path, request.getPath());
-
-
-    // Shut down the server.
-    server.shutdown();
   }
 }

--- a/src/test/java/com/ibm/watson/developer_cloud/tone_analyzer/v3_beta/ToneAnalyzerTest.java
+++ b/src/test/java/com/ibm/watson/developer_cloud/tone_analyzer/v3_beta/ToneAnalyzerTest.java
@@ -1,11 +1,11 @@
 /**
  * Copyright 2015 IBM Corp. All Rights Reserved.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
@@ -26,14 +26,13 @@ import com.google.gson.JsonObject;
 import com.ibm.watson.developer_cloud.WatsonServiceUnitTest;
 import com.ibm.watson.developer_cloud.http.HttpHeaders;
 import com.ibm.watson.developer_cloud.http.HttpMediaType;
-import com.ibm.watson.developer_cloud.tone_analyzer.v3_beta.ToneAnalyzer;
 import com.ibm.watson.developer_cloud.tone_analyzer.v3_beta.model.ToneAnalysis;
 
 /**
  * Tone Analyzer unit test.
  */
 public class ToneAnalyzerTest extends WatsonServiceUnitTest {
-  
+
   private static final String VERSION_DATE = "version";
   private static final String TEXT = "text";
   private static final String FIXTURE = "src/test/resources/tone_analyzer/tone.json";

--- a/src/test/java/com/ibm/watson/developer_cloud/visual_recognition/v3/VisualRecognitionTest.java
+++ b/src/test/java/com/ibm/watson/developer_cloud/visual_recognition/v3/VisualRecognitionTest.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.junit.Before;
 import org.junit.Test;
 
 import com.google.gson.Gson;
@@ -35,7 +36,6 @@ import com.ibm.watson.developer_cloud.visual_recognition.v3.model.VisualClassifi
 import com.ibm.watson.developer_cloud.visual_recognition.v3.model.VisualRecognitionOptions;
 
 import okhttp3.mockwebserver.MockResponse;
-import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
 
 public class VisualRecognitionTest extends WatsonServiceUnitTest {
@@ -53,6 +53,18 @@ public class VisualRecognitionTest extends WatsonServiceUnitTest {
   private static final String PATH_DETECT_FACES = "/v3/detect_faces";
   private static final String PATH_RECOGNIZE_TEXT = "/v3/recognize_text";
 
+  private VisualRecognition service;
+
+  @Override
+  @Before
+  public void setUp() throws Exception {
+    super.setUp();
+
+    service = new VisualRecognition(VisualRecognition.VERSION_DATE_2016_05_19);
+    service.setApiKey(API_KEY);
+    service.setEndPoint(getMockWebServerUrl());
+  }
+
   /**
    * Test classify with file.
    *
@@ -61,16 +73,8 @@ public class VisualRecognitionTest extends WatsonServiceUnitTest {
    */
   @Test
   public void testClassifyWithFile() throws IOException, InterruptedException {
-    MockWebServer server = new MockWebServer();
-
     VisualClassification mockResponse = loadFixture(FIXTURE_CLASSIFICATION, VisualClassification.class);
     server.enqueue(new MockResponse().setBody(mockResponse.toString()));
-
-    server.start();
-
-    VisualRecognition service = new VisualRecognition(VisualRecognition.VERSION_DATE_2016_05_19);
-    service.setApiKey(API_KEY);
-    service.setEndPoint(getMockWebServerUrl(server));
 
     // execute request
     File images = new File(IMAGE_FILE);
@@ -85,9 +89,6 @@ public class VisualRecognitionTest extends WatsonServiceUnitTest {
     assertEquals(path, request.getPath());
     assertEquals("POST", request.getMethod());
     assertEquals(serviceResponse, mockResponse);
-
-    // Shut down the server.
-    server.shutdown();
   }
 
   /**
@@ -100,13 +101,7 @@ public class VisualRecognitionTest extends WatsonServiceUnitTest {
   public void testCreateClassifier() throws IOException, InterruptedException {
     VisualClassifier mockResponse = loadFixture(FIXTURE_CLASSIFIER, VisualClassifier.class);
     
-    MockWebServer server = new MockWebServer();
     server.enqueue(new MockResponse().setBody(mockResponse.toString()));
-    server.start();
-
-    VisualRecognition service = new VisualRecognition(VisualRecognition.VERSION_DATE_2016_05_19);
-    service.setApiKey(API_KEY);
-    service.setEndPoint(getMockWebServerUrl(server));
 
     // execute request
     File images = new File(IMAGE_FILE);
@@ -133,23 +128,13 @@ public class VisualRecognitionTest extends WatsonServiceUnitTest {
     assertTrue(body.contains(contentDisposition));
     assertTrue(body.contains("Content-Disposition: form-data; name=\"name\""));
     assertEquals(serviceResponse, mockResponse);
-
-    // Shut down the server.
-    server.shutdown();
   }
 
   @Test
   public void testDeleteClassifier() throws IOException, InterruptedException {
-    
-    MockWebServer server = new MockWebServer();
     server.enqueue(new MockResponse().setBody(""));
-    server.start();
 
-    VisualRecognition service = new VisualRecognition(VisualRecognition.VERSION_DATE_2016_05_19);
-    service.setApiKey(API_KEY);
-    service.setEndPoint(getMockWebServerUrl(server));
-
-    String class1 = "class1"; 
+    String class1 = "class1";
     service.deleteClassifier(class1).execute();
 
     // first request
@@ -160,22 +145,13 @@ public class VisualRecognitionTest extends WatsonServiceUnitTest {
     
     assertEquals(path, request.getPath());
     assertEquals("DELETE", request.getMethod());
-
-    // Shut down the server.
-    server.shutdown();
   }
 
   @Test
   public void testDetectFaces() throws IOException, InterruptedException  {
     DetectedFaces mockResponse = loadFixture(FIXTURE_FACES, DetectedFaces.class);
     
-    MockWebServer server = new MockWebServer();
     server.enqueue(new MockResponse().setBody(mockResponse.toString()));
-    server.start();
-
-    VisualRecognition service = new VisualRecognition(VisualRecognition.VERSION_DATE_2016_05_19);
-    service.setApiKey(API_KEY);
-    service.setEndPoint(getMockWebServerUrl(server));
 
     // execute request
     File images = new File(IMAGE_FILE);
@@ -196,9 +172,6 @@ public class VisualRecognitionTest extends WatsonServiceUnitTest {
     assertEquals(serviceResponse, mockResponse);
     String contentDisposition = "Content-Disposition: form-data; name=\"images_file\"; filename=\"test.zip\"";
     assertTrue(request.getBody().readUtf8().contains(contentDisposition));
-    
-    // Shut down the server.
-    server.shutdown();
   }
 
   @Test
@@ -206,13 +179,7 @@ public class VisualRecognitionTest extends WatsonServiceUnitTest {
     try {
       VisualClassifier mockResponse = loadFixture(FIXTURE_CLASSIFIER, VisualClassifier.class);
       
-      MockWebServer server = new MockWebServer();
       server.enqueue(new MockResponse().setBody(mockResponse.toString()));
-      server.start();
-
-      VisualRecognition service = new VisualRecognition(VisualRecognition.VERSION_DATE_2016_05_19);
-      service.setApiKey(API_KEY);
-      service.setEndPoint(getMockWebServerUrl(server));
 
       // execute request
       String class1 = "class1"; 
@@ -227,9 +194,6 @@ public class VisualRecognitionTest extends WatsonServiceUnitTest {
       assertEquals(path, request.getPath());
       assertEquals("GET", request.getMethod());
       assertEquals(serviceResponse, mockResponse);
-
-      // Shut down the server.
-      server.shutdown();
     } catch (Exception e) {
       e.printStackTrace();
     }
@@ -247,13 +211,7 @@ public class VisualRecognitionTest extends WatsonServiceUnitTest {
     JsonObject mockResponse = new JsonObject();
     mockResponse.add("classifiers", new Gson().toJsonTree(classifiers));
     
-    MockWebServer server = new MockWebServer();
     server.enqueue(new MockResponse().setBody(mockResponse.toString()));
-    server.start();
-
-    VisualRecognition service = new VisualRecognition(VisualRecognition.VERSION_DATE_2016_05_19);
-    service.setApiKey(API_KEY);
-    service.setEndPoint(getMockWebServerUrl(server));
 
     List<VisualClassifier> serviceResponse = service.getClassifiers().execute();
 
@@ -266,23 +224,13 @@ public class VisualRecognitionTest extends WatsonServiceUnitTest {
     assertEquals(path, request.getPath());
     assertEquals("GET", request.getMethod());
     assertEquals(serviceResponse, classifiers);
-
-    // Shut down the server.
-    server.shutdown();
-
   }
 
   @Test
   public void testRecognizeText() throws IOException, InterruptedException  {
     RecognizedText mockResponse = loadFixture(FIXTURE_TEXT, RecognizedText.class);
     
-    MockWebServer server = new MockWebServer();
     server.enqueue(new MockResponse().setBody(mockResponse.toString()));
-    server.start();
-
-    VisualRecognition service = new VisualRecognition(VisualRecognition.VERSION_DATE_2016_05_19);
-    service.setApiKey(API_KEY);
-    service.setEndPoint(getMockWebServerUrl(server));
 
     // execute request
     String url = "https://test.com";
@@ -305,10 +253,6 @@ public class VisualRecognitionTest extends WatsonServiceUnitTest {
     String body = request.getBody().readUtf8();
     assertTrue(body.contains("Content-Disposition: form-data; name=\"parameters\""));
     assertTrue(body.contains("{\"url\":\"https://test.com/\"}"));
-    
-
-    // Shut down the server.
-    server.shutdown();
   }
 
 }


### PR DESCRIPTION
### Summary

Remove MockServer and use MockWebServer in unit tests (see #316)
