### PR TITLE
Improve ServiceCall and Response generics

### DIFF
--- a/src/main/java/com/ibm/watson/developer_cloud/http/ServiceCall.java
+++ b/src/main/java/com/ibm/watson/developer_cloud/http/ServiceCall.java
@@ -34,7 +34,7 @@ public interface ServiceCall<T> {
      *
      * @param callback the callback
      */
-    void enqueue(ServiceCallback<T> callback);
+    void enqueue(ServiceCallback<? super T> callback);
 
     /**
      * Reactive requests, in this case, you could take advantage both synchronous and asynchronous.

--- a/src/main/java/com/ibm/watson/developer_cloud/service/WatsonService.java
+++ b/src/main/java/com/ibm/watson/developer_cloud/service/WatsonService.java
@@ -183,7 +183,7 @@ public abstract class WatsonService {
       }
 
       @Override
-      public void enqueue(final ServiceCallback<T> callback) {
+      public void enqueue(final ServiceCallback<? super T> callback) {
         call.enqueue(new Callback() {
           @Override
           public void onFailure(Call call, IOException e) {

--- a/src/main/java/com/ibm/watson/developer_cloud/util/ResponseConverterUtils.java
+++ b/src/main/java/com/ibm/watson/developer_cloud/util/ResponseConverterUtils.java
@@ -73,7 +73,7 @@ public final class ResponseConverterUtils {
    * @param type the type
    * @return the response converter
    */
-  public static <T extends GenericModel> ResponseConverter<T> getObject(final Class<T> type) {
+  public static <T extends GenericModel> ResponseConverter<T> getObject(final Class<? extends T> type) {
     return new ResponseConverter<T>() {
       @Override
       public T convert(Response response) {

--- a/src/main/java/com/ibm/watson/developer_cloud/util/ResponseUtils.java
+++ b/src/main/java/com/ibm/watson/developer_cloud/util/ResponseUtils.java
@@ -87,7 +87,7 @@ public final class ResponseUtils {
    * @param type the type of the response
    * @return the POJO
    */
-  public static <T extends GenericModel> T getObject(Response response, Class<T> type) {
+  public static <T extends GenericModel> T getObject(Response response, Class<? extends T> type) {
     JsonReader reader;
     try {
       reader = new JsonReader(response.body().charStream());


### PR DESCRIPTION
### Summary

Following the PECS pattern (Producer extends, Consumer super), I added some generics goodness to the SDK. This enables a more flexible usage, e.g. to write generic `ServiceCallback` instances:

```java
ServiceCallback<GenericModel> cb = (GenericModel m) -> /* do something */;
service.createClassifier(name, "en", trainingData).enqueue(cb);
```

