### PR TITLE
Add Solr resize API to R&R

### DIFF
--- a/examples/java/com/ibm/watson/developer_cloud/retrieve_and_rank/v1/ResizeASolrClusterExample.java
+++ b/examples/java/com/ibm/watson/developer_cloud/retrieve_and_rank/v1/ResizeASolrClusterExample.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright 2016 IBM Corp. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.ibm.watson.developer_cloud.retrieve_and_rank.v1;
+
+import com.ibm.watson.developer_cloud.retrieve_and_rank.v1.RetrieveAndRank;
+import com.ibm.watson.developer_cloud.retrieve_and_rank.v1.model.SolrCluster;
+import com.ibm.watson.developer_cloud.retrieve_and_rank.v1.model.SolrCluster.Status;
+import com.ibm.watson.developer_cloud.retrieve_and_rank.v1.model.SolrClusterOptions;
+import com.ibm.watson.developer_cloud.retrieve_and_rank.v1.model.SolrClusterSizeResponse;
+
+/**
+ * Example of how to create and resize a {@link SolrCluster} with {@link RetrieveAndRank}.
+ */
+public class ResizeASolrClusterExample {
+  public static void main(String[] args) throws InterruptedException {
+
+    // 1 create the service
+    final RetrieveAndRank service = new RetrieveAndRank();
+    service.setUsernameAndPassword("<username>", "<password>");
+    // 2 create the Solr Cluster of size 1
+    final SolrClusterOptions options = new SolrClusterOptions("<cluster-name>", 1);
+    SolrCluster cluster = service.createSolrCluster(options).execute();
+    System.out.println("SolrCluster: " + cluster);
+    final String solrClusterId = cluster.getId();
+    // 2 wait until the Solr Cluster is available
+    while (cluster.getStatus() == Status.NOT_AVAILABLE) {
+      Thread.sleep(10000); // sleep 10 seconds
+      cluster = service.getSolrCluster(solrClusterId).execute();
+      System.out.println("SolrCluster status: " + cluster.getStatus());
+    }
+    // 3 resize the cluster form size 1 to size 2
+    final int desiredClusterSize = 2;
+    SolrClusterSizeResponse response =
+        service.resizeSolrCluster(solrClusterId, desiredClusterSize).execute();
+    System.out.println(response.toString());
+
+    // 4 wait until the resize processs is complete
+    while (response.getCurrentSize() != desiredClusterSize) {
+      if (response.getStatus() == SolrClusterSizeResponse.Status.ERROR) {
+        System.out.println(response.getMessage());
+        return;
+      }
+      System.out.println("Resize status: " + response.getStatus());
+      Thread.sleep(10000);
+      response = service.getSolrClusterResizeStatus(solrClusterId).execute();
+    }
+    System.out.println(response.getMessage());
+    System.out.println("resize completed");
+  }
+}

--- a/src/main/java/com/ibm/watson/developer_cloud/retrieve_and_rank/v1/ClusterLifecycleManager.java
+++ b/src/main/java/com/ibm/watson/developer_cloud/retrieve_and_rank/v1/ClusterLifecycleManager.java
@@ -16,8 +16,8 @@ package com.ibm.watson.developer_cloud.retrieve_and_rank.v1;
 import com.ibm.watson.developer_cloud.http.ServiceCall;
 import com.ibm.watson.developer_cloud.retrieve_and_rank.v1.model.SolrCluster;
 import com.ibm.watson.developer_cloud.retrieve_and_rank.v1.model.SolrClusterOptions;
+import com.ibm.watson.developer_cloud.retrieve_and_rank.v1.model.SolrClusterSizeResponse;
 import com.ibm.watson.developer_cloud.retrieve_and_rank.v1.model.SolrClusters;
-
 /**
  * A client for communicating with the Retrieve and Rank API.
  */
