### PR TITLE
TypedRelation service call in Alchemy Language Java SDK not returning entities

### DIFF
--- a/src/main/java/com/ibm/watson/developer_cloud/alchemy/v1/model/TypedEntitiesAdapter.java
+++ b/src/main/java/com/ibm/watson/developer_cloud/alchemy/v1/model/TypedEntitiesAdapter.java
@@ -28,6 +28,8 @@ public class TypedEntitiesAdapter extends TypeAdapter<List<TypedEntity>> {
 
     @Override
     public void write(JsonWriter writer, List<TypedEntity> value) throws IOException {
+        // No coding the serialization as there is no code relying on this
+        // type to serialize payloads
     }
 
     @Override

--- a/src/main/java/com/ibm/watson/developer_cloud/alchemy/v1/model/TypedEntitiesAdapter.java
+++ b/src/main/java/com/ibm/watson/developer_cloud/alchemy/v1/model/TypedEntitiesAdapter.java
@@ -1,0 +1,58 @@
+package com.ibm.watson.developer_cloud.alchemy.v1.model;
+
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class TypedEntitiesAdapter extends TypeAdapter<List<TypedEntity>> {
+
+    @Override
+    public void write(JsonWriter writer, List<TypedEntity> value) throws IOException {
+    }
+
+    @Override
+    public List<TypedEntity> read(JsonReader reader) throws IOException {
+        List<TypedEntity> es = new ArrayList<TypedEntity>();
+
+        reader.beginArray(); // arguments
+        while (reader.hasNext()) {
+            reader.beginObject(); // argument
+            while (reader.hasNext()) {
+                String name = reader.nextName();
+                if ("entities".equals(name)) {
+                    reader.beginArray();
+                    while (reader.hasNext()) {
+                        TypedEntity e = new TypedEntity();
+                        reader.beginObject();
+                        while (reader.hasNext()) {
+                            String name1 = reader.nextName();
+                            if ("text".equals(name1)) {
+                                e.setText(reader.nextString());
+                            } else if ("type".equals(name1)) {
+                                e.setType(reader.nextString());
+                            } else if ("id".equals(name1)) {
+                                e.setId(reader.nextString());
+                            } else {
+                                reader.skipValue();
+                            }
+                        }
+                        reader.endObject();
+                        es.add(e);
+                    }
+                    reader.endArray();
+                } else {
+                    reader.skipValue();
+                }
+            }
+            reader.endObject();
+        }
+        reader.endArray();
+
+        return es;
+    }
+
+}

--- a/src/main/java/com/ibm/watson/developer_cloud/alchemy/v1/model/TypedEntitiesAdapter.java
+++ b/src/main/java/com/ibm/watson/developer_cloud/alchemy/v1/model/TypedEntitiesAdapter.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2015 IBM Corp. All Rights Reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package com.ibm.watson.developer_cloud.alchemy.v1.model;
 
 import com.google.gson.TypeAdapter;
@@ -8,6 +21,9 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * Created by nastacio on 7/2/2016
+ */
 public class TypedEntitiesAdapter extends TypeAdapter<List<TypedEntity>> {
 
     @Override

--- a/src/main/java/com/ibm/watson/developer_cloud/alchemy/v1/model/TypedRelation.java
+++ b/src/main/java/com/ibm/watson/developer_cloud/alchemy/v1/model/TypedRelation.java
@@ -14,9 +14,11 @@
 
 package com.ibm.watson.developer_cloud.alchemy.v1.model;
 
-import java.util.List;
-
+import com.google.gson.annotations.JsonAdapter;
+import com.google.gson.annotations.SerializedName;
 import com.ibm.watson.developer_cloud.alchemy.v1.AlchemyLanguage;
+
+import java.util.List;
 
 /**
  * Typed relation between {@link TypedEntity}.
@@ -27,7 +29,10 @@ public class TypedRelation {
     private String text;
     private String type;
     private Double score;
-    private List<Entity> entities;
+
+    @JsonAdapter(TypedEntitiesAdapter.class)
+    @SerializedName("arguments")
+    private List<TypedEntity> entities;
 
     /**
      * Gets the text.
@@ -84,20 +89,16 @@ public class TypedRelation {
     }
 
     /**
-     * Gets the entities.
-     *
-     * @return     The entities
+     * @return the entities
      */
-    public List<Entity> getEntities() {
+    public List<TypedEntity> getEntities() {
         return entities;
     }
 
     /**
-     * Sets the entities.
-     *
-     * @param entities     The entities
+     * @param entities the entities to set
      */
-    public void setEntities(List<Entity> entities) {
+    public void setEntities(List<TypedEntity> entities) {
         this.entities = entities;
     }
 

--- a/src/main/java/com/ibm/watson/developer_cloud/alchemy/v1/model/TypedRelation.java
+++ b/src/main/java/com/ibm/watson/developer_cloud/alchemy/v1/model/TypedRelation.java
@@ -14,11 +14,11 @@
 
 package com.ibm.watson.developer_cloud.alchemy.v1.model;
 
+import java.util.List;
+
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;
 import com.ibm.watson.developer_cloud.alchemy.v1.AlchemyLanguage;
-
-import java.util.List;
 
 /**
  * Typed relation between {@link TypedEntity}.

--- a/src/test/java/com/ibm/watson/developer_cloud/alchemy/v1/AlchemyLanguageIT.java
+++ b/src/test/java/com/ibm/watson/developer_cloud/alchemy/v1/AlchemyLanguageIT.java
@@ -13,6 +13,17 @@
  */
 package com.ibm.watson.developer_cloud.alchemy.v1;
 
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+
 import com.ibm.watson.developer_cloud.WatsonServiceTest;
 import com.ibm.watson.developer_cloud.alchemy.v1.model.CombinedResults;
 import com.ibm.watson.developer_cloud.alchemy.v1.model.Concepts;
@@ -33,17 +44,6 @@ import com.ibm.watson.developer_cloud.alchemy.v1.model.Taxonomies;
 import com.ibm.watson.developer_cloud.alchemy.v1.model.TypedEntity;
 import com.ibm.watson.developer_cloud.alchemy.v1.model.TypedRelation;
 import com.ibm.watson.developer_cloud.alchemy.v1.model.TypedRelations;
-
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
-
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 
 /**
  * Created by nizar on 8/25/15.

--- a/src/test/java/com/ibm/watson/developer_cloud/alchemy/v1/AlchemyLanguageIT.java
+++ b/src/test/java/com/ibm/watson/developer_cloud/alchemy/v1/AlchemyLanguageIT.java
@@ -50,468 +50,473 @@ import com.ibm.watson.developer_cloud.alchemy.v1.model.TypedRelations;
  */
 public class AlchemyLanguageIT extends WatsonServiceTest {
 
-    /** The html example. */
-    private String          htmlExample;
+  /** The html example. */
+  private String htmlExample;
 
-    /** The service. */
-    private AlchemyLanguage service;
+  /** The service. */
+  private AlchemyLanguage service;
 
-    /*
-     * (non-Javadoc)
-     * 
-     * @see com.ibm.watson.developer_cloud.WatsonServiceTest#setUp()
-     */
-    @Override
-    @Before
-    public void setUp() throws Exception {
-        super.setUp();
-        service = new AlchemyLanguage();
-        service.setApiKey(getValidProperty("alchemy.alchemy"));
-        service.setDefaultHeaders(getDefaultHeaders());
-        htmlExample = getStringFromInputStream(new FileInputStream(
-                        "src/test/resources/alchemy/example.html"));
+  /*
+   * (non-Javadoc)
+   * 
+   * @see com.ibm.watson.developer_cloud.WatsonServiceTest#setUp()
+   */
+  @Override
+  @Before
+  public void setUp() throws Exception {
+    super.setUp();
+    service = new AlchemyLanguage();
+    service.setApiKey(getValidProperty("alchemy.alchemy"));
+    service.setDefaultHeaders(getDefaultHeaders());
+    htmlExample =
+        getStringFromInputStream(new FileInputStream("src/test/resources/alchemy/example.html"));
 
-    }
-
-    /**
-     * Test api key is null.
-     */
-    @Test(expected = IllegalArgumentException.class)
-    public void testApiKeyIsNull() {
-        final Map<String, Object> params = new HashMap<String, Object>();
-        params.put(AlchemyLanguage.URL, "http://www.techcrunch.com/");
-
-        final AlchemyLanguage language = new AlchemyLanguage();
-        language.setApiKey(null);
-        language.getKeywords(params).execute();
-    }
-
-    /**
-     * Test comboined.
-     */
-    @Test
-    public void testComboined() {
-        final Map<String, Object> params = new HashMap<String, Object>();
-        params.put(AlchemyLanguage.URL, "http://www.techcrunch.com/");
-        final CombinedResults combined = service.getCombinedResults(params).execute();
-        Assert.assertNotNull(combined);
-    }
-
-    /**
-     * Test Get testFeeds.
-     */
-    @Test
-    public void testFeeds() {
-        final Map<String, Object> params = new HashMap<String, Object>();
-        params.put(AlchemyLanguage.URL, "http://www.techcrunch.com/");
-        final Feeds feeds = service.getFeeds(params).execute();
-        Assert.assertNotNull(feeds);
-    }
-
-    /**
-     * Test Get testGetAuthor.
-     */
-    @Test
-    public void testGetAuthors() {
-        final Map<String, Object> params = new HashMap<String, Object>();
-        params.put(AlchemyLanguage.URL,
-                        "http://www.politico.com/blogs/media/2012/02/detroit-news-ed-upset-over-romney-edit-115247.html");
-        final DocumentAuthors authors = service.getAuthors(params).execute();
-        Assert.assertNotNull(authors);
-    }
-
-    /**
-     * Test get concepts HTML.
-     */
-    @Test
-    public void testGetConceptsHTML() {
-        final Map<String, Object> params = new HashMap<String, Object>();
-        params.put(AlchemyLanguage.HTML, htmlExample);
-        final Concepts concepts = service.getConcepts(params).execute();
-        Assert.assertNotNull(concepts);
-        Assert.assertFalse(concepts.getConcepts().isEmpty());
-    }
-
-    /**
-     * Test get concepts Tet.
-     */
-    @Test
-    public void testGetConceptsText() {
-        final Map<String, Object> params = new HashMap<String, Object>();
-        params.put(AlchemyLanguage.TEXT, htmlExample);
-        final Concepts concepts = service.getConcepts(params).execute();
-        Assert.assertNotNull(concepts);
-        Assert.assertFalse(concepts.getConcepts().isEmpty());
-    }
-
-    /**
-     * Test Get getTaxonomy URL.
-     */
-    @Test
-    public void testGetConceptsUrl() {
-        final Map<String, Object> params = new HashMap<String, Object>();
-        params.put(AlchemyLanguage.URL, "http://www.techcrunch.com/");
-        final Concepts concepts = service.getConcepts(params).execute();
-        Assert.assertNotNull(concepts);
-        Assert.assertFalse(concepts.getConcepts().isEmpty());
-    }
-
-    /**
-     * Test Get entities HTML.
-     */
-    @Test
-    public void testGetEntitiesHtml() {
-        final Map<String, Object> params = new HashMap<String, Object>();
-        params.put(AlchemyLanguage.HTML, htmlExample);
-
-        final Entities entities = service.getEntities(params).execute();
-        Assert.assertNotNull(entities);
-        Assert.assertFalse(entities.getEntities().isEmpty());
-    }
-
-    /**
-     * Test Get entities URL.
-     */
-    @Test
-    public void testGetEntitiesUrl() {
-        final Map<String, Object> params = new HashMap<String, Object>();
-        params.put(AlchemyLanguage.URL, "http://www.techcrunch.com/");
-        final Entities entities = service.getEntities(params).execute();
-        Assert.assertNotNull(entities);
-        Assert.assertFalse(entities.getEntities().isEmpty());
-    }
-
-    /**
-     * Test Get entities HTML.
-     */
-    @Test
-    public void testGetEntitiesWithDifferentCharacters() {
-        final Map<String, Object> params = new HashMap<String, Object>();
-        final String text = "Mr. Vice President, my old colleague from Massachusetts"
-                        + "and your new Speaker & John McCormack, Members of the 87th Congress, "
-                        + "ladies and gentlemen: -.*&^%$#@!@#$%^&*()";
-        params.put(AlchemyLanguage.TEXT, text);
-
-        final Entities entities = service.getEntities(params).execute();
-        Assert.assertNotNull(entities);
-        Assert.assertFalse(entities.getEntities().isEmpty());
-    }
-
-    /**
-     * Test Get testGetLanguage.
-     */
-    @Test
-    public void testGetLanguage() {
-        final Map<String, Object> params = new HashMap<String, Object>();
-        params.put(AlchemyLanguage.URL, "http://news.google.fr/");
-        final Language language = service.getLanguage(params).execute();
-        Assert.assertNotNull(language);
-    }
-
-    /**
-     * Test get publication date html.
-     */
-    @Test
-    public void testGetPublicationDateHTML() {
-        final Map<String, Object> params = new HashMap<String, Object>();
-        params.put(AlchemyLanguage.HTML, htmlExample);
-        final DocumentPublicationDate date = service.getPublicationDate(params).execute();
-        Assert.assertNotNull(date);
-        Assert.assertNotNull(date.getPublicationDate());
-    }
-
-    /**
-     * Test get publication date url.
-     */
-    @Test
-    public void testGetPublicationDateURL() {
-        final Map<String, Object> params = new HashMap<String, Object>();
-        params.put(AlchemyLanguage.URL, "http://www.techcrunch.com/");
-        final DocumentPublicationDate date = service.getPublicationDate(params).execute();
-        Assert.assertNotNull(date);
-        Assert.assertNotNull(date.getPublicationDate());
-    }
-
-    /**
-     * Test Get testGetRelationsHtml HTML.
-     * 
-     */
-    @Test
-    public void testGetRelationsHtml() {
-        final Map<String, Object> params = new HashMap<String, Object>();
-        params.put(AlchemyLanguage.HTML, htmlExample);
-        final SAORelations relations = service.getRelations(params).execute();
-        Assert.assertNotNull(relations);
-    }
-
-    /**
-     * Test Get testGetRelationsUrl URL.
-     */
-    @Test
-    public void testGetRelationsUrl() {
-        final Map<String, Object> params = new HashMap<String, Object>();
-        params.put(AlchemyLanguage.URL, "http://www.techcrunch.com/");
-        final SAORelations relations = service.getRelations(params).execute();
-        Assert.assertNotNull(relations);
-    }
-
-    /**
-     * Test Get testGetTargetedSentiment HTML.
-     */
-    @Test
-    public void testGetTargetedSentimentHtml() {
-        final Map<String, Object> params = new HashMap<String, Object>();
-        params.put(AlchemyLanguage.HTML, htmlExample);
-        params.put(AlchemyLanguage.TARGET, "Watson");
-        final DocumentSentiment documentSentiment = service.getSentiment(params).execute();
-        Assert.assertNotNull(documentSentiment);
-    }
-
-    /**
-     * Test Get testGetTargetedSentiment Url.
-     */
-    @Test
-    public void testGetTargetedSentimentURL() {
-        final Map<String, Object> params = new HashMap<String, Object>();
-        params.put(AlchemyLanguage.URL,
-                        "http://techcrunch.com/2012/03/01/keen-on-anand-rajaraman-how-walmart-wants-to-leapfrog-over-amazon-tctv/");
-        params.put(AlchemyLanguage.TARGET, "Walmart");
-        final DocumentSentiment documentSentiment = service.getSentiment(params).execute();
-        Assert.assertNotNull(documentSentiment);
-    }
-
-    /**
-     * Test Get testGetTargetedSentiment Url and multiple targets.
-     */
-    @Test
-    public void testGetTargetedSentimentURLAndTargets() {
-        final Map<String, Object> params = new HashMap<String, Object>();
-        params.put(AlchemyLanguage.URL,
-                        "http://techcrunch.com/2012/03/01/keen-on-anand-rajaraman-how-walmart-wants-to-leapfrog-over-amazon-tctv/");
-        params.put(AlchemyLanguage.TARGETS, "Walmart|Walmart");
-        final DocumentSentiment documentSentiment = service.getSentiment(params).execute();
-        Assert.assertNotNull(documentSentiment);
-    }
-
-    /**
-     * Test Get getTaxonomy HTML.
-     * 
-     * @throws IOException
-     *             Signals that an I/O exception has occurred.
-     */
-    @Test
-    public void testGetTaxonomyHtml() throws IOException {
-        final Map<String, Object> params = new HashMap<String, Object>();
-        params.put(AlchemyLanguage.HTML, htmlExample);
-        final Taxonomies taxonomy = service.getTaxonomy(params).execute();
-        Assert.assertNotNull(taxonomy);
-        Assert.assertFalse(taxonomy.getTaxonomy().isEmpty());
-    }
-
-    /**
-     * Test Get getTaxonomy URL.
-     */
-    @Test
-    public void testGetTaxonomyUrl() {
-        final Map<String, Object> params = new HashMap<String, Object>();
-        params.put(AlchemyLanguage.URL, "http://www.techcrunch.com/");
-        final Taxonomies taxonomy = service.getTaxonomy(params).execute();
-        Assert.assertNotNull(taxonomy);
-        Assert.assertFalse(taxonomy.getTaxonomy().isEmpty());
-    }
-
-    /**
-     * Test Get testGetTextSentiment HTML.
-     */
-    @Test
-    public void testGetTextSentimentHtml() {
-        final Map<String, Object> params = new HashMap<String, Object>();
-        params.put(AlchemyLanguage.HTML, htmlExample);
-        final DocumentSentiment documentSentiment = service.getSentiment(params).execute();
-        Assert.assertNotNull(documentSentiment);
-    }
-
-    /**
-     * Test Get testGetTextSentiment URL.
-     */
-    @Test
-    public void testGetTextSentimentUrl() {
-        final Map<String, Object> params = new HashMap<String, Object>();
-        params.put(AlchemyLanguage.URL, "http://www.techcrunch.com/");
-        final DocumentSentiment documentSentiment = service.getSentiment(params).execute();
-        Assert.assertNotNull(documentSentiment);
-    }
-
-    /**
-     * Test Get testGetTitle.
-     */
-    @Test
-    public void testGetTitle() {
-        final Map<String, Object> params = new HashMap<String, Object>();
-        params.put(AlchemyLanguage.URL, "http://www.techcrunch.com/");
-        final DocumentTitle title = service.getTitle(params).execute();
-        Assert.assertNotNull(title);
-    }
-
-    /**
-     * Test Get keywords HTML.
-     * 
-     */
-    @Test
-    public void testGetWordsHtml() {
-        final Map<String, Object> params = new HashMap<String, Object>();
-        params.put(AlchemyLanguage.HTML, htmlExample);
-
-        final Keywords keywords = service.getKeywords(params).execute();
-        Assert.assertNotNull(keywords);
-        Assert.assertFalse(keywords.getKeywords().isEmpty());
-    }
-
-    /**
-     * Test Get keywords URL.
-     */
-    @Test
-    public void testGetWordsUrl() {
-        final Map<String, Object> params = new HashMap<String, Object>();
-        params.put(AlchemyLanguage.URL, "http://www.techcrunch.com/");
-        final Keywords keywords = service.getKeywords(params).execute();
-        Assert.assertNotNull(keywords);
-        Assert.assertFalse(keywords.getKeywords().isEmpty());
-    }
-
-    /**
-     * Test microformats.
-     */
-    @Test
-    public void testMicroformats() {
-        final Map<String, Object> params = new HashMap<String, Object>();
-        params.put(AlchemyLanguage.URL, "http://microformats.org/wiki/hcard");
-        final Microformats microformats = service.getMicroformats(params).execute();
-        Assert.assertNotNull(microformats);
-    }
-
-    /**
-     * Test Get testGetRawText.
-     */
-    @Test
-    public void testRawText() {
-        final Map<String, Object> params = new HashMap<String, Object>();
-        params.put(AlchemyLanguage.URL, "http://www.test.com/");
-        params.put(AlchemyLanguage.RAW, true);
-        final DocumentText text = service.getText(params).execute();
-        Assert.assertNotNull(text);
-    }
-
-    /**
-     * Test Get testGetText.
-     */
-    @Test
-    public void testText() {
-        final Map<String, Object> params = new HashMap<String, Object>();
-        params.put(AlchemyLanguage.URL, "http://www.techcrunch.com/");
-        final DocumentText text = service.getText(params).execute();
-        Assert.assertNotNull(text);
-    }
-
-    /**
-     * Test get dates from a url.
-     */
-    @Test
-    public void testGetDates() {
-        final Map<String, Object> params = new HashMap<String, Object>();
-        params.put(AlchemyLanguage.TEXT, "Let's meet on January 4th, 2004");
-        params.put(AlchemyLanguage.ANCHOR_DATE, "2013-12-16 20:06:18");
-
-        final Dates dates = service.getDates(params).execute();
-        Assert.assertNotNull(dates);
-        Assert.assertNotNull(dates.getDates());
-        Assert.assertFalse(dates.getDates().isEmpty());
-    }
-
-    /**
-     * Test get emotion from HTML.
-     */
-    @Test
-    public void testGetEmotionHTML() {
-        final Map<String, Object> params = new HashMap<String, Object>();
-        params.put(AlchemyLanguage.HTML, htmlExample);
-        final DocumentEmotion emotion = service.getEmotion(params).execute();
-        Assert.assertNotNull(emotion);
-        Assert.assertNotNull(emotion.getEmotion());
-    }
-
-    /**
-     * Test get emotion from text.
-     */
-    @Test
-    public void testGetEmotionText() {
-        final Map<String, Object> params = new HashMap<String, Object>();
-        params.put(AlchemyLanguage.TEXT, htmlExample);
-        final DocumentEmotion emotion = service.getEmotion(params).execute();
-        Assert.assertNotNull(emotion);
-        Assert.assertNotNull(emotion.getEmotion());
-    }
-
-    /**
-     * Test Get emotion from URL.
-     */
-    @Test
-    public void testGetEmotionUrl() {
-        final Map<String, Object> params = new HashMap<String, Object>();
-        params.put(AlchemyLanguage.URL, "http://www.techcrunch.com/");
-        final DocumentEmotion emotion = service.getEmotion(params).execute();
-        Assert.assertNotNull(emotion);
-        Assert.assertNotNull(emotion.getEmotion());
-    }
-
-    /**
-     * Test get typed relations from HTML.
-     */
-    @Test
-    @Ignore
-    public void testGetTypedRelationsHTML() {
-        final Map<String, Object> params = new HashMap<String, Object>();
-        params.put(AlchemyLanguage.HTML, htmlExample);
-        final TypedRelations typedRelations = service.getTypedRelations(params).execute();
-        Assert.assertNotNull(typedRelations);
-        Assert.assertNotNull(typedRelations.getTypedRelations());
-    }
-
-    /**
-     * Test get typed relations from text.
-     */
-    @Test
-  public void testGetTypedRelationsText() {
-    final Map<String, Object> params = new HashMap<String, Object>();
-    params.put(AlchemyLanguage.TEXT, "Leiming Qian lives in New York.");
-    params.put(AlchemyLanguage.MODEL_ID, "ie-en-news");
-    final TypedRelations typedRelations = service.getTypedRelations(params).execute();
-    Assert.assertNotNull(typedRelations);
-    List<TypedRelation> trs = typedRelations.getTypedRelations();
-    Assert.assertNotNull(trs);
-    Assert.assertFalse(trs.isEmpty());
-    for (TypedRelation tr : trs) {
-       Assert.assertNotNull(tr.getType());
-       Assert.assertNotNull(tr.getEntities());
-       Assert.assertFalse(tr.getEntities().isEmpty());
-       for (TypedEntity e : tr.getEntities()) {
-          Assert.assertNotNull(e.getId());
-          Assert.assertNotNull(e.getText());
-          Assert.assertNotNull(e.getType());
-       }
-    }
   }
 
-    /**
-     * Test Get typed relations from URL.
-     */
-    @Test
-    @Ignore
-    public void testGetTypedRelationsUrl() {
-        final Map<String, Object> params = new HashMap<String, Object>();
-        params.put(AlchemyLanguage.URL, "http://www.techcrunch.com/");
-        final TypedRelations typedRelations = service.getTypedRelations(params).execute();
-        Assert.assertNotNull(typedRelations);
-        Assert.assertNotNull(typedRelations.getTypedRelations());
-    }
+  /**
+   * Test api key is null.
+   */
+  @Test(expected = IllegalArgumentException.class)
+  public void testApiKeyIsNull() {
+    final Map<String, Object> params = new HashMap<String, Object>();
+    params.put(AlchemyLanguage.URL, "http://www.techcrunch.com/");
+
+    final AlchemyLanguage language = new AlchemyLanguage();
+    language.setApiKey(null);
+    language.getKeywords(params).execute();
+  }
+
+  /**
+   * Test comboined.
+   */
+  @Test
+  public void testComboined() {
+    final Map<String, Object> params = new HashMap<String, Object>();
+    params.put(AlchemyLanguage.URL, "http://www.techcrunch.com/");
+    final CombinedResults combined = service.getCombinedResults(params).execute();
+    Assert.assertNotNull(combined);
+  }
+
+  /**
+   * Test Get testFeeds.
+   */
+  @Test
+  public void testFeeds() {
+    final Map<String, Object> params = new HashMap<String, Object>();
+    params.put(AlchemyLanguage.URL, "http://www.techcrunch.com/");
+    final Feeds feeds = service.getFeeds(params).execute();
+    Assert.assertNotNull(feeds);
+  }
+
+  /**
+   * Test Get testGetAuthor.
+   */
+  @Test
+  public void testGetAuthors() {
+    final Map<String, Object> params = new HashMap<String, Object>();
+    params
+        .put(AlchemyLanguage.URL,
+            "http://www.politico.com/blogs/media/2012/02/detroit-news-ed-upset-over-romney-edit-115247.html");
+    final DocumentAuthors authors = service.getAuthors(params).execute();
+    Assert.assertNotNull(authors);
+  }
+
+  /**
+   * Test get concepts HTML.
+   */
+  @Test
+  public void testGetConceptsHTML() {
+    final Map<String, Object> params = new HashMap<String, Object>();
+    params.put(AlchemyLanguage.HTML, htmlExample);
+    final Concepts concepts = service.getConcepts(params).execute();
+    Assert.assertNotNull(concepts);
+    Assert.assertFalse(concepts.getConcepts().isEmpty());
+  }
+
+  /**
+   * Test get concepts Tet.
+   */
+  @Test
+  public void testGetConceptsText() {
+    final Map<String, Object> params = new HashMap<String, Object>();
+    params.put(AlchemyLanguage.TEXT, htmlExample);
+    final Concepts concepts = service.getConcepts(params).execute();
+    Assert.assertNotNull(concepts);
+    Assert.assertFalse(concepts.getConcepts().isEmpty());
+  }
+
+  /**
+   * Test Get getTaxonomy URL.
+   */
+  @Test
+  public void testGetConceptsUrl() {
+    final Map<String, Object> params = new HashMap<String, Object>();
+    params.put(AlchemyLanguage.URL, "http://www.techcrunch.com/");
+    final Concepts concepts = service.getConcepts(params).execute();
+    Assert.assertNotNull(concepts);
+    Assert.assertFalse(concepts.getConcepts().isEmpty());
+  }
+
+  /**
+   * Test Get entities HTML.
+   */
+  @Test
+  public void testGetEntitiesHtml() {
+    final Map<String, Object> params = new HashMap<String, Object>();
+    params.put(AlchemyLanguage.HTML, htmlExample);
+
+    final Entities entities = service.getEntities(params).execute();
+    Assert.assertNotNull(entities);
+    Assert.assertFalse(entities.getEntities().isEmpty());
+  }
+
+  /**
+   * Test Get entities URL.
+   */
+  @Test
+  public void testGetEntitiesUrl() {
+    final Map<String, Object> params = new HashMap<String, Object>();
+    params.put(AlchemyLanguage.URL, "http://www.techcrunch.com/");
+    final Entities entities = service.getEntities(params).execute();
+    Assert.assertNotNull(entities);
+    Assert.assertFalse(entities.getEntities().isEmpty());
+  }
+
+  /**
+   * Test Get entities HTML.
+   */
+  @Test
+  public void testGetEntitiesWithDifferentCharacters() {
+    final Map<String, Object> params = new HashMap<String, Object>();
+    final String text =
+        "Mr. Vice President, my old colleague from Massachusetts"
+            + "and your new Speaker & John McCormack, Members of the 87th Congress, "
+            + "ladies and gentlemen: -.*&^%$#@!@#$%^&*()";
+    params.put(AlchemyLanguage.TEXT, text);
+
+    final Entities entities = service.getEntities(params).execute();
+    Assert.assertNotNull(entities);
+    Assert.assertFalse(entities.getEntities().isEmpty());
+  }
+
+  /**
+   * Test Get testGetLanguage.
+   */
+  @Test
+  public void testGetLanguage() {
+    final Map<String, Object> params = new HashMap<String, Object>();
+    params.put(AlchemyLanguage.URL, "http://news.google.fr/");
+    final Language language = service.getLanguage(params).execute();
+    Assert.assertNotNull(language);
+  }
+
+  /**
+   * Test get publication date html.
+   */
+  @Test
+  public void testGetPublicationDateHTML() {
+    final Map<String, Object> params = new HashMap<String, Object>();
+    params.put(AlchemyLanguage.HTML, htmlExample);
+    final DocumentPublicationDate date = service.getPublicationDate(params).execute();
+    Assert.assertNotNull(date);
+    Assert.assertNotNull(date.getPublicationDate());
+  }
+
+  /**
+   * Test get publication date url.
+   */
+  @Test
+  public void testGetPublicationDateURL() {
+    final Map<String, Object> params = new HashMap<String, Object>();
+    params.put(AlchemyLanguage.URL, "http://www.techcrunch.com/");
+    final DocumentPublicationDate date = service.getPublicationDate(params).execute();
+    Assert.assertNotNull(date);
+    Assert.assertNotNull(date.getPublicationDate());
+  }
+
+  /**
+   * Test Get testGetRelationsHtml HTML.
+   * 
+   */
+  @Test
+  public void testGetRelationsHtml() {
+    final Map<String, Object> params = new HashMap<String, Object>();
+    params.put(AlchemyLanguage.HTML, htmlExample);
+    final SAORelations relations = service.getRelations(params).execute();
+    Assert.assertNotNull(relations);
+  }
+
+  /**
+   * Test Get testGetRelationsUrl URL.
+   */
+  @Test
+  public void testGetRelationsUrl() {
+    final Map<String, Object> params = new HashMap<String, Object>();
+    params.put(AlchemyLanguage.URL, "http://www.techcrunch.com/");
+    final SAORelations relations = service.getRelations(params).execute();
+    Assert.assertNotNull(relations);
+  }
+
+  /**
+   * Test Get testGetTargetedSentiment HTML.
+   */
+  @Test
+  public void testGetTargetedSentimentHtml() {
+    final Map<String, Object> params = new HashMap<String, Object>();
+    params.put(AlchemyLanguage.HTML, htmlExample);
+    params.put(AlchemyLanguage.TARGET, "Watson");
+    final DocumentSentiment documentSentiment = service.getSentiment(params).execute();
+    Assert.assertNotNull(documentSentiment);
+  }
+
+  /**
+   * Test Get testGetTargetedSentiment Url.
+   */
+  @Test
+  public void testGetTargetedSentimentURL() {
+    final Map<String, Object> params = new HashMap<String, Object>();
+    params
+        .put(
+            AlchemyLanguage.URL,
+            "http://techcrunch.com/2012/03/01/keen-on-anand-rajaraman-how-walmart-wants-to-leapfrog-over-amazon-tctv/");
+    params.put(AlchemyLanguage.TARGET, "Walmart");
+    final DocumentSentiment documentSentiment = service.getSentiment(params).execute();
+    Assert.assertNotNull(documentSentiment);
+  }
+
+  /**
+   * Test Get testGetTargetedSentiment Url and multiple targets.
+   */
+  @Test
+  public void testGetTargetedSentimentURLAndTargets() {
+    final Map<String, Object> params = new HashMap<String, Object>();
+    params
+        .put(
+            AlchemyLanguage.URL,
+            "http://techcrunch.com/2012/03/01/keen-on-anand-rajaraman-how-walmart-wants-to-leapfrog-over-amazon-tctv/");
+    params.put(AlchemyLanguage.TARGETS, "Walmart|Walmart");
+    final DocumentSentiment documentSentiment = service.getSentiment(params).execute();
+    Assert.assertNotNull(documentSentiment);
+  }
+
+  /**
+   * Test Get getTaxonomy HTML.
+   * 
+   * @throws IOException Signals that an I/O exception has occurred.
+   */
+  @Test
+  public void testGetTaxonomyHtml() throws IOException {
+    final Map<String, Object> params = new HashMap<String, Object>();
+    params.put(AlchemyLanguage.HTML, htmlExample);
+    final Taxonomies taxonomy = service.getTaxonomy(params).execute();
+    Assert.assertNotNull(taxonomy);
+    Assert.assertFalse(taxonomy.getTaxonomy().isEmpty());
+  }
+
+  /**
+   * Test Get getTaxonomy URL.
+   */
+  @Test
+  public void testGetTaxonomyUrl() {
+    final Map<String, Object> params = new HashMap<String, Object>();
+    params.put(AlchemyLanguage.URL, "http://www.techcrunch.com/");
+    final Taxonomies taxonomy = service.getTaxonomy(params).execute();
+    Assert.assertNotNull(taxonomy);
+    Assert.assertFalse(taxonomy.getTaxonomy().isEmpty());
+  }
+
+  /**
+   * Test Get testGetTextSentiment HTML.
+   */
+  @Test
+  public void testGetTextSentimentHtml() {
+    final Map<String, Object> params = new HashMap<String, Object>();
+    params.put(AlchemyLanguage.HTML, htmlExample);
+    final DocumentSentiment documentSentiment = service.getSentiment(params).execute();
+    Assert.assertNotNull(documentSentiment);
+  }
+
+  /**
+   * Test Get testGetTextSentiment URL.
+   */
+  @Test
+  public void testGetTextSentimentUrl() {
+    final Map<String, Object> params = new HashMap<String, Object>();
+    params.put(AlchemyLanguage.URL, "http://www.techcrunch.com/");
+    final DocumentSentiment documentSentiment = service.getSentiment(params).execute();
+    Assert.assertNotNull(documentSentiment);
+  }
+
+  /**
+   * Test Get testGetTitle.
+   */
+  @Test
+  public void testGetTitle() {
+    final Map<String, Object> params = new HashMap<String, Object>();
+    params.put(AlchemyLanguage.URL, "http://www.techcrunch.com/");
+    final DocumentTitle title = service.getTitle(params).execute();
+    Assert.assertNotNull(title);
+  }
+
+  /**
+   * Test Get keywords HTML.
+   * 
+   */
+  @Test
+  public void testGetWordsHtml() {
+    final Map<String, Object> params = new HashMap<String, Object>();
+    params.put(AlchemyLanguage.HTML, htmlExample);
+
+    final Keywords keywords = service.getKeywords(params).execute();
+    Assert.assertNotNull(keywords);
+    Assert.assertFalse(keywords.getKeywords().isEmpty());
+  }
+
+  /**
+   * Test Get keywords URL.
+   */
+  @Test
+  public void testGetWordsUrl() {
+    final Map<String, Object> params = new HashMap<String, Object>();
+    params.put(AlchemyLanguage.URL, "http://www.techcrunch.com/");
+    final Keywords keywords = service.getKeywords(params).execute();
+    Assert.assertNotNull(keywords);
+    Assert.assertFalse(keywords.getKeywords().isEmpty());
+  }
+
+  /**
+   * Test microformats.
+   */
+  @Test
+  public void testMicroformats() {
+    final Map<String, Object> params = new HashMap<String, Object>();
+    params.put(AlchemyLanguage.URL, "http://microformats.org/wiki/hcard");
+    final Microformats microformats = service.getMicroformats(params).execute();
+    Assert.assertNotNull(microformats);
+  }
+
+  /**
+   * Test Get testGetRawText.
+   */
+  @Test
+  public void testRawText() {
+    final Map<String, Object> params = new HashMap<String, Object>();
+    params.put(AlchemyLanguage.URL, "http://www.test.com/");
+    params.put(AlchemyLanguage.RAW, true);
+    final DocumentText text = service.getText(params).execute();
+    Assert.assertNotNull(text);
+  }
+
+  /**
+   * Test Get testGetText.
+   */
+  @Test
+  public void testText() {
+    final Map<String, Object> params = new HashMap<String, Object>();
+    params.put(AlchemyLanguage.URL, "http://www.techcrunch.com/");
+    final DocumentText text = service.getText(params).execute();
+    Assert.assertNotNull(text);
+  }
+
+  /**
+   * Test get dates from a url.
+   */
+  @Test
+  public void testGetDates() {
+    final Map<String, Object> params = new HashMap<String, Object>();
+    params.put(AlchemyLanguage.TEXT, "Let's meet on January 4th, 2004");
+    params.put(AlchemyLanguage.ANCHOR_DATE, "2013-12-16 20:06:18");
+    
+    final Dates dates = service.getDates(params).execute();
+    Assert.assertNotNull(dates);
+    Assert.assertNotNull(dates.getDates());
+    Assert.assertFalse(dates.getDates().isEmpty());
+  }
+  
+  /**
+   * Test get emotion from HTML.
+   */
+  @Test
+  public void testGetEmotionHTML() {
+    final Map<String, Object> params = new HashMap<String, Object>();
+    params.put(AlchemyLanguage.HTML, htmlExample);
+    final DocumentEmotion emotion = service.getEmotion(params).execute();
+    Assert.assertNotNull(emotion);
+    Assert.assertNotNull(emotion.getEmotion());
+  }
+
+  /**
+   * Test get emotion from text.
+   */
+  @Test
+  public void testGetEmotionText() {
+    final Map<String, Object> params = new HashMap<String, Object>();
+    params.put(AlchemyLanguage.TEXT, htmlExample);
+    final DocumentEmotion emotion = service.getEmotion(params).execute();
+    Assert.assertNotNull(emotion);
+    Assert.assertNotNull(emotion.getEmotion());
+  }
+
+  /**
+   * Test Get emotion from URL.
+   */
+  @Test
+  public void testGetEmotionUrl() {
+    final Map<String, Object> params = new HashMap<String, Object>();
+    params.put(AlchemyLanguage.URL, "http://www.techcrunch.com/");
+    final DocumentEmotion emotion = service.getEmotion(params).execute();
+    Assert.assertNotNull(emotion);
+    Assert.assertNotNull(emotion.getEmotion());
+  }
+  
+  /**
+   * Test get typed relations from HTML.
+   */
+  @Test
+  @Ignore
+  public void testGetTypedRelationsHTML() {
+    final Map<String, Object> params = new HashMap<String, Object>();
+    params.put(AlchemyLanguage.HTML, htmlExample);
+    final TypedRelations typedRelations = service.getTypedRelations(params).execute();
+    Assert.assertNotNull(typedRelations);
+    Assert.assertNotNull(typedRelations.getTypedRelations());
+  }
+
+  /**
+   * Test get typed relations from text.
+   */
+  @Test
+  public void testGetTypedRelationsText() {
+      final Map<String, Object> params = new HashMap<String, Object>();
+      params.put(AlchemyLanguage.TEXT, "Leiming Qian lives in New York.");
+      params.put(AlchemyLanguage.MODEL_ID, "ie-en-news");
+      final TypedRelations typedRelations = service.getTypedRelations(params).execute();
+      Assert.assertNotNull(typedRelations);
+      List<TypedRelation> trs = typedRelations.getTypedRelations();
+      Assert.assertNotNull(trs);
+      Assert.assertFalse(trs.isEmpty());
+      for (TypedRelation tr : trs) {
+         Assert.assertNotNull(tr.getType());
+         Assert.assertNotNull(tr.getEntities());
+         Assert.assertFalse(tr.getEntities().isEmpty());
+         for (TypedEntity e : tr.getEntities()) {
+            Assert.assertNotNull(e.getId());
+            Assert.assertNotNull(e.getText());
+            Assert.assertNotNull(e.getType());
+         }
+      }
+  }
+
+  /**
+   * Test Get typed relations from URL.
+   */
+  @Test
+  @Ignore
+  public void testGetTypedRelationsUrl() {
+    final Map<String, Object> params = new HashMap<String, Object>();
+    params.put(AlchemyLanguage.URL, "http://www.techcrunch.com/");
+    final TypedRelations typedRelations = service.getTypedRelations(params).execute();
+    Assert.assertNotNull(typedRelations);
+    Assert.assertNotNull(typedRelations.getTypedRelations());
+  }
 }

--- a/src/test/java/com/ibm/watson/developer_cloud/alchemy/v1/AlchemyLanguageIT.java
+++ b/src/test/java/com/ibm/watson/developer_cloud/alchemy/v1/AlchemyLanguageIT.java
@@ -30,6 +30,7 @@ import com.ibm.watson.developer_cloud.alchemy.v1.model.Language;
 import com.ibm.watson.developer_cloud.alchemy.v1.model.Microformats;
 import com.ibm.watson.developer_cloud.alchemy.v1.model.SAORelations;
 import com.ibm.watson.developer_cloud.alchemy.v1.model.Taxonomies;
+import com.ibm.watson.developer_cloud.alchemy.v1.model.TypedEntity;
 import com.ibm.watson.developer_cloud.alchemy.v1.model.TypedRelation;
 import com.ibm.watson.developer_cloud.alchemy.v1.model.TypedRelations;
 
@@ -49,442 +50,437 @@ import java.util.Map;
  */
 public class AlchemyLanguageIT extends WatsonServiceTest {
 
-  /** The html example. */
-  private String htmlExample;
+    /** The html example. */
+    private String          htmlExample;
 
-  /** The service. */
-  private AlchemyLanguage service;
+    /** The service. */
+    private AlchemyLanguage service;
 
-  /*
-   * (non-Javadoc)
-   * 
-   * @see com.ibm.watson.developer_cloud.WatsonServiceTest#setUp()
-   */
-  @Override
-  @Before
-  public void setUp() throws Exception {
-    super.setUp();
-    service = new AlchemyLanguage();
-    service.setApiKey(getValidProperty("alchemy.alchemy"));
-    service.setDefaultHeaders(getDefaultHeaders());
-    htmlExample =
-        getStringFromInputStream(new FileInputStream("src/test/resources/alchemy/example.html"));
+    /*
+     * (non-Javadoc)
+     * 
+     * @see com.ibm.watson.developer_cloud.WatsonServiceTest#setUp()
+     */
+    @Override
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        service = new AlchemyLanguage();
+        service.setApiKey(getValidProperty("alchemy.alchemy"));
+        service.setDefaultHeaders(getDefaultHeaders());
+        htmlExample = getStringFromInputStream(new FileInputStream(
+                        "src/test/resources/alchemy/example.html"));
 
-  }
+    }
 
-  /**
-   * Test api key is null.
-   */
-  @Test(expected = IllegalArgumentException.class)
-  public void testApiKeyIsNull() {
-    final Map<String, Object> params = new HashMap<String, Object>();
-    params.put(AlchemyLanguage.URL, "http://www.techcrunch.com/");
+    /**
+     * Test api key is null.
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public void testApiKeyIsNull() {
+        final Map<String, Object> params = new HashMap<String, Object>();
+        params.put(AlchemyLanguage.URL, "http://www.techcrunch.com/");
 
-    final AlchemyLanguage language = new AlchemyLanguage();
-    language.setApiKey(null);
-    language.getKeywords(params).execute();
-  }
+        final AlchemyLanguage language = new AlchemyLanguage();
+        language.setApiKey(null);
+        language.getKeywords(params).execute();
+    }
 
-  /**
-   * Test comboined.
-   */
-  @Test
-  public void testComboined() {
-    final Map<String, Object> params = new HashMap<String, Object>();
-    params.put(AlchemyLanguage.URL, "http://www.techcrunch.com/");
-    final CombinedResults combined = service.getCombinedResults(params).execute();
-    Assert.assertNotNull(combined);
-  }
+    /**
+     * Test comboined.
+     */
+    @Test
+    public void testComboined() {
+        final Map<String, Object> params = new HashMap<String, Object>();
+        params.put(AlchemyLanguage.URL, "http://www.techcrunch.com/");
+        final CombinedResults combined = service.getCombinedResults(params).execute();
+        Assert.assertNotNull(combined);
+    }
 
-  /**
-   * Test Get testFeeds.
-   */
-  @Test
-  public void testFeeds() {
-    final Map<String, Object> params = new HashMap<String, Object>();
-    params.put(AlchemyLanguage.URL, "http://www.techcrunch.com/");
-    final Feeds feeds = service.getFeeds(params).execute();
-    Assert.assertNotNull(feeds);
-  }
+    /**
+     * Test Get testFeeds.
+     */
+    @Test
+    public void testFeeds() {
+        final Map<String, Object> params = new HashMap<String, Object>();
+        params.put(AlchemyLanguage.URL, "http://www.techcrunch.com/");
+        final Feeds feeds = service.getFeeds(params).execute();
+        Assert.assertNotNull(feeds);
+    }
 
-  /**
-   * Test Get testGetAuthor.
-   */
-  @Test
-  public void testGetAuthors() {
-    final Map<String, Object> params = new HashMap<String, Object>();
-    params
-        .put(AlchemyLanguage.URL,
-            "http://www.politico.com/blogs/media/2012/02/detroit-news-ed-upset-over-romney-edit-115247.html");
-    final DocumentAuthors authors = service.getAuthors(params).execute();
-    Assert.assertNotNull(authors);
-  }
+    /**
+     * Test Get testGetAuthor.
+     */
+    @Test
+    public void testGetAuthors() {
+        final Map<String, Object> params = new HashMap<String, Object>();
+        params.put(AlchemyLanguage.URL,
+                        "http://www.politico.com/blogs/media/2012/02/detroit-news-ed-upset-over-romney-edit-115247.html");
+        final DocumentAuthors authors = service.getAuthors(params).execute();
+        Assert.assertNotNull(authors);
+    }
 
-  /**
-   * Test get concepts HTML.
-   */
-  @Test
-  public void testGetConceptsHTML() {
-    final Map<String, Object> params = new HashMap<String, Object>();
-    params.put(AlchemyLanguage.HTML, htmlExample);
-    final Concepts concepts = service.getConcepts(params).execute();
-    Assert.assertNotNull(concepts);
-    Assert.assertFalse(concepts.getConcepts().isEmpty());
-  }
+    /**
+     * Test get concepts HTML.
+     */
+    @Test
+    public void testGetConceptsHTML() {
+        final Map<String, Object> params = new HashMap<String, Object>();
+        params.put(AlchemyLanguage.HTML, htmlExample);
+        final Concepts concepts = service.getConcepts(params).execute();
+        Assert.assertNotNull(concepts);
+        Assert.assertFalse(concepts.getConcepts().isEmpty());
+    }
 
-  /**
-   * Test get concepts Tet.
-   */
-  @Test
-  public void testGetConceptsText() {
-    final Map<String, Object> params = new HashMap<String, Object>();
-    params.put(AlchemyLanguage.TEXT, htmlExample);
-    final Concepts concepts = service.getConcepts(params).execute();
-    Assert.assertNotNull(concepts);
-    Assert.assertFalse(concepts.getConcepts().isEmpty());
-  }
+    /**
+     * Test get concepts Tet.
+     */
+    @Test
+    public void testGetConceptsText() {
+        final Map<String, Object> params = new HashMap<String, Object>();
+        params.put(AlchemyLanguage.TEXT, htmlExample);
+        final Concepts concepts = service.getConcepts(params).execute();
+        Assert.assertNotNull(concepts);
+        Assert.assertFalse(concepts.getConcepts().isEmpty());
+    }
 
-  /**
-   * Test Get getTaxonomy URL.
-   */
-  @Test
-  public void testGetConceptsUrl() {
-    final Map<String, Object> params = new HashMap<String, Object>();
-    params.put(AlchemyLanguage.URL, "http://www.techcrunch.com/");
-    final Concepts concepts = service.getConcepts(params).execute();
-    Assert.assertNotNull(concepts);
-    Assert.assertFalse(concepts.getConcepts().isEmpty());
-  }
+    /**
+     * Test Get getTaxonomy URL.
+     */
+    @Test
+    public void testGetConceptsUrl() {
+        final Map<String, Object> params = new HashMap<String, Object>();
+        params.put(AlchemyLanguage.URL, "http://www.techcrunch.com/");
+        final Concepts concepts = service.getConcepts(params).execute();
+        Assert.assertNotNull(concepts);
+        Assert.assertFalse(concepts.getConcepts().isEmpty());
+    }
 
-  /**
-   * Test Get entities HTML.
-   */
-  @Test
-  public void testGetEntitiesHtml() {
-    final Map<String, Object> params = new HashMap<String, Object>();
-    params.put(AlchemyLanguage.HTML, htmlExample);
+    /**
+     * Test Get entities HTML.
+     */
+    @Test
+    public void testGetEntitiesHtml() {
+        final Map<String, Object> params = new HashMap<String, Object>();
+        params.put(AlchemyLanguage.HTML, htmlExample);
 
-    final Entities entities = service.getEntities(params).execute();
-    Assert.assertNotNull(entities);
-    Assert.assertFalse(entities.getEntities().isEmpty());
-  }
+        final Entities entities = service.getEntities(params).execute();
+        Assert.assertNotNull(entities);
+        Assert.assertFalse(entities.getEntities().isEmpty());
+    }
 
-  /**
-   * Test Get entities URL.
-   */
-  @Test
-  public void testGetEntitiesUrl() {
-    final Map<String, Object> params = new HashMap<String, Object>();
-    params.put(AlchemyLanguage.URL, "http://www.techcrunch.com/");
-    final Entities entities = service.getEntities(params).execute();
-    Assert.assertNotNull(entities);
-    Assert.assertFalse(entities.getEntities().isEmpty());
-  }
+    /**
+     * Test Get entities URL.
+     */
+    @Test
+    public void testGetEntitiesUrl() {
+        final Map<String, Object> params = new HashMap<String, Object>();
+        params.put(AlchemyLanguage.URL, "http://www.techcrunch.com/");
+        final Entities entities = service.getEntities(params).execute();
+        Assert.assertNotNull(entities);
+        Assert.assertFalse(entities.getEntities().isEmpty());
+    }
 
-  /**
-   * Test Get entities HTML.
-   */
-  @Test
-  public void testGetEntitiesWithDifferentCharacters() {
-    final Map<String, Object> params = new HashMap<String, Object>();
-    final String text =
-        "Mr. Vice President, my old colleague from Massachusetts"
-            + "and your new Speaker & John McCormack, Members of the 87th Congress, "
-            + "ladies and gentlemen: -.*&^%$#@!@#$%^&*()";
-    params.put(AlchemyLanguage.TEXT, text);
+    /**
+     * Test Get entities HTML.
+     */
+    @Test
+    public void testGetEntitiesWithDifferentCharacters() {
+        final Map<String, Object> params = new HashMap<String, Object>();
+        final String text = "Mr. Vice President, my old colleague from Massachusetts"
+                        + "and your new Speaker & John McCormack, Members of the 87th Congress, "
+                        + "ladies and gentlemen: -.*&^%$#@!@#$%^&*()";
+        params.put(AlchemyLanguage.TEXT, text);
 
-    final Entities entities = service.getEntities(params).execute();
-    Assert.assertNotNull(entities);
-    Assert.assertFalse(entities.getEntities().isEmpty());
-  }
+        final Entities entities = service.getEntities(params).execute();
+        Assert.assertNotNull(entities);
+        Assert.assertFalse(entities.getEntities().isEmpty());
+    }
 
-  /**
-   * Test Get testGetLanguage.
-   */
-  @Test
-  public void testGetLanguage() {
-    final Map<String, Object> params = new HashMap<String, Object>();
-    params.put(AlchemyLanguage.URL, "http://news.google.fr/");
-    final Language language = service.getLanguage(params).execute();
-    Assert.assertNotNull(language);
-  }
+    /**
+     * Test Get testGetLanguage.
+     */
+    @Test
+    public void testGetLanguage() {
+        final Map<String, Object> params = new HashMap<String, Object>();
+        params.put(AlchemyLanguage.URL, "http://news.google.fr/");
+        final Language language = service.getLanguage(params).execute();
+        Assert.assertNotNull(language);
+    }
 
-  /**
-   * Test get publication date html.
-   */
-  @Test
-  public void testGetPublicationDateHTML() {
-    final Map<String, Object> params = new HashMap<String, Object>();
-    params.put(AlchemyLanguage.HTML, htmlExample);
-    final DocumentPublicationDate date = service.getPublicationDate(params).execute();
-    Assert.assertNotNull(date);
-    Assert.assertNotNull(date.getPublicationDate());
-  }
+    /**
+     * Test get publication date html.
+     */
+    @Test
+    public void testGetPublicationDateHTML() {
+        final Map<String, Object> params = new HashMap<String, Object>();
+        params.put(AlchemyLanguage.HTML, htmlExample);
+        final DocumentPublicationDate date = service.getPublicationDate(params).execute();
+        Assert.assertNotNull(date);
+        Assert.assertNotNull(date.getPublicationDate());
+    }
 
-  /**
-   * Test get publication date url.
-   */
-  @Test
-  public void testGetPublicationDateURL() {
-    final Map<String, Object> params = new HashMap<String, Object>();
-    params.put(AlchemyLanguage.URL, "http://www.techcrunch.com/");
-    final DocumentPublicationDate date = service.getPublicationDate(params).execute();
-    Assert.assertNotNull(date);
-    Assert.assertNotNull(date.getPublicationDate());
-  }
+    /**
+     * Test get publication date url.
+     */
+    @Test
+    public void testGetPublicationDateURL() {
+        final Map<String, Object> params = new HashMap<String, Object>();
+        params.put(AlchemyLanguage.URL, "http://www.techcrunch.com/");
+        final DocumentPublicationDate date = service.getPublicationDate(params).execute();
+        Assert.assertNotNull(date);
+        Assert.assertNotNull(date.getPublicationDate());
+    }
 
-  /**
-   * Test Get testGetRelationsHtml HTML.
-   * 
-   */
-  @Test
-  public void testGetRelationsHtml() {
-    final Map<String, Object> params = new HashMap<String, Object>();
-    params.put(AlchemyLanguage.HTML, htmlExample);
-    final SAORelations relations = service.getRelations(params).execute();
-    Assert.assertNotNull(relations);
-  }
+    /**
+     * Test Get testGetRelationsHtml HTML.
+     * 
+     */
+    @Test
+    public void testGetRelationsHtml() {
+        final Map<String, Object> params = new HashMap<String, Object>();
+        params.put(AlchemyLanguage.HTML, htmlExample);
+        final SAORelations relations = service.getRelations(params).execute();
+        Assert.assertNotNull(relations);
+    }
 
-  /**
-   * Test Get testGetRelationsUrl URL.
-   */
-  @Test
-  public void testGetRelationsUrl() {
-    final Map<String, Object> params = new HashMap<String, Object>();
-    params.put(AlchemyLanguage.URL, "http://www.techcrunch.com/");
-    final SAORelations relations = service.getRelations(params).execute();
-    Assert.assertNotNull(relations);
-  }
+    /**
+     * Test Get testGetRelationsUrl URL.
+     */
+    @Test
+    public void testGetRelationsUrl() {
+        final Map<String, Object> params = new HashMap<String, Object>();
+        params.put(AlchemyLanguage.URL, "http://www.techcrunch.com/");
+        final SAORelations relations = service.getRelations(params).execute();
+        Assert.assertNotNull(relations);
+    }
 
-  /**
-   * Test Get testGetTargetedSentiment HTML.
-   */
-  @Test
-  public void testGetTargetedSentimentHtml() {
-    final Map<String, Object> params = new HashMap<String, Object>();
-    params.put(AlchemyLanguage.HTML, htmlExample);
-    params.put(AlchemyLanguage.TARGET, "Watson");
-    final DocumentSentiment documentSentiment = service.getSentiment(params).execute();
-    Assert.assertNotNull(documentSentiment);
-  }
+    /**
+     * Test Get testGetTargetedSentiment HTML.
+     */
+    @Test
+    public void testGetTargetedSentimentHtml() {
+        final Map<String, Object> params = new HashMap<String, Object>();
+        params.put(AlchemyLanguage.HTML, htmlExample);
+        params.put(AlchemyLanguage.TARGET, "Watson");
+        final DocumentSentiment documentSentiment = service.getSentiment(params).execute();
+        Assert.assertNotNull(documentSentiment);
+    }
 
-  /**
-   * Test Get testGetTargetedSentiment Url.
-   */
-  @Test
-  public void testGetTargetedSentimentURL() {
-    final Map<String, Object> params = new HashMap<String, Object>();
-    params
-        .put(
-            AlchemyLanguage.URL,
-            "http://techcrunch.com/2012/03/01/keen-on-anand-rajaraman-how-walmart-wants-to-leapfrog-over-amazon-tctv/");
-    params.put(AlchemyLanguage.TARGET, "Walmart");
-    final DocumentSentiment documentSentiment = service.getSentiment(params).execute();
-    Assert.assertNotNull(documentSentiment);
-  }
+    /**
+     * Test Get testGetTargetedSentiment Url.
+     */
+    @Test
+    public void testGetTargetedSentimentURL() {
+        final Map<String, Object> params = new HashMap<String, Object>();
+        params.put(AlchemyLanguage.URL,
+                        "http://techcrunch.com/2012/03/01/keen-on-anand-rajaraman-how-walmart-wants-to-leapfrog-over-amazon-tctv/");
+        params.put(AlchemyLanguage.TARGET, "Walmart");
+        final DocumentSentiment documentSentiment = service.getSentiment(params).execute();
+        Assert.assertNotNull(documentSentiment);
+    }
 
-  /**
-   * Test Get testGetTargetedSentiment Url and multiple targets.
-   */
-  @Test
-  public void testGetTargetedSentimentURLAndTargets() {
-    final Map<String, Object> params = new HashMap<String, Object>();
-    params
-        .put(
-            AlchemyLanguage.URL,
-            "http://techcrunch.com/2012/03/01/keen-on-anand-rajaraman-how-walmart-wants-to-leapfrog-over-amazon-tctv/");
-    params.put(AlchemyLanguage.TARGETS, "Walmart|Walmart");
-    final DocumentSentiment documentSentiment = service.getSentiment(params).execute();
-    Assert.assertNotNull(documentSentiment);
-  }
+    /**
+     * Test Get testGetTargetedSentiment Url and multiple targets.
+     */
+    @Test
+    public void testGetTargetedSentimentURLAndTargets() {
+        final Map<String, Object> params = new HashMap<String, Object>();
+        params.put(AlchemyLanguage.URL,
+                        "http://techcrunch.com/2012/03/01/keen-on-anand-rajaraman-how-walmart-wants-to-leapfrog-over-amazon-tctv/");
+        params.put(AlchemyLanguage.TARGETS, "Walmart|Walmart");
+        final DocumentSentiment documentSentiment = service.getSentiment(params).execute();
+        Assert.assertNotNull(documentSentiment);
+    }
 
-  /**
-   * Test Get getTaxonomy HTML.
-   * 
-   * @throws IOException Signals that an I/O exception has occurred.
-   */
-  @Test
-  public void testGetTaxonomyHtml() throws IOException {
-    final Map<String, Object> params = new HashMap<String, Object>();
-    params.put(AlchemyLanguage.HTML, htmlExample);
-    final Taxonomies taxonomy = service.getTaxonomy(params).execute();
-    Assert.assertNotNull(taxonomy);
-    Assert.assertFalse(taxonomy.getTaxonomy().isEmpty());
-  }
+    /**
+     * Test Get getTaxonomy HTML.
+     * 
+     * @throws IOException
+     *             Signals that an I/O exception has occurred.
+     */
+    @Test
+    public void testGetTaxonomyHtml() throws IOException {
+        final Map<String, Object> params = new HashMap<String, Object>();
+        params.put(AlchemyLanguage.HTML, htmlExample);
+        final Taxonomies taxonomy = service.getTaxonomy(params).execute();
+        Assert.assertNotNull(taxonomy);
+        Assert.assertFalse(taxonomy.getTaxonomy().isEmpty());
+    }
 
-  /**
-   * Test Get getTaxonomy URL.
-   */
-  @Test
-  public void testGetTaxonomyUrl() {
-    final Map<String, Object> params = new HashMap<String, Object>();
-    params.put(AlchemyLanguage.URL, "http://www.techcrunch.com/");
-    final Taxonomies taxonomy = service.getTaxonomy(params).execute();
-    Assert.assertNotNull(taxonomy);
-    Assert.assertFalse(taxonomy.getTaxonomy().isEmpty());
-  }
+    /**
+     * Test Get getTaxonomy URL.
+     */
+    @Test
+    public void testGetTaxonomyUrl() {
+        final Map<String, Object> params = new HashMap<String, Object>();
+        params.put(AlchemyLanguage.URL, "http://www.techcrunch.com/");
+        final Taxonomies taxonomy = service.getTaxonomy(params).execute();
+        Assert.assertNotNull(taxonomy);
+        Assert.assertFalse(taxonomy.getTaxonomy().isEmpty());
+    }
 
-  /**
-   * Test Get testGetTextSentiment HTML.
-   */
-  @Test
-  public void testGetTextSentimentHtml() {
-    final Map<String, Object> params = new HashMap<String, Object>();
-    params.put(AlchemyLanguage.HTML, htmlExample);
-    final DocumentSentiment documentSentiment = service.getSentiment(params).execute();
-    Assert.assertNotNull(documentSentiment);
-  }
+    /**
+     * Test Get testGetTextSentiment HTML.
+     */
+    @Test
+    public void testGetTextSentimentHtml() {
+        final Map<String, Object> params = new HashMap<String, Object>();
+        params.put(AlchemyLanguage.HTML, htmlExample);
+        final DocumentSentiment documentSentiment = service.getSentiment(params).execute();
+        Assert.assertNotNull(documentSentiment);
+    }
 
-  /**
-   * Test Get testGetTextSentiment URL.
-   */
-  @Test
-  public void testGetTextSentimentUrl() {
-    final Map<String, Object> params = new HashMap<String, Object>();
-    params.put(AlchemyLanguage.URL, "http://www.techcrunch.com/");
-    final DocumentSentiment documentSentiment = service.getSentiment(params).execute();
-    Assert.assertNotNull(documentSentiment);
-  }
+    /**
+     * Test Get testGetTextSentiment URL.
+     */
+    @Test
+    public void testGetTextSentimentUrl() {
+        final Map<String, Object> params = new HashMap<String, Object>();
+        params.put(AlchemyLanguage.URL, "http://www.techcrunch.com/");
+        final DocumentSentiment documentSentiment = service.getSentiment(params).execute();
+        Assert.assertNotNull(documentSentiment);
+    }
 
-  /**
-   * Test Get testGetTitle.
-   */
-  @Test
-  public void testGetTitle() {
-    final Map<String, Object> params = new HashMap<String, Object>();
-    params.put(AlchemyLanguage.URL, "http://www.techcrunch.com/");
-    final DocumentTitle title = service.getTitle(params).execute();
-    Assert.assertNotNull(title);
-  }
+    /**
+     * Test Get testGetTitle.
+     */
+    @Test
+    public void testGetTitle() {
+        final Map<String, Object> params = new HashMap<String, Object>();
+        params.put(AlchemyLanguage.URL, "http://www.techcrunch.com/");
+        final DocumentTitle title = service.getTitle(params).execute();
+        Assert.assertNotNull(title);
+    }
 
-  /**
-   * Test Get keywords HTML.
-   * 
-   */
-  @Test
-  public void testGetWordsHtml() {
-    final Map<String, Object> params = new HashMap<String, Object>();
-    params.put(AlchemyLanguage.HTML, htmlExample);
+    /**
+     * Test Get keywords HTML.
+     * 
+     */
+    @Test
+    public void testGetWordsHtml() {
+        final Map<String, Object> params = new HashMap<String, Object>();
+        params.put(AlchemyLanguage.HTML, htmlExample);
 
-    final Keywords keywords = service.getKeywords(params).execute();
-    Assert.assertNotNull(keywords);
-    Assert.assertFalse(keywords.getKeywords().isEmpty());
-  }
+        final Keywords keywords = service.getKeywords(params).execute();
+        Assert.assertNotNull(keywords);
+        Assert.assertFalse(keywords.getKeywords().isEmpty());
+    }
 
-  /**
-   * Test Get keywords URL.
-   */
-  @Test
-  public void testGetWordsUrl() {
-    final Map<String, Object> params = new HashMap<String, Object>();
-    params.put(AlchemyLanguage.URL, "http://www.techcrunch.com/");
-    final Keywords keywords = service.getKeywords(params).execute();
-    Assert.assertNotNull(keywords);
-    Assert.assertFalse(keywords.getKeywords().isEmpty());
-  }
+    /**
+     * Test Get keywords URL.
+     */
+    @Test
+    public void testGetWordsUrl() {
+        final Map<String, Object> params = new HashMap<String, Object>();
+        params.put(AlchemyLanguage.URL, "http://www.techcrunch.com/");
+        final Keywords keywords = service.getKeywords(params).execute();
+        Assert.assertNotNull(keywords);
+        Assert.assertFalse(keywords.getKeywords().isEmpty());
+    }
 
-  /**
-   * Test microformats.
-   */
-  @Test
-  public void testMicroformats() {
-    final Map<String, Object> params = new HashMap<String, Object>();
-    params.put(AlchemyLanguage.URL, "http://microformats.org/wiki/hcard");
-    final Microformats microformats = service.getMicroformats(params).execute();
-    Assert.assertNotNull(microformats);
-  }
+    /**
+     * Test microformats.
+     */
+    @Test
+    public void testMicroformats() {
+        final Map<String, Object> params = new HashMap<String, Object>();
+        params.put(AlchemyLanguage.URL, "http://microformats.org/wiki/hcard");
+        final Microformats microformats = service.getMicroformats(params).execute();
+        Assert.assertNotNull(microformats);
+    }
 
-  /**
-   * Test Get testGetRawText.
-   */
-  @Test
-  public void testRawText() {
-    final Map<String, Object> params = new HashMap<String, Object>();
-    params.put(AlchemyLanguage.URL, "http://www.test.com/");
-    params.put(AlchemyLanguage.RAW, true);
-    final DocumentText text = service.getText(params).execute();
-    Assert.assertNotNull(text);
-  }
+    /**
+     * Test Get testGetRawText.
+     */
+    @Test
+    public void testRawText() {
+        final Map<String, Object> params = new HashMap<String, Object>();
+        params.put(AlchemyLanguage.URL, "http://www.test.com/");
+        params.put(AlchemyLanguage.RAW, true);
+        final DocumentText text = service.getText(params).execute();
+        Assert.assertNotNull(text);
+    }
 
-  /**
-   * Test Get testGetText.
-   */
-  @Test
-  public void testText() {
-    final Map<String, Object> params = new HashMap<String, Object>();
-    params.put(AlchemyLanguage.URL, "http://www.techcrunch.com/");
-    final DocumentText text = service.getText(params).execute();
-    Assert.assertNotNull(text);
-  }
+    /**
+     * Test Get testGetText.
+     */
+    @Test
+    public void testText() {
+        final Map<String, Object> params = new HashMap<String, Object>();
+        params.put(AlchemyLanguage.URL, "http://www.techcrunch.com/");
+        final DocumentText text = service.getText(params).execute();
+        Assert.assertNotNull(text);
+    }
 
-  /**
-   * Test get dates from a url.
-   */
-  @Test
-  public void testGetDates() {
-    final Map<String, Object> params = new HashMap<String, Object>();
-    params.put(AlchemyLanguage.TEXT, "Let's meet on January 4th, 2004");
-    params.put(AlchemyLanguage.ANCHOR_DATE, "2013-12-16 20:06:18");
-    
-    final Dates dates = service.getDates(params).execute();
-    Assert.assertNotNull(dates);
-    Assert.assertNotNull(dates.getDates());
-    Assert.assertFalse(dates.getDates().isEmpty());
-  }
-  
-  /**
-   * Test get emotion from HTML.
-   */
-  @Test
-  public void testGetEmotionHTML() {
-    final Map<String, Object> params = new HashMap<String, Object>();
-    params.put(AlchemyLanguage.HTML, htmlExample);
-    final DocumentEmotion emotion = service.getEmotion(params).execute();
-    Assert.assertNotNull(emotion);
-    Assert.assertNotNull(emotion.getEmotion());
-  }
+    /**
+     * Test get dates from a url.
+     */
+    @Test
+    public void testGetDates() {
+        final Map<String, Object> params = new HashMap<String, Object>();
+        params.put(AlchemyLanguage.TEXT, "Let's meet on January 4th, 2004");
+        params.put(AlchemyLanguage.ANCHOR_DATE, "2013-12-16 20:06:18");
 
-  /**
-   * Test get emotion from text.
-   */
-  @Test
-  public void testGetEmotionText() {
-    final Map<String, Object> params = new HashMap<String, Object>();
-    params.put(AlchemyLanguage.TEXT, htmlExample);
-    final DocumentEmotion emotion = service.getEmotion(params).execute();
-    Assert.assertNotNull(emotion);
-    Assert.assertNotNull(emotion.getEmotion());
-  }
+        final Dates dates = service.getDates(params).execute();
+        Assert.assertNotNull(dates);
+        Assert.assertNotNull(dates.getDates());
+        Assert.assertFalse(dates.getDates().isEmpty());
+    }
 
-  /**
-   * Test Get emotion from URL.
-   */
-  @Test
-  public void testGetEmotionUrl() {
-    final Map<String, Object> params = new HashMap<String, Object>();
-    params.put(AlchemyLanguage.URL, "http://www.techcrunch.com/");
-    final DocumentEmotion emotion = service.getEmotion(params).execute();
-    Assert.assertNotNull(emotion);
-    Assert.assertNotNull(emotion.getEmotion());
-  }
-  
-  /**
-   * Test get typed relations from HTML.
-   */
-  @Test
-  @Ignore
-  public void testGetTypedRelationsHTML() {
-    final Map<String, Object> params = new HashMap<String, Object>();
-    params.put(AlchemyLanguage.HTML, htmlExample);
-    final TypedRelations typedRelations = service.getTypedRelations(params).execute();
-    Assert.assertNotNull(typedRelations);
-    Assert.assertNotNull(typedRelations.getTypedRelations());
-  }
+    /**
+     * Test get emotion from HTML.
+     */
+    @Test
+    public void testGetEmotionHTML() {
+        final Map<String, Object> params = new HashMap<String, Object>();
+        params.put(AlchemyLanguage.HTML, htmlExample);
+        final DocumentEmotion emotion = service.getEmotion(params).execute();
+        Assert.assertNotNull(emotion);
+        Assert.assertNotNull(emotion.getEmotion());
+    }
 
-  /**
-   * Test get typed relations from text.
-   */
-  @Test
+    /**
+     * Test get emotion from text.
+     */
+    @Test
+    public void testGetEmotionText() {
+        final Map<String, Object> params = new HashMap<String, Object>();
+        params.put(AlchemyLanguage.TEXT, htmlExample);
+        final DocumentEmotion emotion = service.getEmotion(params).execute();
+        Assert.assertNotNull(emotion);
+        Assert.assertNotNull(emotion.getEmotion());
+    }
+
+    /**
+     * Test Get emotion from URL.
+     */
+    @Test
+    public void testGetEmotionUrl() {
+        final Map<String, Object> params = new HashMap<String, Object>();
+        params.put(AlchemyLanguage.URL, "http://www.techcrunch.com/");
+        final DocumentEmotion emotion = service.getEmotion(params).execute();
+        Assert.assertNotNull(emotion);
+        Assert.assertNotNull(emotion.getEmotion());
+    }
+
+    /**
+     * Test get typed relations from HTML.
+     */
+    @Test
+    @Ignore
+    public void testGetTypedRelationsHTML() {
+        final Map<String, Object> params = new HashMap<String, Object>();
+        params.put(AlchemyLanguage.HTML, htmlExample);
+        final TypedRelations typedRelations = service.getTypedRelations(params).execute();
+        Assert.assertNotNull(typedRelations);
+        Assert.assertNotNull(typedRelations.getTypedRelations());
+    }
+
+    /**
+     * Test get typed relations from text.
+     */
+    @Test
   public void testGetTypedRelationsText() {
     final Map<String, Object> params = new HashMap<String, Object>();
     params.put(AlchemyLanguage.TEXT, "Leiming Qian lives in New York.");
@@ -494,26 +490,28 @@ public class AlchemyLanguageIT extends WatsonServiceTest {
     List<TypedRelation> trs = typedRelations.getTypedRelations();
     Assert.assertNotNull(trs);
     Assert.assertFalse(trs.isEmpty());
-    trs.stream().forEach(tr -> Assert.assertNotNull(tr.getType()));
-    trs.stream().forEach(tr -> Assert.assertNotNull(tr.getEntities()));
-    trs.stream().forEach(tr -> Assert.assertFalse(tr.getEntities().isEmpty()));
-    trs.stream().forEach(tr -> tr.getEntities().stream().forEach(e -> {
-        Assert.assertNotNull(e.getId());
-        Assert.assertNotNull(e.getText());
-        Assert.assertNotNull(e.getType());
-    }));
+    for (TypedRelation tr : trs) {
+       Assert.assertNotNull(tr.getType());
+       Assert.assertNotNull(tr.getEntities());
+       Assert.assertFalse(tr.getEntities().isEmpty());
+       for (TypedEntity e : tr.getEntities()) {
+          Assert.assertNotNull(e.getId());
+          Assert.assertNotNull(e.getText());
+          Assert.assertNotNull(e.getType());
+       }
+    }
   }
 
-  /**
-   * Test Get typed relations from URL.
-   */
-  @Test
-  @Ignore
-  public void testGetTypedRelationsUrl() {
-    final Map<String, Object> params = new HashMap<String, Object>();
-    params.put(AlchemyLanguage.URL, "http://www.techcrunch.com/");
-    final TypedRelations typedRelations = service.getTypedRelations(params).execute();
-    Assert.assertNotNull(typedRelations);
-    Assert.assertNotNull(typedRelations.getTypedRelations());
-  }
+    /**
+     * Test Get typed relations from URL.
+     */
+    @Test
+    @Ignore
+    public void testGetTypedRelationsUrl() {
+        final Map<String, Object> params = new HashMap<String, Object>();
+        params.put(AlchemyLanguage.URL, "http://www.techcrunch.com/");
+        final TypedRelations typedRelations = service.getTypedRelations(params).execute();
+        Assert.assertNotNull(typedRelations);
+        Assert.assertNotNull(typedRelations.getTypedRelations());
+    }
 }

--- a/src/test/java/com/ibm/watson/developer_cloud/alchemy/v1/AlchemyLanguageIT.java
+++ b/src/test/java/com/ibm/watson/developer_cloud/alchemy/v1/AlchemyLanguageIT.java
@@ -13,16 +13,6 @@
  */
 package com.ibm.watson.developer_cloud.alchemy.v1;
 
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
-
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
-
 import com.ibm.watson.developer_cloud.WatsonServiceTest;
 import com.ibm.watson.developer_cloud.alchemy.v1.model.CombinedResults;
 import com.ibm.watson.developer_cloud.alchemy.v1.model.Concepts;
@@ -40,7 +30,19 @@ import com.ibm.watson.developer_cloud.alchemy.v1.model.Language;
 import com.ibm.watson.developer_cloud.alchemy.v1.model.Microformats;
 import com.ibm.watson.developer_cloud.alchemy.v1.model.SAORelations;
 import com.ibm.watson.developer_cloud.alchemy.v1.model.Taxonomies;
+import com.ibm.watson.developer_cloud.alchemy.v1.model.TypedRelation;
 import com.ibm.watson.developer_cloud.alchemy.v1.model.TypedRelations;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Created by nizar on 8/25/15.
@@ -485,11 +487,21 @@ public class AlchemyLanguageIT extends WatsonServiceTest {
   @Test
   public void testGetTypedRelationsText() {
     final Map<String, Object> params = new HashMap<String, Object>();
-    params.put(AlchemyLanguage.TEXT, "Jake is one of the developers in the team.");
-    params.put(AlchemyLanguage.MODEL_ID, "en-us-tir");
+    params.put(AlchemyLanguage.TEXT, "Leiming Qian lives in New York.");
+    params.put(AlchemyLanguage.MODEL_ID, "ie-en-news");
     final TypedRelations typedRelations = service.getTypedRelations(params).execute();
     Assert.assertNotNull(typedRelations);
-    Assert.assertNotNull(typedRelations.getTypedRelations());
+    List<TypedRelation> trs = typedRelations.getTypedRelations();
+    Assert.assertNotNull(trs);
+    Assert.assertFalse(trs.isEmpty());
+    trs.stream().forEach(tr -> Assert.assertNotNull(tr.getType()));
+    trs.stream().forEach(tr -> Assert.assertNotNull(tr.getEntities()));
+    trs.stream().forEach(tr -> Assert.assertFalse(tr.getEntities().isEmpty()));
+    trs.stream().forEach(tr -> tr.getEntities().stream().forEach(e -> {
+        Assert.assertNotNull(e.getId());
+        Assert.assertNotNull(e.getText());
+        Assert.assertNotNull(e.getType());
+    }));
   }
 
   /**


### PR DESCRIPTION
🐛

This is a proposed fix for
#367

It takes the "arguments/argument" indirection into account when deserializing the server payloads into TypedRelation Java objects. Without this fix, the "entities" are not deserialized correctly and TypedRelation.getEntities() always returns a null pointer.

I also changed the type of TypedRelation.entities from Entity to TypedEntity, which seemed the original intention of the design all along.