### PR TITLE
Remove Apache Commons Lang dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,7 @@
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
       <version>3.4</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.bundles.repackaged</groupId>

--- a/src/main/java/com/ibm/watson/developer_cloud/retrieve_and_rank/v1/util/ZipUtils.java
+++ b/src/main/java/com/ibm/watson/developer_cloud/retrieve_and_rank/v1/util/ZipUtils.java
@@ -27,8 +27,6 @@ import java.io.IOException;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
-import org.apache.commons.lang3.StringUtils;
-
 /**
  * Utility class to manage Solr ZIP configuration files.
  */
@@ -90,7 +88,15 @@ public final class ZipUtils {
 
   private static void writeZipEntry(ZipOutputStream out, String name, byte[] data)
       throws IOException {
-    final ZipEntry entry = new ZipEntry(StringUtils.removeStart(name, "/"));
+    final String cleanedName;
+
+    if (name == null || name.isEmpty() || !name.startsWith("/")) {
+      cleanedName = name;
+    } else {
+      cleanedName = name.substring(1);
+    }
+
+    final ZipEntry entry = new ZipEntry(cleanedName);
     out.putNextEntry(entry);
     out.write(data, 0, data.length);
     out.closeEntry();

--- a/src/main/java/com/ibm/watson/developer_cloud/service/AlchemyService.java
+++ b/src/main/java/com/ibm/watson/developer_cloud/service/AlchemyService.java
@@ -17,8 +17,6 @@ import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import org.apache.commons.lang3.StringUtils;
-
 import com.google.gson.JsonObject;
 import com.ibm.watson.developer_cloud.http.HttpStatus;
 import com.ibm.watson.developer_cloud.http.ResponseConverter;
@@ -26,6 +24,7 @@ import com.ibm.watson.developer_cloud.service.exception.BadRequestException;
 import com.ibm.watson.developer_cloud.service.exception.ServiceResponseException;
 import com.ibm.watson.developer_cloud.service.exception.TooManyRequestsException;
 import com.ibm.watson.developer_cloud.service.exception.UnauthorizedException;
+import com.ibm.watson.developer_cloud.util.RequestUtils;
 import com.ibm.watson.developer_cloud.util.ResponseUtils;
 
 import okhttp3.HttpUrl;
@@ -196,7 +195,7 @@ public abstract class AlchemyService extends WatsonService {
     }
 
     if (params == null || i == acceptedFormats.length) {
-      throw new IllegalArgumentException(StringUtils.join(acceptedFormats, ",") + " should be specified");
+      throw new IllegalArgumentException(RequestUtils.join(acceptedFormats, ",") + " should be specified");
     }
     return acceptedFormats[i];
   }

--- a/src/main/java/com/ibm/watson/developer_cloud/tone_analyzer/v3/ToneAnalyzer.java
+++ b/src/main/java/com/ibm/watson/developer_cloud/tone_analyzer/v3/ToneAnalyzer.java
@@ -13,8 +13,6 @@
  */
 package com.ibm.watson.developer_cloud.tone_analyzer.v3;
 
-import org.apache.commons.lang3.StringUtils;
-
 import com.google.gson.JsonObject;
 import com.ibm.watson.developer_cloud.http.HttpHeaders;
 import com.ibm.watson.developer_cloud.http.HttpMediaType;
@@ -23,6 +21,7 @@ import com.ibm.watson.developer_cloud.http.ServiceCall;
 import com.ibm.watson.developer_cloud.service.WatsonService;
 import com.ibm.watson.developer_cloud.tone_analyzer.v3.model.ToneAnalysis;
 import com.ibm.watson.developer_cloud.tone_analyzer.v3.model.ToneOptions;
+import com.ibm.watson.developer_cloud.util.RequestUtils;
 import com.ibm.watson.developer_cloud.util.ResponseConverterUtils;
 import com.ibm.watson.developer_cloud.util.Validator;
 
@@ -101,7 +100,7 @@ public class ToneAnalyzer extends WatsonService {
     }
 
     if (options != null && options.tones() != null) {
-      requestBuilder.query(TONES, StringUtils.join(options.tones(), ","));
+      requestBuilder.query(TONES, RequestUtils.join(options.tones(), ","));
     }
 
     if (options != null && options.includeSentences() != null) {

--- a/src/main/java/com/ibm/watson/developer_cloud/tradeoff_analytics/v1/TradeoffAnalytics.java
+++ b/src/main/java/com/ibm/watson/developer_cloud/tradeoff_analytics/v1/TradeoffAnalytics.java
@@ -13,8 +13,6 @@
  */
 package com.ibm.watson.developer_cloud.tradeoff_analytics.v1;
 
-import org.apache.commons.lang3.Validate;
-
 import com.ibm.watson.developer_cloud.http.HttpMediaType;
 import com.ibm.watson.developer_cloud.http.RequestBuilder;
 import com.ibm.watson.developer_cloud.http.ServiceCall;
@@ -24,6 +22,7 @@ import com.ibm.watson.developer_cloud.tradeoff_analytics.v1.model.Problem;
 import com.ibm.watson.developer_cloud.tradeoff_analytics.v1.model.Resolution;
 import com.ibm.watson.developer_cloud.util.GsonSingleton;
 import com.ibm.watson.developer_cloud.util.ResponseConverterUtils;
+import com.ibm.watson.developer_cloud.util.Validator;
 
 /**
  * The IBM Watson Tradeoff Analytics service applies decision analytics technology, enabling users
@@ -102,7 +101,7 @@ public class TradeoffAnalytics extends WatsonService {
    * @return the decision problem
    */
   public ServiceCall<Dilemma> dilemmas(final Problem problem, final Boolean generateVisualization) {
-    Validate.notNull(problem, "problem was not specified");
+    Validator.notNull(problem, "problem was not specified");
 
     final String contentJson = GsonSingleton.getGsonWithoutPrettyPrinting().toJson(problem);
 

--- a/src/main/java/com/ibm/watson/developer_cloud/util/RequestUtils.java
+++ b/src/main/java/com/ibm/watson/developer_cloud/util/RequestUtils.java
@@ -26,8 +26,6 @@ import java.util.Properties;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import org.apache.commons.lang3.ArrayUtils;
-
 import com.ibm.watson.developer_cloud.service.WatsonService;
 
 import okhttp3.Request;
@@ -129,6 +127,17 @@ public final class RequestUtils {
    */
   public static String replaceEndPoint(String url, String endPoint) {
     return endPoint + url.replaceFirst(DEFAULT_ENDPOINT, "");
+  }
+
+  /**
+   * Creates a String of all elements of an array, separated by a separator.
+   *
+   * @param array the array
+   * @param separator the separator
+   * @return the joined String
+   */
+  public static <T> String join(T[] array, String separator) {
+    return join(Arrays.asList(array), separator);
   }
 
   /**


### PR DESCRIPTION
### Summary

Following the efforts to keep the method count and Android binary size low, it is now safe to remove Apache Commons Lang as dependency. This is a reduction of 3,582 methods and 435 kb :tada:  

To keep a pleasant testing experience, Apache Commons Lang is still included in the tests.