### PR TITLE
Enforce travis.sh failure when maven fails

### DIFF
--- a/.utility/travis.sh
+++ b/.utility/travis.sh
@@ -1,10 +1,12 @@
 #!/bin/bash
 
+set -e # enforces the script to fail as soon as one command fails
+
 if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then
-	echo '$TRAVIS_PULL_REQUEST is false, running all tests'
+  echo '$TRAVIS_PULL_REQUEST is false, running all tests'
   openssl aes-256-cbc -K $encrypted_a973fe4f8e79_key -iv $encrypted_a973fe4f8e79_iv -in .config.properties.enc -out src/test/resources/.config.properties -d
   mvn clean cobertura:cobertura-integration-test
 else
-	echo '$TRAVIS_PULL_REQUEST is not false ($TRAVIS_PULL_REQUEST), running unit tests'
-	mvn clean test
+  echo '$TRAVIS_PULL_REQUEST is not false ($TRAVIS_PULL_REQUEST), running unit tests'
+  mvn clean test
 fi

--- a/pom.xml
+++ b/pom.xml
@@ -168,7 +168,6 @@
 					<includes>
 						<include>**/*IT.java</include>
 					</includes>
-					<skipAfterFailureCount>1</skipAfterFailureCount>
 				</configuration>
 				<executions>
 					<execution>

--- a/pom.xml
+++ b/pom.xml
@@ -168,6 +168,7 @@
 					<includes>
 						<include>**/*IT.java</include>
 					</includes>
+					<skipAfterFailureCount>1</skipAfterFailureCount>
 				</configuration>
 				<executions>
 					<execution>
@@ -175,6 +176,7 @@
 						<phase>integration-test</phase>
 						<goals>
 							<goal>integration-test</goal>
+							<goal>verify</goal>
 						</goals>
 					</execution>
 				</executions>
@@ -186,6 +188,7 @@
 				<configuration>
 					<format>xml</format>
 					<aggregate>true</aggregate>
+					<check></check>
 					<instrumentation>
 						<ignores>
 							<ignore>*.model*</ignore>


### PR DESCRIPTION
### Summary

#322: The Travis build seems to pass, even though the integration tests fail (see [Travis build log](https://travis-ci.org/watson-developer-cloud/java-sdk/jobs/136002119#L716))