### PR TITLE
Add get username and password util, update conversation payload

### DIFF
--- a/src/main/java/com/ibm/watson/developer_cloud/conversation/v1_experimental/model/MessageResponse.java
+++ b/src/main/java/com/ibm/watson/developer_cloud/conversation/v1_experimental/model/MessageResponse.java
@@ -95,6 +95,24 @@ public class MessageResponse extends GenericModel {
     public void setValue(String value) {
       this.value = value;
     }
+
+    @Override public boolean equals(Object obj) {
+      if (this == obj)
+        return true;
+      if (obj instanceof MessageResponse) {
+        MessageResponse.Entity test = (MessageResponse.Entity) obj;
+        if (this.getEntity() == test.getEntity()) {
+          if (this.getLocation() == test.getLocation()) {
+            if (this.getValue() == test.getValue()) {
+              return true;
+            }
+          }
+        }
+      }
+      return false;
+    }
+
+
   }
 
   /**
@@ -146,6 +164,21 @@ public class MessageResponse extends GenericModel {
      */
     public void setIntent(String intent) {
       this.intent = intent;
+    }
+    
+    @Override public boolean equals(Object obj) {
+      if(this == obj){
+        return true;
+      }
+      if(obj instanceof MessageResponse.Intent){
+        MessageResponse.Intent test = (Intent)obj;
+        if(this.getConfidence() == test.getConfidence()){
+          if(this.getIntent() == test.getIntent()){
+            return true;
+          }
+        }
+      }
+      return false;
     }
   }
 
