### PR TITLE
Warn developer when Requests are not executed

### DIFF
--- a/src/main/java/com/ibm/watson/developer_cloud/service/WatsonService.java
+++ b/src/main/java/com/ibm/watson/developer_cloud/service/WatsonService.java
@@ -225,6 +225,16 @@ public abstract class WatsonService {
 
         return completableFuture;
       }
+
+      @Override
+      protected void finalize() throws Throwable {
+        super.finalize();
+
+        if (!call.isExecuted()) {
+          final Request r = call.request();
+          LOG.warning(r.method() + " request to " + r.url() + " has not been sent. Did you forget to call execute()?");
+        }
+      }
     };
   }
 


### PR DESCRIPTION
### Summary

Upgrading from v2.7 to v3 can make requests like `naturalLanguageClassifier.createClassifier(name, "en", trainingData)` fail silently, because `execute()` is missing. This pull request adds a `finalize` method to `ServiceCall` which outputs a warning if the call has not been executed.