### PR TITLE
Synchronize SimpleDateFormat usage

### DIFF
--- a/src/main/java/com/ibm/watson/developer_cloud/util/DateSerializer.java
+++ b/src/main/java/com/ibm/watson/developer_cloud/util/DateSerializer.java
@@ -14,6 +14,7 @@
 package com.ibm.watson.developer_cloud.util;
 
 import java.lang.reflect.Type;
+import java.text.SimpleDateFormat;
 import java.util.Date;
 
 import com.google.gson.JsonElement;
@@ -26,6 +27,10 @@ import com.google.gson.JsonSerializer;
  * Date serializer.
  */
 public class DateSerializer implements JsonSerializer<Date> {
+
+  // SimpleDateFormat is NOT thread safe - they require private visibility and synchronized access
+  private final SimpleDateFormat utc = new SimpleDateFormat(DateDeserializer.DATE_UTC);
+
   /*
    * (non-Javadoc)
    * 
@@ -33,7 +38,8 @@ public class DateSerializer implements JsonSerializer<Date> {
    * com.google.gson.JsonSerializationContext)
    */
   @Override
-  public JsonElement serialize(Date src, Type typeOfSrc, JsonSerializationContext context) {
-    return src == null ? JsonNull.INSTANCE : new JsonPrimitive(DateDeserializer.UTC.format(src));
+  // DateSerializer.serialize() is NOT thread safe because of the underlying SimpleDateFormats.
+  public synchronized JsonElement serialize(Date src, Type typeOfSrc, JsonSerializationContext context) {
+    return src == null ? JsonNull.INSTANCE : new JsonPrimitive(utc.format(src));
   }
 }


### PR DESCRIPTION
### Summary

This fix prevents multithreading bugs with `SimpleDateFormat` in `DateSerializer` and `DateDeserializer`.

> Date formats are not synchronized. It is recommended to create separate format instances for each thread. If multiple threads access a format concurrently, it must be synchronized externally.
 -- [SimpleDateFormat documentation](https://docs.oracle.com/javase/7/docs/api/java/text/SimpleDateFormat.html)