@@ -61,4 +61,18 @@ public interface ClusterLifecycleManager {
    * @return the Solr cluster list
    */
   ServiceCall<SolrClusters> getSolrClusters();
+
+  /**
+   * Change the size of the Solr cluster.
+   *
+   * @return the status of the resize request
+   */
+  ServiceCall<SolrClusterSizeResponse> resizeSolrCluster(String SolrClusterId, int requestedSize);
+
+  /**
+   * Get the status of a resize request for a cluster.
+   *
+   * @return the status of the resize request
+   */
+  ServiceCall<SolrClusterSizeResponse> getSolrClusterResizeStatus(String SolrClusterId);
 }

--- a/src/main/java/com/ibm/watson/developer_cloud/retrieve_and_rank/v1/RetrieveAndRank.java
+++ b/src/main/java/com/ibm/watson/developer_cloud/retrieve_and_rank/v1/RetrieveAndRank.java
@@ -31,6 +31,8 @@ import com.ibm.watson.developer_cloud.retrieve_and_rank.v1.model.Rankers;
 import com.ibm.watson.developer_cloud.retrieve_and_rank.v1.model.Ranking;
 import com.ibm.watson.developer_cloud.retrieve_and_rank.v1.model.SolrCluster;
 import com.ibm.watson.developer_cloud.retrieve_and_rank.v1.model.SolrClusterOptions;
+import com.ibm.watson.developer_cloud.retrieve_and_rank.v1.model.SolrClusterResizeRequest;
+import com.ibm.watson.developer_cloud.retrieve_and_rank.v1.model.SolrClusterSizeResponse;
 import com.ibm.watson.developer_cloud.retrieve_and_rank.v1.model.SolrClusterStats;
 import com.ibm.watson.developer_cloud.retrieve_and_rank.v1.model.SolrClusters;
 import com.ibm.watson.developer_cloud.retrieve_and_rank.v1.model.SolrConfigs;
@@ -74,6 +76,7 @@ public class RetrieveAndRank extends WatsonService implements ClusterLifecycleMa
   private static final String PATH_SOLR_CLUSTERS_CONFIG = "/v1/solr_clusters/%s/config";
   private static final String PATH_SOLR_CLUSTERS_CONFIGS = "/v1/solr_clusters/%s/config/%s";
   private static final String URL = "https://gateway.watsonplatform.net/retrieve-and-rank/api";
+  private static final String PATH_SOLR_CLUSTERS_SIZE = "/v1/solr_clusters/%s/cluster_size";
 
   /**
    * Instantiates a new ranker client.
@@ -434,5 +437,53 @@ public class RetrieveAndRank extends WatsonService implements ClusterLifecycleMa
     final RequestBuilder requestBuilder = RequestBuilder.post(configPath);
     requestBuilder.body(RequestBody.create(MediaType.parse(HttpMediaType.APPLICATION_ZIP), zippedConfig));
     return requestBuilder;
+  }
+  /*
+   * (non-Javadoc)
+   *
+   * @see
+   * com.ibm.watson.developer_cloud.retrieve_and_rank.v1.ClusterLifecycleManager#resizeSolrCluster
+   * (java.lang.String)
+   */
+  @Override
+  public ServiceCall<SolrClusterSizeResponse> resizeSolrCluster(String SolrClusterId,
+      int requestedSize) {
+    final Request request = buildResizeRequest(SolrClusterId, requestedSize);
+    return createServiceCall(request,
+        ResponseConverterUtils.getObject(SolrClusterSizeResponse.class));
+  }
+
+  /*
+   * (non-Javadoc)
+   *
+   * @see com.ibm.watson.developer_cloud.retrieve_and_rank.v1.ClusterLifecycleManager#
+   * getSolrClusterResizeStatus (java.lang.String)
+   */
+  @Override
+  public ServiceCall<SolrClusterSizeResponse> getSolrClusterResizeStatus(String SolrClusterId) {
+    final Request request = buildGetSizeRequest(SolrClusterId);
+    return createServiceCall(request,
+        ResponseConverterUtils.getObject(SolrClusterSizeResponse.class));
+  }
+
+  private Request buildResizeRequest(String solrClusterId, int desiredSize) {
+    final String resizePath = createSizePath(solrClusterId);
+    final SolrClusterResizeRequest resizeRequest = new SolrClusterResizeRequest(desiredSize);
+    final RequestBuilder requestBuilder = RequestBuilder.put(resizePath);
+    requestBuilder.bodyContent(GsonSingleton.getGsonWithoutPrettyPrinting().toJson(resizeRequest),
+        HttpMediaType.APPLICATION_JSON);
+    return requestBuilder.build();
+  }
+
+  private String createSizePath(String solrClusterId) {
+    Validator.isTrue(solrClusterId != null && !solrClusterId.isEmpty(),
+        "solrClusterId cannot be null or empty");
+    return String.format(PATH_SOLR_CLUSTERS_SIZE, solrClusterId);
+  }
+
+  private Request buildGetSizeRequest(String solrClusterId) {
+    final String resizePath = createSizePath(solrClusterId);
+    final RequestBuilder requestBuilder = RequestBuilder.get(resizePath);
+    return requestBuilder.build();
   }
 }

