### PR TITLE
[WIP] Improve integration test execution

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -171,6 +171,10 @@
 				<artifactId>maven-failsafe-plugin</artifactId>
 				<version>2.19</version>
 				<configuration>
+					<!--
+					ForkCount parallelizes the test execution on a per-class basis.
+					-->
+					<forkCount>8</forkCount>
 					<includes>
 						<include>**/*IT.java</include>
 						<!--

--- a/pom.xml
+++ b/pom.xml
@@ -173,6 +173,12 @@
 				<configuration>
 					<includes>
 						<include>**/*IT.java</include>
+						<!--
+						This is a simple way to include the unit tests in Cobertura's
+						code coverage. One downside is, that unit tests are now executed
+						twice during the verify phase.
+						-->
+						<include>**/*Test.java</include>
 					</includes>
 				</configuration>
 				<executions>


### PR DESCRIPTION
### Summary

This pull requests includes unit tests in the code coverage in a simple way. The downside is that unit tests are now effectively executed twice for the `mvn cobertura:cobertura-integration-tests` goal.

Removing the MockServer in #316 allows a class-based parallelization of the integration tests. This means that all methods inside one class are executed sequentially, but multiple test classes may be executed in parallel. I had promising results with a parallelization factor of **8** on my local machine, cutting down integration test time to 1:07 min