### PR TITLE
Fix javax android compatability

### DIFF
--- a/src/main/java/com/ibm/watson/developer_cloud/relationship_extraction/v1_beta/model/Dataset.java
+++ b/src/main/java/com/ibm/watson/developer_cloud/relationship_extraction/v1_beta/model/Dataset.java
@@ -13,12 +13,11 @@
  */
 package com.ibm.watson.developer_cloud.relationship_extraction.v1_beta.model;
 
-import javax.management.relation.RelationException;
-
 import com.ibm.watson.developer_cloud.service.model.GenericModel;
 
 /**
- * Dataset to be use in the {@link RelationException} service.
+ * Dataset to be use in the
+ * {@link com.ibm.watson.developer_cloud.relationship_extraction.v1_beta.RelationshipExtraction} service.
  */
 public class Dataset extends GenericModel {
 

--- a/src/main/java/com/ibm/watson/developer_cloud/util/CredentialUtils.java
+++ b/src/main/java/com/ibm/watson/developer_cloud/util/CredentialUtils.java
@@ -19,7 +19,6 @@ import java.util.logging.Logger;
 
 import javax.naming.Context;
 import javax.naming.InitialContext;
-import javax.naming.NamingException;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
@@ -76,6 +75,8 @@ public final class CredentialUtils {
 
   /**
    * Attempt to get the Base64-encoded API key through JNDI
+   *
+   * This method should will always return null on Android due to the javax functions being unsupported
    * 
    * @param serviceName Name of the bluemix service
    * @return The encoded API Key
@@ -89,7 +90,7 @@ public final class CredentialUtils {
       Context context = new InitialContext();
       String lookupName = "watson-developer-cloud/" + serviceName + "/credentials";
       return (String) context.lookup(lookupName);
-    } catch (NamingException e) {
+    } catch (Exception e) {
       return null;
     }
   }

--- a/src/main/java/com/ibm/watson/developer_cloud/util/CredentialUtils.java
+++ b/src/main/java/com/ibm/watson/developer_cloud/util/CredentialUtils.java
@@ -76,7 +76,7 @@ public final class CredentialUtils {
   /**
    * Attempt to get the Base64-encoded API key through JNDI
    *
-   * This method should will always return null on Android due to the javax functions being unsupported
+   * This method should always return null on Android due to the javax functions being unsupported
    * 
    * @param serviceName Name of the bluemix service
    * @return The encoded API Key


### PR DESCRIPTION
This pull request fixes the issues developers targeting older Android versions were seeing due to the use of `javax`. This has been tested with API 19 (Android 4.4), API 21 (Android 5.0), and API 23 (Android 6.0).