--- a/src/main/java/com/ibm/watson/developer_cloud/retrieve_and_rank/v1/model/ApiConstants.java
+++ b/src/main/java/com/ibm/watson/developer_cloud/retrieve_and_rank/v1/model/ApiConstants.java
@@ -70,4 +70,16 @@ public class ApiConstants {
   
   /** The Constant PERCENT_USED. */
   public static final String PERCENT_USED = "percent_used";
+  /** The Constant RESIZE_STATUS. */
+
+  public static final String RESIZE_STATUS = "status";
+
+  /** The Constant RESIZE_MESSAGE. */
+  public static final String RESIZE_MESSAGE = "message";
+
+  /** The Constant TARGET_CLUSTER_SIZE. */
+  public static final String TARGET_CLUSTER_SIZE = "target_cluster_size";
+
+  /** The Constant String CLUSTER_ID. */
+  public static final String CLUSTER_ID = "cluster_id";
 }

--- a/src/main/java/com/ibm/watson/developer_cloud/retrieve_and_rank/v1/model/SolrClusterResizeRequest.java
+++ b/src/main/java/com/ibm/watson/developer_cloud/retrieve_and_rank/v1/model/SolrClusterResizeRequest.java
@@ -1,0 +1,42 @@
+/*
+ * BEGIN_COPYRIGHT
+ *
+ * IBM Confidential OCO Source Materials
+ *
+ * 5725-Y07 (C) Copyright IBM Corp. 2016 All Rights Reserved.
+ *
+ * The source code for this program is not published or otherwise divested of its trade secrets,
+ * irrespective of what has been deposited with the U.S. Copyright Office.
+ *
+ * END_COPYRIGHT
+ */
+package com.ibm.watson.developer_cloud.retrieve_and_rank.v1.model;
+
+
+import static com.ibm.watson.developer_cloud.retrieve_and_rank.v1.model.ApiConstants.*;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * A value type for the JSON body provided when creating a Solr resize request.
+ */
+public class SolrClusterResizeRequest {
+
+  @SerializedName(CLUSTER_SIZE)
+  private final int clusterSize;
+
+  /**
+   * Instantiates a cluster resize request
+   *
+   * @param clusterSize the desired cluster size
+   */
+  public SolrClusterResizeRequest(final int clusterSize) {
+    this.clusterSize = clusterSize;
+  }
+
+  @SerializedName(CLUSTER_SIZE)
+  public int getClusterSize() {
+    return clusterSize;
+  }
+
+}

--- a/src/main/java/com/ibm/watson/developer_cloud/retrieve_and_rank/v1/model/SolrClusterResizeRequest.java
+++ b/src/main/java/com/ibm/watson/developer_cloud/retrieve_and_rank/v1/model/SolrClusterResizeRequest.java
@@ -1,14 +1,15 @@
-/*
- * BEGIN_COPYRIGHT
- *
- * IBM Confidential OCO Source Materials
- *
- * 5725-Y07 (C) Copyright IBM Corp. 2016 All Rights Reserved.
- *
- * The source code for this program is not published or otherwise divested of its trade secrets,
- * irrespective of what has been deposited with the U.S. Copyright Office.
- *
- * END_COPYRIGHT
+/**
+ * Copyright 2016 IBM Corp. All Rights Reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
  */
 package com.ibm.watson.developer_cloud.retrieve_and_rank.v1.model;
 