@@ -240,7 +273,13 @@ public class MessageResponse extends GenericModel {
    * @return an array of strings which is to be displayed/returned to the end user
    */
   public String[] getText() {
-    return (output != null && output.containsKey(TEXT)) ? (String[]) output.get(TEXT) : null;
+    if (output != null && output.containsKey(TEXT)) {
+      List<?> text = (List<?>) output.get(TEXT);
+      if (text != null) {
+        text.toArray(new String[0]);
+      }
+    }
+    return null;
   }
 
   /**

--- a/src/main/java/com/ibm/watson/developer_cloud/conversation/v1_experimental/model/MessageResponse.java
+++ b/src/main/java/com/ibm/watson/developer_cloud/conversation/v1_experimental/model/MessageResponse.java
@@ -16,10 +16,9 @@ package com.ibm.watson.developer_cloud.conversation.v1_experimental.model;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.commons.lang3.StringUtils;
-
 import com.ibm.watson.developer_cloud.conversation.v1_experimental.ConversationService;
 import com.ibm.watson.developer_cloud.service.model.GenericModel;
+import com.ibm.watson.developer_cloud.util.RequestUtils;
 
 /**
  * The response payload from the Conversation service's message API call
@@ -165,15 +164,15 @@ public class MessageResponse extends GenericModel {
     public void setIntent(String intent) {
       this.intent = intent;
     }
-    
+
     @Override public boolean equals(Object obj) {
-      if(this == obj){
+      if (this == obj) {
         return true;
       }
-      if(obj instanceof MessageResponse.Intent){
-        MessageResponse.Intent test = (Intent)obj;
-        if(this.getConfidence() == test.getConfidence()){
-          if(this.getIntent() == test.getIntent()){
+      if (obj instanceof MessageResponse.Intent) {
+        MessageResponse.Intent test = (Intent) obj;
+        if (this.getConfidence() == test.getConfidence()) {
+          if (this.getIntent() == test.getIntent()) {
             return true;
           }
         }
@@ -267,16 +266,20 @@ public class MessageResponse extends GenericModel {
    * to calling:
    * 
    * <pre>
-   * String[] text = null; Map<String, Object> output = response.getOutput(); return if(output !=
-   * null){ text = (String[])output.get("text"); }
+   * List<?> text = null;
+   * Map<String, Object> output = response.getOutput();
+   * if (output != null) {
+   *   text = (List<?>) output.get("text");
+   * }
+   * </pre>
    * 
    * @return an array of strings which is to be displayed/returned to the end user
    */
-  public String[] getText() {
+  public List<String> getText() {
     if (output != null && output.containsKey(TEXT)) {
       List<?> text = (List<?>) output.get(TEXT);
       if (text != null) {
-        text.toArray(new String[0]);
+        return (List<String>) text;
       }
     }
     return null;
@@ -291,9 +294,9 @@ public class MessageResponse extends GenericModel {
    *         separator string
    */
   public String getTextConcatenated(String separator) {
-    if (output != null && output.containsKey(TEXT)) {
-      String[] outputText = (String[]) output.get(TEXT);
-      return StringUtils.join(outputText, separator);
+    List<String> outputText = getText();
+    if (outputText != null) {
+      return RequestUtils.join(outputText, separator);
     }
     return null;
   }

--- a/src/main/java/com/ibm/watson/developer_cloud/conversation/v1_experimental/model/MessageResponse.java
+++ b/src/main/java/com/ibm/watson/developer_cloud/conversation/v1_experimental/model/MessageResponse.java
@@ -94,24 +94,6 @@ public class MessageResponse extends GenericModel {
     public void setValue(String value) {
       this.value = value;
     }
-
-    @Override public boolean equals(Object obj) {
-      if (this == obj)
-        return true;
-      if (obj instanceof MessageResponse) {
-        MessageResponse.Entity test = (MessageResponse.Entity) obj;
-        if (this.getEntity() == test.getEntity()) {
-          if (this.getLocation() == test.getLocation()) {
-            if (this.getValue() == test.getValue()) {
-              return true;
-            }
-          }
-        }
-      }
-      return false;
-    }
-
-
   }
 
   /**
@@ -163,21 +145,6 @@ public class MessageResponse extends GenericModel {
      */
     public void setIntent(String intent) {
       this.intent = intent;
-    }
-
-    @Override public boolean equals(Object obj) {
-      if (this == obj) {
-        return true;
-      }
-      if (obj instanceof MessageResponse.Intent) {
-        MessageResponse.Intent test = (Intent) obj;
-        if (this.getConfidence() == test.getConfidence()) {
-          if (this.getIntent() == test.getIntent()) {
-            return true;
-          }
-        }
-      }
-      return false;
     }
   }
 
@@ -309,9 +276,9 @@ public class MessageResponse extends GenericModel {
   public void setInput(Map<String, Object> input) {
     this.input = input;
   }
-  
-  public String getInputText(){
-    if(this.input != null && this.input.containsKey(TEXT)){
+
+  public String getInputText() {
+    if (this.input != null && this.input.containsKey(TEXT)) {
       return this.input.get(TEXT).toString();
     }
     return null;

--- a/src/main/java/com/ibm/watson/developer_cloud/conversation/v1_experimental/model/MessageResponse.java
+++ b/src/main/java/com/ibm/watson/developer_cloud/conversation/v1_experimental/model/MessageResponse.java
@@ -16,6 +16,8 @@ package com.ibm.watson.developer_cloud.conversation.v1_experimental.model;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.commons.lang3.StringUtils;
+
 import com.ibm.watson.developer_cloud.conversation.v1_experimental.ConversationService;
 import com.ibm.watson.developer_cloud.service.model.GenericModel;
 
@@ -232,14 +234,28 @@ public class MessageResponse extends GenericModel {
    * to calling:
    * 
    * <pre>
-   * String text = null;
-   * Map<String, Object> output = response.getOutput();
-   * return if(output != null){ text
-   * = output.get("text"); }
+   * String[] text = null; Map<String, Object> output = response.getOutput(); return if(output !=
+   * null){ text = (String[])output.get("text"); }
    * 
-   * @return the text which is to be displayed/returned to the end user
+   * @return an array of strings which is to be displayed/returned to the end user
    */
-  public String getText() {
-    return (output != null && output.containsKey(TEXT)) ? output.get(TEXT).toString() : null;
+  public String[] getText() {
+    return (output != null && output.containsKey(TEXT)) ? (String[]) output.get(TEXT) : null;
+  }
+
+  /**
+   * A convenience method for getting the text property from the output object. The text property is
+   * an array of strings. This convenience class concatenates the array, separating each entry with
+   * the separator string.
+   * 
+   * @return a concatenation of the strings in the output array, with each string separated by the
+   *         separator string
+   */
+  public String getTextConcatenated(String separator) {
+    if (output != null && output.containsKey(TEXT)) {
+      String[] outputText = (String[]) output.get(TEXT);
+      return StringUtils.join(outputText, separator);
+    }
+    return null;
   }
 }

--- a/src/main/java/com/ibm/watson/developer_cloud/conversation/v1_experimental/model/MessageResponse.java
+++ b/src/main/java/com/ibm/watson/developer_cloud/conversation/v1_experimental/model/MessageResponse.java
@@ -185,6 +185,7 @@ public class MessageResponse extends GenericModel {
   private List<Entity> entities;
   private List<Intent> intents;
   private Map<String, Object> output;
+  private Map<String, Object> input;
 
 
   /**
@@ -297,6 +298,21 @@ public class MessageResponse extends GenericModel {
     List<String> outputText = getText();
     if (outputText != null) {
       return RequestUtils.join(outputText, separator);
+    }
+    return null;
+  }
+
+  public Map<String, Object> getInput() {
+    return input;
+  }
+
+  public void setInput(Map<String, Object> input) {
+    this.input = input;
+  }
+  
+  public String getInputText(){
+    if(this.input != null && this.input.containsKey(TEXT)){
+      return this.input.get(TEXT).toString();
     }
     return null;
   }

--- a/src/main/java/com/ibm/watson/developer_cloud/util/CredentialUtils.java
+++ b/src/main/java/com/ibm/watson/developer_cloud/util/CredentialUtils.java
@@ -174,7 +174,7 @@ public final class CredentialUtils {
       return getKeyUsingJNDI(serviceName);
     if (serviceName.equalsIgnoreCase(ALCHEMY_API)) {
       final JsonObject credentials = getCredentialsObject(services, serviceName, plan);
-      if (serviceName.equalsIgnoreCase(ALCHEMY_API)) {
+      if (credentials != null && serviceName.equalsIgnoreCase(ALCHEMY_API)) {
         return credentials.get(APIKEY).getAsString();
       }
     } else {
@@ -286,7 +286,7 @@ public final class CredentialUtils {
       return null;
 
     final JsonObject credentials = getCredentialsObject(services, serviceName, plan);
-    if (credentials.has(URL))
+    if (credentials != null && credentials.has(URL))
       return credentials.get(URL).getAsString();
 
     return null;

--- a/src/main/java/com/ibm/watson/developer_cloud/util/CredentialUtils.java
+++ b/src/main/java/com/ibm/watson/developer_cloud/util/CredentialUtils.java
@@ -32,6 +32,35 @@ import okhttp3.Credentials;
  * The Class CredentialUtils.
  */
 public final class CredentialUtils {
+  /**
+   * A util class to easily store service credentials.
+   * 
+   */
+  public static class ServiceCredentials {
+    private String password;
+    private String username;
+
+    public ServiceCredentials(String username, String password) {
+      this.username = username;
+      this.password = password;
+    }
+
+    public String getPassword() {
+      return password;
+    }
+
+    public String getUsername() {
+      return username;
+    }
+
+    public void setPassword(String password) {
+      this.password = password;
+    }
+
+    public void setUsername(String username) {
+      this.username = username;
+    }
+  }
 
   /** The Constant ALCHEMY_API. */
   private static final String ALCHEMY_API = "alchemy_api";
@@ -152,26 +181,14 @@ public final class CredentialUtils {
     if (services == null)
       return getKeyUsingJNDI(serviceName);
     if (serviceName.equalsIgnoreCase(ALCHEMY_API)) {
-      for (final Entry<String, JsonElement> entry : services.entrySet()) {
-        final String key = entry.getKey();
-        if (key.startsWith(serviceName)) {
-          final JsonArray servInstances = services.getAsJsonArray(key);
-          for (final JsonElement instance : servInstances) {
-            final JsonObject service = instance.getAsJsonObject();
-            final String instancePlan = service.get(PLAN).getAsString();
-            if (plan == null || plan.equalsIgnoreCase(instancePlan)) {
-              final JsonObject credentials = instance.getAsJsonObject().getAsJsonObject(CREDENTIALS);
-              if (serviceName.equalsIgnoreCase(ALCHEMY_API)) {
-                return credentials.get(APIKEY).getAsString();
-              }
-            }
-          }
-        }
+      final JsonObject credentials = getCredentialsObject(services, serviceName, plan);
+      if (serviceName.equalsIgnoreCase(ALCHEMY_API)) {
+        return credentials.get(APIKEY).getAsString();
       }
     } else {
-      String[] userNameAndPw = getUserNameAndPassword(serviceName, plan);
-      if (userNameAndPw != null && userNameAndPw.length == 2) {
-        return Credentials.basic(userNameAndPw[0], userNameAndPw[1]);
+      ServiceCredentials credentials = getUserNameAndPassword(serviceName, plan);
+      if (credentials != null) {
+        return Credentials.basic(credentials.getUsername(), credentials.getPassword());
       }
     }
     return null;
@@ -184,10 +201,9 @@ public final class CredentialUtils {
    * <code>getUserNameAndPassword(serviceName, null);</code>
    * 
    * @param serviceName the name of the service whose credentials are sought
-   * @return a string array of length 2. The first array entry is the username, the second the
-   *         password.
+   * @return an object representing the service's credentials
    */
-  public static String[] getUserNameAndPassword(String serviceName) {
+  public static ServiceCredentials getUserNameAndPassword(String serviceName) {
     return getUserNameAndPassword(serviceName, null);
   }
 
@@ -197,10 +213,9 @@ public final class CredentialUtils {
    * service) will be returned. Null will be returned if the plan does not exist.
    * 
    * @param serviceName the name of the service whose credentials are sought
-   * @return a string array of length 2. The first array entry is the username, the second the
-   *         password.
+   * @return an object representing the service's credentials
    */
-  public static String[] getUserNameAndPassword(String serviceName, String plan) {
+  public static ServiceCredentials getUserNameAndPassword(String serviceName, String plan) {
     if (serviceName == null || serviceName.isEmpty())
       return null;
 
@@ -208,22 +223,42 @@ public final class CredentialUtils {
     if (services == null)
       return null;
 
-    for (final Entry<String, JsonElement> entry : services.entrySet()) {
+    JsonObject jsonCredentials = getCredentialsObject(services, serviceName, plan);
+    if (jsonCredentials != null) {
+      String username = null;
+      if (jsonCredentials.has(USERNAME)) {
+        username = jsonCredentials.get(USERNAME).getAsString();
+      }
+      String password = null;
+      if (jsonCredentials.has(PASSWORD)) {
+        password = jsonCredentials.get(PASSWORD).getAsString();
+      }
+      if (username != null || password != null) {
+        // both will be null in the case of Alchemy API
+        return new ServiceCredentials(username, password);
+      }
+    }
+    return null;
+  }
+
+  /**
+   * A helper method to retrieve the appropriate 'credentials' JSON property value from the VCAP_SERVICES
+   * 
+   * @param vcapServices JSON object representing the VCAP_SERVICES
+   * @param serviceName the name of the service whose credentials are sought
+   * @param plan the name of the plan for which the credentials are sought, e.g. 'standard', 'beta' etc, may be null
+   * @return the first set of credentials that match the search criteria, service name and plan. May return null
+   */
+  private static JsonObject getCredentialsObject(JsonObject vcapServices, String serviceName, String plan) {
+    for (final Entry<String, JsonElement> entry : vcapServices.entrySet()) {
       final String key = entry.getKey();
       if (key.startsWith(serviceName)) {
-        final JsonArray servInstances = services.getAsJsonArray(key);
+        final JsonArray servInstances = vcapServices.getAsJsonArray(key);
         for (final JsonElement instance : servInstances) {
           final JsonObject service = instance.getAsJsonObject();
           final String instancePlan = service.get(PLAN).getAsString();
           if (plan == null || plan.equalsIgnoreCase(instancePlan)) {
-            final JsonObject credentials = instance.getAsJsonObject().getAsJsonObject(CREDENTIALS);
-            if (serviceName.equalsIgnoreCase(ALCHEMY_API)) {
-              return null;
-            } else {
-              final String username = credentials.get(USERNAME).getAsString();
-              final String password = credentials.get(PASSWORD).getAsString();
-              return new String[] {username, password};
-            }
+            return instance.getAsJsonObject().getAsJsonObject(CREDENTIALS);
           }
         }
       }
@@ -258,21 +293,10 @@ public final class CredentialUtils {
     if (services == null)
       return null;
 
-    for (final Entry<String, JsonElement> entry : services.entrySet()) {
-      final String key = entry.getKey();
-      if (key.startsWith(serviceName)) {
-        final JsonArray servInstances = services.getAsJsonArray(key);
-        for (final JsonElement instance : servInstances) {
-          final JsonObject service = instance.getAsJsonObject();
-          final String instancePlan = service.get(PLAN).getAsString();
-          if (plan == null || plan.equalsIgnoreCase(instancePlan)) {
-            final JsonObject credentials = instance.getAsJsonObject().getAsJsonObject(CREDENTIALS);
-            if (credentials.has(URL))
-              return credentials.get(URL).getAsString();
-          }
-        }
-      }
-    }
+    final JsonObject credentials = getCredentialsObject(services, serviceName, plan);
+    if (credentials.has(URL))
+      return credentials.get(URL).getAsString();
+
     return null;
   }
 

--- a/src/main/java/com/ibm/watson/developer_cloud/util/CredentialUtils.java
+++ b/src/main/java/com/ibm/watson/developer_cloud/util/CredentialUtils.java
@@ -40,7 +40,7 @@ public final class CredentialUtils {
     private String password;
     private String username;
 
-    public ServiceCredentials(String username, String password) {
+    private ServiceCredentials(String username, String password) {
       this.username = username;
       this.password = password;
     }
@@ -51,14 +51,6 @@ public final class CredentialUtils {
 
     public String getUsername() {
       return username;
-    }
-
-    public void setPassword(String password) {
-      this.password = password;
-    }
-
-    public void setUsername(String username) {
-      this.username = username;
     }
   }
 

--- a/src/test/java/com/ibm/watson/developer_cloud/conversation/v1_experimental/ConversationTest.java
+++ b/src/test/java/com/ibm/watson/developer_cloud/conversation/v1_experimental/ConversationTest.java
@@ -13,14 +13,13 @@
  */
 package com.ibm.watson.developer_cloud.conversation.v1_experimental;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertArrayEquals;
 
 import java.io.IOException;
 
 import org.apache.commons.lang3.StringUtils;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -66,7 +65,7 @@ public class ConversationTest extends WatsonServiceUnitTest {
    */
   @Test
   public void testSendMessage() throws IOException, InterruptedException {
-    String text = "I'd like to get a quote to replace my windows";
+    String text = "I'd like to get insurance to for my home";
 
     MessageResponse mockResponse = loadFixture(FIXTURE, MessageResponse.class);
     server.enqueue(jsonResponse(mockResponse));
@@ -85,7 +84,7 @@ public class ConversationTest extends WatsonServiceUnitTest {
     assertEquals("Do you want to get a quote?", serviceResponse.getTextConcatenated(" "));
     assertEquals(request.getMethod(), "POST");
     assertNotNull(request.getHeader(HttpHeaders.AUTHORIZATION));
-    assertEquals("{\"input\":{\"text\":\"I'd like to get a quote to replace my windows\"}}", request.getBody().readUtf8());
+    assertEquals("{\"input\":{\"text\":\"I'd like to get insurance to for my home\"}}", request.getBody().readUtf8());
     assertEquals(serviceResponse, mockResponse);
   }
 }

--- a/src/test/java/com/ibm/watson/developer_cloud/conversation/v1_experimental/ConversationTest.java
+++ b/src/test/java/com/ibm/watson/developer_cloud/conversation/v1_experimental/ConversationTest.java
@@ -18,7 +18,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 import java.io.IOException;
-import java.util.Arrays;
 
 import org.apache.commons.lang3.StringUtils;
 import org.junit.Before;

--- a/src/test/java/com/ibm/watson/developer_cloud/conversation/v1_experimental/ConversationTest.java
+++ b/src/test/java/com/ibm/watson/developer_cloud/conversation/v1_experimental/ConversationTest.java
@@ -15,10 +15,12 @@ package com.ibm.watson.developer_cloud.conversation.v1_experimental;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertArrayEquals;
 
 import java.io.IOException;
 
 import org.apache.commons.lang3.StringUtils;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -79,7 +81,8 @@ public class ConversationTest extends WatsonServiceUnitTest {
 
     String path = StringUtils.join(PATH_MESSAGE, "?", VERSION, "=", ConversationService.VERSION_DATE_2016_05_19);
     assertEquals(path, request.getPath());
-    assertEquals("Do you want to get a quote?", serviceResponse.getText());
+    assertArrayEquals(new String[] {"Do you want to get a quote?"}, serviceResponse.getText());
+    assertEquals("Do you want to get a quote?", serviceResponse.getTextConcatenated(" "));
     assertEquals(request.getMethod(), "POST");
     assertNotNull(request.getHeader(HttpHeaders.AUTHORIZATION));
     assertEquals("{\"input\":{\"text\":\"I'd like to get a quote to replace my windows\"}}", request.getBody().readUtf8());

--- a/src/test/java/com/ibm/watson/developer_cloud/conversation/v1_experimental/ConversationTest.java
+++ b/src/test/java/com/ibm/watson/developer_cloud/conversation/v1_experimental/ConversationTest.java
@@ -18,6 +18,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 import java.io.IOException;
+import java.util.Arrays;
 
 import org.apache.commons.lang3.StringUtils;
 import org.junit.Before;
@@ -80,7 +81,7 @@ public class ConversationTest extends WatsonServiceUnitTest {
 
     String path = StringUtils.join(PATH_MESSAGE, "?", VERSION, "=", ConversationService.VERSION_DATE_2016_05_19);
     assertEquals(path, request.getPath());
-    assertArrayEquals(new String[] {"Do you want to get a quote?"}, serviceResponse.getText());
+    assertArrayEquals(new String[] {"Do you want to get a quote?"}, serviceResponse.getText().toArray(new String[0]));
     assertEquals("Do you want to get a quote?", serviceResponse.getTextConcatenated(" "));
     assertEquals(request.getMethod(), "POST");
     assertNotNull(request.getHeader(HttpHeaders.AUTHORIZATION));

--- a/src/test/java/com/ibm/watson/developer_cloud/util/CredentialUtilsTest.java
+++ b/src/test/java/com/ibm/watson/developer_cloud/util/CredentialUtilsTest.java
@@ -18,6 +18,7 @@ import static org.junit.Assert.assertNull;
 
 import java.io.InputStream;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -40,6 +41,12 @@ public class CredentialUtilsTest extends WatsonServiceTest {
 
   /** The Constant VCAP_SERVICES. */
   private static final String VCAP_SERVICES = "vcap_services.json";
+  
+  private static final String NOT_A_USERNAME = "not-a-username";
+  private static final String NOT_A_PASSWORD = "not-a-password";
+  private static final String NOT_A_FREE_USERNAME = "not-a-free-username";
+  private static final String NOT_A_FREE_PASSWORD = "not-a-free-password";
+  private static final String PLAN = "standard";
 
   /**
    * Setup.
@@ -63,5 +70,35 @@ public class CredentialUtilsTest extends WatsonServiceTest {
     assertEquals(API_KEY_FREE, CredentialUtils.getAPIKey(SERVICE_NAME, null));
     assertEquals(API_KEY_FREE, CredentialUtils.getAPIKey(SERVICE_NAME, CredentialUtils.PLAN_FREE));
     assertEquals(API_KEY_STANDARD, CredentialUtils.getAPIKey(SERVICE_NAME, CredentialUtils.PLAN_STANDARD));
+  }
+  
+  @Test
+  public void testGetUserNameAndPasswordWithoutPlan(){
+    assertNull(CredentialUtils.getUserNameAndPassword(null));
+    assertNull(CredentialUtils.getUserNameAndPassword(null, null));
+    
+    String[] credentials = CredentialUtils.getUserNameAndPassword(SERVICE_NAME);
+    Assert.assertTrue(credentials != null);
+    assertEquals(credentials.length, 2);
+    assertEquals(credentials[0], NOT_A_FREE_USERNAME);
+    assertEquals(credentials[1], NOT_A_FREE_PASSWORD);
+    
+    credentials = CredentialUtils.getUserNameAndPassword(SERVICE_NAME, null);
+    Assert.assertTrue(credentials != null);
+    assertEquals(credentials.length, 2);
+    assertEquals(credentials[0], NOT_A_FREE_USERNAME);
+    assertEquals(credentials[1], NOT_A_FREE_PASSWORD);
+  }
+  
+  @Test
+  public void testGetUserCredentialsWithPlan(){
+    assertNull(CredentialUtils.getUserNameAndPassword(null));
+    assertNull(CredentialUtils.getUserNameAndPassword(null, null));
+    
+    String[] credentials = CredentialUtils.getUserNameAndPassword(SERVICE_NAME, PLAN);
+    Assert.assertTrue(credentials != null);
+    assertEquals(credentials.length, 2);
+    assertEquals(credentials[0], NOT_A_USERNAME);
+    assertEquals(credentials[1], NOT_A_PASSWORD);
   }
 }

--- a/src/test/java/com/ibm/watson/developer_cloud/util/CredentialUtilsTest.java
+++ b/src/test/java/com/ibm/watson/developer_cloud/util/CredentialUtilsTest.java
@@ -24,6 +24,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import com.ibm.watson.developer_cloud.WatsonServiceTest;
+import com.ibm.watson.developer_cloud.util.CredentialUtils.ServiceCredentials;
 
 /**
  * The Class CredentialUtilsTest.
@@ -78,17 +79,15 @@ public class CredentialUtilsTest extends WatsonServiceTest {
     assertNull(CredentialUtils.getUserNameAndPassword(null));
     assertNull(CredentialUtils.getUserNameAndPassword(null, null));
     
-    String[] credentials = CredentialUtils.getUserNameAndPassword(SERVICE_NAME);
+    ServiceCredentials credentials = CredentialUtils.getUserNameAndPassword(SERVICE_NAME);
     Assert.assertTrue(credentials != null);
-    assertEquals(credentials.length, 2);
-    assertEquals(credentials[0], NOT_A_FREE_USERNAME);
-    assertEquals(credentials[1], NOT_A_FREE_PASSWORD);
+    assertEquals(credentials.getUsername(), NOT_A_FREE_USERNAME);
+    assertEquals(credentials.getPassword(), NOT_A_FREE_PASSWORD);
     
     credentials = CredentialUtils.getUserNameAndPassword(SERVICE_NAME, null);
     assertTrue(credentials != null);
-    assertEquals(credentials.length, 2);
-    assertEquals(credentials[0], NOT_A_FREE_USERNAME);
-    assertEquals(credentials[1], NOT_A_FREE_PASSWORD);
+    assertEquals(credentials.getUsername(), NOT_A_FREE_USERNAME);
+    assertEquals(credentials.getPassword(), NOT_A_FREE_PASSWORD);
   }
   
   @Test
@@ -96,10 +95,9 @@ public class CredentialUtilsTest extends WatsonServiceTest {
     assertNull(CredentialUtils.getUserNameAndPassword(null));
     assertNull(CredentialUtils.getUserNameAndPassword(null, null));
     
-    String[] credentials = CredentialUtils.getUserNameAndPassword(SERVICE_NAME, PLAN);
+    ServiceCredentials credentials = CredentialUtils.getUserNameAndPassword(SERVICE_NAME, PLAN);
     assertTrue(credentials != null);
-    assertEquals(credentials.length, 2);
-    assertEquals(credentials[0], NOT_A_USERNAME);
-    assertEquals(credentials[1], NOT_A_PASSWORD);
+    assertEquals(credentials.getUsername(), NOT_A_USERNAME);
+    assertEquals(credentials.getPassword(), NOT_A_PASSWORD);
   }
 }

--- a/src/test/java/com/ibm/watson/developer_cloud/util/CredentialUtilsTest.java
+++ b/src/test/java/com/ibm/watson/developer_cloud/util/CredentialUtilsTest.java
@@ -15,6 +15,7 @@ package com.ibm.watson.developer_cloud.util;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import java.io.InputStream;
 
@@ -84,7 +85,7 @@ public class CredentialUtilsTest extends WatsonServiceTest {
     assertEquals(credentials[1], NOT_A_FREE_PASSWORD);
     
     credentials = CredentialUtils.getUserNameAndPassword(SERVICE_NAME, null);
-    Assert.assertTrue(credentials != null);
+    assertTrue(credentials != null);
     assertEquals(credentials.length, 2);
     assertEquals(credentials[0], NOT_A_FREE_USERNAME);
     assertEquals(credentials[1], NOT_A_FREE_PASSWORD);
@@ -96,7 +97,7 @@ public class CredentialUtilsTest extends WatsonServiceTest {
     assertNull(CredentialUtils.getUserNameAndPassword(null, null));
     
     String[] credentials = CredentialUtils.getUserNameAndPassword(SERVICE_NAME, PLAN);
-    Assert.assertTrue(credentials != null);
+    assertTrue(credentials != null);
     assertEquals(credentials.length, 2);
     assertEquals(credentials[0], NOT_A_USERNAME);
     assertEquals(credentials[1], NOT_A_PASSWORD);

--- a/src/test/resources/conversation/conversation.json
+++ b/src/test/resources/conversation/conversation.json
@@ -9,10 +9,12 @@
      {
        "entity": "house",
        "value": "home",
-       "location": [21, 25]
+       "location": [36, 40]
      }
   ],
-  
+  "input": {
+    "text": "I'd like to get insurance to for my home"
+  }
   "context": {
    
   },

--- a/src/test/resources/conversation/conversation.json
+++ b/src/test/resources/conversation/conversation.json
@@ -11,6 +11,6 @@
   },
   
   "output": {
-    "text": "Do you want to get a quote?"
+    "text": ["Do you want to get a quote?"]
   }
 }

--- a/src/test/resources/conversation/conversation.json
+++ b/src/test/resources/conversation/conversation.json
@@ -14,7 +14,7 @@
   ],
   "input": {
     "text": "I'd like to get insurance to for my home"
-  }
+  },
   "context": {
    
   },

--- a/src/test/resources/conversation/conversation.json
+++ b/src/test/resources/conversation/conversation.json
@@ -5,7 +5,14 @@
        "confidence": 0.943643
      }
    ],
-   
+   "entities": [
+     {
+       "entity": "house",
+       "value": "home",
+       "location": [21, 25]
+     }
+  ],
+  
   "context": {
    
   },


### PR DESCRIPTION
### Summary

Added a new util method to CredentialUtils to allow clients to get the user name and password from the VCAP_SERVICES.
Update the conversation payload to reflect the fact that output.text in the response is now a string array and that an input.text property has also been added to the response payload.
Added helper methods to parse the input and output property values (maps)

@max-vogler ^^^
Thanks for contributing to the Watson Developer Cloud!