--- a/src/main/java/com/ibm/watson/developer_cloud/retrieve_and_rank/v1/model/SolrClusterSizeResponse.java
+++ b/src/main/java/com/ibm/watson/developer_cloud/retrieve_and_rank/v1/model/SolrClusterSizeResponse.java
@@ -1,16 +1,15 @@
-/* BEGIN_COPYRIGHT
- *
- * IBM Confidential
- * OCO Source Materials
- *
- * 5725-Y07
- * (C) Copyright IBM Corp. 2016 All Rights Reserved.
- *
- * The source code for this program is not published or otherwise
- * divested of its trade secrets, irrespective of what has been
- * deposited with the U.S. Copyright Office.
- *
- * END_COPYRIGHT
+/**
+ * Copyright 2016 IBM Corp. All Rights Reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
  */
 package com.ibm.watson.developer_cloud.retrieve_and_rank.v1.model;
 

--- a/src/main/java/com/ibm/watson/developer_cloud/retrieve_and_rank/v1/model/SolrClusterSizeResponse.java
+++ b/src/main/java/com/ibm/watson/developer_cloud/retrieve_and_rank/v1/model/SolrClusterSizeResponse.java
@@ -1,0 +1,100 @@
+/* BEGIN_COPYRIGHT
+ *
+ * IBM Confidential
+ * OCO Source Materials
+ *
+ * 5725-Y07
+ * (C) Copyright IBM Corp. 2016 All Rights Reserved.
+ *
+ * The source code for this program is not published or otherwise
+ * divested of its trade secrets, irrespective of what has been
+ * deposited with the U.S. Copyright Office.
+ *
+ * END_COPYRIGHT
+ */
+package com.ibm.watson.developer_cloud.retrieve_and_rank.v1.model;
+
+import static com.ibm.watson.developer_cloud.retrieve_and_rank.v1.model.ApiConstants.*;
+
+import com.google.gson.annotations.SerializedName;
+import com.ibm.watson.developer_cloud.service.model.GenericModel;
+
+/**
+ * The status of a Solr Cluster Resize request.
+ */
+public class SolrClusterSizeResponse extends GenericModel {
+
+  public enum Status {
+    RESIZING,
+    ERROR
+  }
+
+  @SerializedName(CLUSTER_ID)
+  private final String clusterId;
+  @SerializedName(CLUSTER_SIZE)
+  private final Integer currentSize;
+  @SerializedName(TARGET_CLUSTER_SIZE)
+  private final Integer targetSize;
+  @SerializedName(RESIZE_STATUS)
+  private final Status status;
+  @SerializedName(RESIZE_MESSAGE)
+  private final String message;
+
+  /**
+   * Instantiates a resize request response.
+   *
+   * @param clusterId the cluster Id
+   * @param currentSize the cluster size
+   * @param targetSize size to resize the cluster to
+   * @param message response message from the R&R service
+   * @param status The status of the resize process
+   */
+  public SolrClusterSizeResponse(final String clusterId, final Integer currentSize, final Integer targetSize,
+      final String message, final Status status) {
+    this.clusterId = clusterId;
+    this.status = status;
+    this.currentSize = currentSize;
+    this.targetSize = targetSize;
+    this.message = message;
+  }
+
+  /**
+   * Instantiates size request response for a cluster that's not being resized currently.
+   *
+   * @param clusterId the cluster Id
+   * @param currentSize the cluster size
+   * @param message response message from the R&R service.
+   */
+  public SolrClusterSizeResponse(final String clusterId, final Integer currentSize, final String message) {
+    this.clusterId = clusterId;
+    this.status = null;
+    this.currentSize = currentSize;
+    this.targetSize = null;
+    this.message = message;
+  }
+
+  @SerializedName(CLUSTER_ID)
+  public String geClusterId() {
+    return clusterId;
+  }
+
+  @SerializedName(RESIZE_STATUS)
+  public Status getStatus() {
+    return status;
+  }
+
+  @SerializedName(CLUSTER_SIZE)
+  public Integer getCurrentSize() {
+    return currentSize;
+  }
+
+  @SerializedName(TARGET_CLUSTER_SIZE)
+  public Integer getTargetSize() {
+    return targetSize;
+  }
+
+  @SerializedName(RESIZE_MESSAGE)
+  public String getMessage() {
+    return message;
+  }
+}

--- a/src/test/java/com/ibm/watson/developer_cloud/retrieve_and_rank/v1/RetrieveAndRankTest.java
+++ b/src/test/java/com/ibm/watson/developer_cloud/retrieve_and_rank/v1/RetrieveAndRankTest.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright 2016 IBM Corp. All Rights Reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.ibm.watson.developer_cloud.retrieve_and_rank.v1;
+
+import static org.junit.Assert.*;
+
+import java.io.FileNotFoundException;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.ibm.watson.developer_cloud.WatsonServiceUnitTest;
+import com.ibm.watson.developer_cloud.http.HttpHeaders;
+import com.ibm.watson.developer_cloud.http.HttpMediaType;
+import com.ibm.watson.developer_cloud.retrieve_and_rank.v1.model.SolrClusterSizeResponse;
+
+import okhttp3.mockwebserver.RecordedRequest;
+
+/**
+ *
+ * Retrieve and Rank unit test
+ */
+public class RetrieveAndRankTest extends WatsonServiceUnitTest {
+
+  private static final String FIXTURE = "src/test/resources/retrieve_and_rank/resize.json";
+  private static final String ANY_CLUSTER_ID = "ANY_CLUSTER_ID";
+  private static final Object RESIZE_PATH = "/v1/solr_clusters/ANY_CLUSTER_ID/cluster_size";
+
+  private RetrieveAndRank service;
+
+  /*
+   * (non-Javadoc)
+   * 
+   * @see com.ibm.watson.developer_cloud.RetrieveAndRankTest#setUp()
+   */
+  @Override
+  @Before
+  public void setUp() throws Exception {
+    super.setUp();
+    service = new RetrieveAndRank();
+    service.setApiKey("");
+    service.setEndPoint(getMockWebServerUrl());
+
+  }
+
+  /**
+   * Test cluster resize
+   * 
+   * @throws FileNotFoundException
+   * @throws InterruptedException
+   */
+  @Test
+  public void testClusterResize() throws FileNotFoundException, InterruptedException {
+    SolrClusterSizeResponse mockResponse = loadFixture(FIXTURE, SolrClusterSizeResponse.class);
+    server.enqueue(jsonResponse(mockResponse));
+    SolrClusterSizeResponse serviceResponse =
+        service.resizeSolrCluster(ANY_CLUSTER_ID, 2).execute();
+    RecordedRequest request = server.takeRequest();
+
+    assertEquals(RESIZE_PATH, request.getPath());
+    assertEquals("PUT", request.getMethod());
+    assertEquals("{\"cluster_size\":2}", request.getBody().readUtf8());
+    assertNotNull(request.getHeader(HttpHeaders.AUTHORIZATION));
+    assertEquals(mockResponse, serviceResponse);
+    assertEquals(request.getHeader(HttpHeaders.ACCEPT), HttpMediaType.APPLICATION_JSON);
+  }
+}

--- a/src/test/resources/retrieve_and_rank/resize.json
+++ b/src/test/resources/retrieve_and_rank/resize.json
@@ -1,0 +1,7 @@
+{
+  "cluster_id": "ANY_CLUSTER_ID",
+  "cluster_size": 1,
+  "target_cluster_size": 2,
+  "status": "RESIZING",
+  "message": "WRRCSR027: Resizing cluster [ANY_CLUSTER_ID] from size [1] to size [2]."
+}


### PR DESCRIPTION
Add a cluster resize API that allows posting a resize operation and getting information on a cluster's size using the Retrieve&Rank service.  
In addition there is an example file that shows how to use the new API. 


Thanks for contributing to the Watson Developer Cloud!
