### PR TITLE
[document-conversion] Adds index document API

### DIFF
--- a/examples/java/com/ibm/watson/developer_cloud/document_conversion/v1/DocumentConversionIndexDocumentExample.java
+++ b/examples/java/com/ibm/watson/developer_cloud/document_conversion/v1/DocumentConversionIndexDocumentExample.java
@@ -1,0 +1,157 @@
+/**
+ * Copyright 2015 IBM Corp. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.ibm.watson.developer_cloud.document_conversion.v1;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.ibm.watson.developer_cloud.document_conversion.v1.model.IndexDocumentOptions;
+import com.ibm.watson.developer_cloud.document_conversion.v1.model.IndexConfiguration;
+import com.ibm.watson.developer_cloud.http.HttpMediaType;
+
+/**
+ * Example class that shows the index document usage of the Document Conversion service
+ */
+public class DocumentConversionIndexDocumentExample {
+
+  public static void main(String[] args) {
+    DocumentConversion service = new DocumentConversion(DocumentConversion.VERSION_DATE_2015_12_01);
+    service.setUsernameAndPassword("<username>", "<password>");
+
+    // ----- Global Values -----
+    IndexConfiguration indexConfiguration = new IndexConfiguration("<serviceInstanceId>", "<clusterId>", "<searchCollectionName>");
+
+    // Create some metadata for indexing
+    final Map<String, String> metadata = new HashMap<String, String>();
+    metadata.put("id", "1");
+    metadata.put("SomeMetadataName", "SomeMetadataValue");
+
+    // Create a convert document configuration that will exclude all anchor tags (<a>) from the input HTML file
+    String convertDocumentConfigAsString = "{ \"normalized_html\" : { \"exclude_tags_completely\":[\"a\"] } }";
+    JsonParser jsonParser = new JsonParser();
+    JsonObject convertDocumentConfig = jsonParser.parse(convertDocumentConfigAsString).getAsJsonObject();
+
+    // Sample file to index
+    File document = new File("src/test/resources/document_conversion/html-with-extra-content-input.htm");
+    String html = "<html><head><title>Sample HTML</title></head><body><h1>Intro</h1><p>Some content!</p></body></html>";
+    InputStream documentInputStream = new ByteArrayInputStream(html.getBytes());
+
+    // ----- Examples for performing a dry run of the index document API -----
+    printHeaderForExample("Dry run for indexing a document");
+    IndexDocumentOptions indexDocumentOptions1 = new IndexDocumentOptions.Builder()
+        .document(document)
+        .dryRun(true)
+        .build();
+    String indexDocumentDryRun = service.indexDocument(indexDocumentOptions1).execute();
+    System.out.println(indexDocumentDryRun);
+
+    printHeaderForExample("Dry run for indexing a document (using input stream)");
+    IndexDocumentOptions indexDocumentOptions2 = new IndexDocumentOptions.Builder()
+        .document(documentInputStream, HttpMediaType.TEXT_HTML)
+        .dryRun(true)
+        .build();
+    String indexDocumentInputStreamDryRun = service.indexDocument(indexDocumentOptions2).execute();
+    System.out.println(indexDocumentInputStreamDryRun);
+
+    printHeaderForExample("Dry run for indexing metadata");
+    IndexDocumentOptions indexDocumentOptions3 = new IndexDocumentOptions.Builder()
+        .metadata(metadata)
+        .dryRun(true)
+        .build();
+    String indexMetadataDryRun = service.indexDocument(indexDocumentOptions3).execute();
+    System.out.println(indexMetadataDryRun);
+
+    printHeaderForExample("Dry run for indexing document and metadata");
+    IndexDocumentOptions indexDocumentOptions4 = new IndexDocumentOptions.Builder()
+        .document(document)
+        .metadata(metadata)
+        .dryRun(true)
+        .build();
+    String indexDocumentAndMetadataDryRun = service.indexDocument(indexDocumentOptions4).execute();
+    System.out.println(indexDocumentAndMetadataDryRun);
+
+    printHeaderForExample("Dry run for indexing document with provided media type and metadata");
+    IndexDocumentOptions indexDocumentOptions5 = new IndexDocumentOptions.Builder()
+        .document(document)
+        .metadata(metadata)
+        .mediaType(HttpMediaType.TEXT_HTML)
+        .dryRun(true)
+        .build();
+    String indexDocumentWithMediaTypeAndMetadataDryRun = service.indexDocument(indexDocumentOptions5).execute();
+    System.out.println(indexDocumentWithMediaTypeAndMetadataDryRun);
+
+    printHeaderForExample("Dry run for indexing document with provided media type, metadata, and convert document config");
+    IndexDocumentOptions indexDocumentOptions6 = new IndexDocumentOptions.Builder()
+        .document(document)
+        .metadata(metadata)
+        .mediaType(HttpMediaType.TEXT_HTML)
+        .convertDocumentConfig(convertDocumentConfig)
+        .dryRun(true)
+        .build();
+    String indexDocumentWithMediaTypeAndMetadataAndConfigDryRun = service.indexDocument(indexDocumentOptions6).execute();
+    System.out.println(indexDocumentWithMediaTypeAndMetadataAndConfigDryRun);
+
+    printHeaderForExample("Index metadata");
+    IndexDocumentOptions indexDocumentOptions7 = new IndexDocumentOptions.Builder()
+        .metadata(metadata)
+        .indexConfiguration(indexConfiguration)
+        .dryRun(false)
+        .build();
+    String indexMetadata = service.indexDocument(indexDocumentOptions7).execute();
+    System.out.println(indexMetadata);
+
+    printHeaderForExample("Index a document and metadata");
+    IndexDocumentOptions indexDocumentOptions8 = new IndexDocumentOptions.Builder()
+        .document(document)
+        .metadata(metadata)
+        .indexConfiguration(indexConfiguration)
+        .dryRun(false)
+        .build();
+    String indexDocumentAndMetadata = service.indexDocument(indexDocumentOptions8).execute();
+    System.out.println(indexDocumentAndMetadata);
+
+    printHeaderForExample("Index document with provided media type and metadata");
+    IndexDocumentOptions indexDocumentOptions9 = new IndexDocumentOptions.Builder()
+        .document(document)
+        .metadata(metadata)
+        .mediaType(HttpMediaType.TEXT_HTML)
+        .indexConfiguration(indexConfiguration)
+        .dryRun(false)
+        .build();
+    String indexDocumentWithMediaTypeAndMetadata = service.indexDocument(indexDocumentOptions9).execute();
+    System.out.println(indexDocumentWithMediaTypeAndMetadata);
+
+    printHeaderForExample("Index document with provided media type, metadata, and convert document config");
+    IndexDocumentOptions indexDocumentOptions10 = new IndexDocumentOptions.Builder()
+        .document(document)
+        .metadata(metadata)
+        .mediaType(HttpMediaType.TEXT_HTML)
+        .convertDocumentConfig(convertDocumentConfig)
+        .indexConfiguration(indexConfiguration)
+        .dryRun(false)
+        .build();
+    String indexDocumentWithMediaTypeAndMetadataAndConfig = service.indexDocument(indexDocumentOptions10).execute();
+    System.out.println(indexDocumentWithMediaTypeAndMetadataAndConfig);
+  }
+
+  private static void printHeaderForExample(String message) {
+    System.out.println("\n================================================================================\n"
+        + message + "\n================================================================================\n");
+  }
+}

--- a/src/main/java/com/ibm/watson/developer_cloud/document_conversion/v1/DocumentConversion.java
+++ b/src/main/java/com/ibm/watson/developer_cloud/document_conversion/v1/DocumentConversion.java
@@ -277,16 +277,16 @@ public class DocumentConversion extends WatsonService {
         throw new IllegalArgumentException("A configuration is required for indexing.");
       // Build the configuration for the index document request
       final JsonObject config = new JsonObject();
-      JsonObject rnrConfig = new JsonObject();
+      JsonObject retrieveAndRankConfig = new JsonObject();
       if (dryRun) {
-        rnrConfig.addProperty(DRY_RUN, true);
+        retrieveAndRankConfig.addProperty(DRY_RUN, true);
       } else {
-        rnrConfig.addProperty(DRY_RUN, false);
-        rnrConfig.addProperty(SERVICE_INSTANCE_ID, indexConfiguration.getServiceInstanceId());
-        rnrConfig.addProperty(CLUSTER_ID, indexConfiguration.getClusterId());
-        rnrConfig.addProperty(SEARCH_COLLECTION, indexConfiguration.getSearchCollectionName());
+        retrieveAndRankConfig.addProperty(DRY_RUN, false);
+        retrieveAndRankConfig.addProperty(SERVICE_INSTANCE_ID, indexConfiguration.getServiceInstanceId());
+        retrieveAndRankConfig.addProperty(CLUSTER_ID, indexConfiguration.getClusterId());
+        retrieveAndRankConfig.addProperty(SEARCH_COLLECTION, indexConfiguration.getSearchCollectionName());
       }
-      config.add(RETRIEVE_AND_RANK, rnrConfig);
+      config.add(RETRIEVE_AND_RANK, retrieveAndRankConfig);
       if (convertDocumentConfig != null) {
         config.add(CONVERT_DOCUMENT, convertDocumentConfig);
       }

--- a/src/main/java/com/ibm/watson/developer_cloud/document_conversion/v1/model/IndexConfiguration.java
+++ b/src/main/java/com/ibm/watson/developer_cloud/document_conversion/v1/model/IndexConfiguration.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright 2016 IBM Corp. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.ibm.watson.developer_cloud.document_conversion.v1.model;
+
+import com.ibm.watson.developer_cloud.document_conversion.v1.DocumentConversion;
+import com.ibm.watson.developer_cloud.retrieve_and_rank.v1.RetrieveAndRank;
+import com.ibm.watson.developer_cloud.service.model.GenericModel;
+
+/**
+ * Structure that stores the configuration for the Retrieve and Rank service
+ * when indexing documents through the Document Conversion service
+ *
+ * @see DocumentConversion
+ * @see RetrieveAndRank
+ */
+public class IndexConfiguration extends GenericModel {
+
+  /**
+   * The instance id for the Retrieve and Rank service
+   */
+  private String serviceInstanceId;
+
+  /**
+   * The Solr cluster id from the Retrieve and Rank service
+   */
+  private String clusterId;
+
+  /**
+   * The Solr search collection name
+   */
+  private String searchCollectionName;
+
+  /**
+   * Constructor for the Retrieve and Rank configuration. You will need to get Retrieve and Rank
+   * service credentials and create a Solr cluster through the Retrieve and Rank service prior
+   * to creating this configuration object.
+   * @param serviceInstanceId The instance id for the Retrieve and Rank service
+   * @param clusterId The Solr cluster id from the Retrieve and Rank service
+   * @param searchCollectionName The Solr search collection name
+   *
+   * @see RetrieveAndRank
+   */
+  public IndexConfiguration(String serviceInstanceId, String clusterId, String searchCollectionName) {
+    this.serviceInstanceId = serviceInstanceId;
+    this.clusterId = clusterId;
+    this.searchCollectionName = searchCollectionName;
+  }
+
+  /**
+   * Gets the service instance id for the Retrieve and Rank service
+   * @return String
+   */
+  public String getServiceInstanceId() { return serviceInstanceId; }
+
+  /**
+   * Gets the cluster id for the Retrieve and Rank service
+   * @return String
+   */
+  public String getClusterId() { return clusterId; }
+
+  /**
+   * Gets the search collection name for the Retrieve and Rank service
+   * @return String
+   */
+  public String getSearchCollectionName() { return searchCollectionName; }
+}

--- a/src/main/java/com/ibm/watson/developer_cloud/document_conversion/v1/model/IndexDocumentOptions.java
+++ b/src/main/java/com/ibm/watson/developer_cloud/document_conversion/v1/model/IndexDocumentOptions.java
@@ -1,0 +1,201 @@
+package com.ibm.watson.developer_cloud.document_conversion.v1.model;
+
+import com.google.gson.JsonObject;
+
+import java.io.File;
+import java.io.InputStream;
+import java.util.Map;
+
+public class IndexDocumentOptions {
+  private File document;
+  private InputStream documentInputStream;
+  private String mediaType;
+  private Map<String, String> metadata;
+  private JsonObject convertDocumentConfig;
+  private IndexConfiguration indexConfiguration;
+  private Boolean dryRun;
+
+  /**
+   * Gets the document
+   *
+   * @return document The document to be converted and indexed
+   */
+  public File document() {
+    return document;
+  }
+
+  /**
+   * Gets the document as an input stream
+   *
+   * @return InputStream The document to be converted and indexed
+   */
+  public InputStream getDocumentInputStream() { return documentInputStream; }
+
+  /**
+   * Gets the media type
+   *
+   * @return mediaType The media type of the document to be converted and indexed
+   */
+  public String mediaType() {
+    return mediaType;
+  }
+
+  /**
+   * Gets the metadata
+   *
+   * @return metadata The metadata of the document that will be indexed
+   */
+  public Map<String, String> metadata() {
+    return metadata;
+  }
+
+  /**
+   * Gets the configuration for the convert document phase
+   *
+   * @return conversionConfiguration Configuration for the convert document phase
+   */
+  public JsonObject convertDocumentConfig() {
+    return convertDocumentConfig;
+  }
+
+  /**
+   * Gets configuration for the retrieve and rank service for the indexing phase
+   *
+   * @return indexConfiguration Configuration for the retrieve and rank service for the indexing phase
+   */
+  public IndexConfiguration indexConfiguration() {
+    return indexConfiguration;
+  }
+
+  /**
+   * Gets the dryRun flag
+   *
+   * @return dryRun If true, performs a dry run for testing purposes (document won't be indexed), else to index the document
+   */
+  public Boolean dryRun() {
+    return dryRun;
+  }
+
+  /**
+   * Builder.
+   */
+  public static class Builder {
+    private File document;
+    private InputStream documentInputStream;
+    private String mediaType;
+    private Map<String, String> metadata;
+    private JsonObject conversionConfiguration;
+    private IndexConfiguration indexConfiguration;
+    private boolean dryRun;
+
+    private Builder(IndexDocumentOptions options) {
+      this.document = options.document;
+      this.documentInputStream = options.documentInputStream;
+      this.mediaType = options.mediaType;
+      this.metadata = options.metadata;
+      this.conversionConfiguration = options.convertDocumentConfig;
+      this.indexConfiguration = options.indexConfiguration;
+      this.dryRun = options.dryRun;
+    }
+
+    /**
+     * Instantiates a new builder.
+     */
+    public Builder() {}
+
+    /**
+     * Builds the index document options.
+     *
+     * @return the index document options
+     */
+    public IndexDocumentOptions build() { return new IndexDocumentOptions(this); }
+
+    /**
+     * Sets the document as an input stream and its media type
+     * @param document The document to be converted and indexed
+     * @param mediaType The media type of the document
+     * @return the index document options
+     */
+    public Builder document(InputStream document, String mediaType){
+      this.documentInputStream = document;
+      this.mediaType = mediaType;
+      return this;
+    }
+
+    /**
+     * Sets the document
+     *
+     * @param document The document to be converted and indexed
+     * @return the index document options
+     */
+    public Builder document(File document){
+      this.document = document;
+      return this;
+    }
+
+    /**
+     * Sets the media type
+     *
+     * @param mediaType The media type of the document to be converted and indexed
+     * @return the index document options
+     */
+    public Builder mediaType(String mediaType){
+      this.mediaType = mediaType;
+      return this;
+    }
+
+    /**
+     * Sets the metadata
+     *
+     * @param metadata The metadata of the document that will be indexed
+     * @return the index document options
+     */
+    public Builder metadata(Map<String, String> metadata){
+      this.metadata = metadata;
+      return this;
+    }
+
+    /**
+     * Sets the convert document configuration
+     *
+     * @param convertDocumentConfig Configuration for the convert document phase
+     * @return the index document options
+     */
+    public Builder convertDocumentConfig(JsonObject convertDocumentConfig){
+      this.conversionConfiguration = convertDocumentConfig;
+      return this;
+    }
+
+    /*
+     * Sets the retrieve and rank configuration
+     *
+     * @param indexConfiguration Configuration for the retrieve and rank service for the indexing phase
+     * @return the index document options
+     */
+    public Builder indexConfiguration(IndexConfiguration indexConfiguration){
+      this.indexConfiguration = indexConfiguration;
+      return this;
+    }
+
+    /*
+    * Sets the dryRun flag
+    *
+    * @param dryRun If true, performs a dry run for testing purposes (document won't be indexed), else to index the document
+    * @return the index document options
+    */
+    public Builder dryRun(Boolean dryRun){
+      this.dryRun = dryRun;
+      return this;
+    }
+  }
+
+  private IndexDocumentOptions(Builder builder) {
+    this.document = builder.document;
+    this.documentInputStream = builder.documentInputStream;
+    this.mediaType = builder.mediaType;
+    this.metadata = builder.metadata;
+    this.convertDocumentConfig = builder.conversionConfiguration;
+    this.indexConfiguration = builder.indexConfiguration;
+    this.dryRun = builder.dryRun;
+  }
+}

--- a/src/main/java/com/ibm/watson/developer_cloud/document_conversion/v1/model/Metadata.java
+++ b/src/main/java/com/ibm/watson/developer_cloud/document_conversion/v1/model/Metadata.java
@@ -63,7 +63,8 @@ public class Metadata extends GenericModel {
   }
 
   private static class MetadataEntry extends GenericModel {
-    private String name, value;
+    private String name;
+    private String value;
 
     MetadataEntry(String name, String value) {
       this.name = name;

--- a/src/main/java/com/ibm/watson/developer_cloud/document_conversion/v1/model/Metadata.java
+++ b/src/main/java/com/ibm/watson/developer_cloud/document_conversion/v1/model/Metadata.java
@@ -1,0 +1,74 @@
+/**
+ * Copyright 2016 IBM Corp. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.ibm.watson.developer_cloud.document_conversion.v1.model;
+
+import com.ibm.watson.developer_cloud.document_conversion.v1.DocumentConversion;
+import com.ibm.watson.developer_cloud.service.model.GenericModel;
+import com.ibm.watson.developer_cloud.util.GsonSingleton;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Structure that stores all metadata entries for document when indexing
+ *
+ * @see DocumentConversion
+ */
+public class Metadata extends GenericModel {
+
+  private static final String METADATA = "metadata";
+  private Map<String, String> metadata;
+
+  /**
+   * Gets the metadata
+   *
+   * @return Map of metadata values
+   */
+  public Map<String, String> getMetadata() { return metadata; }
+
+  /**
+   * Sets the metadata
+   *
+   * @param metadata The Map of metadata values
+   */
+  public void setMetadata(Map<String, String> metadata) { this.metadata = metadata; }
+
+  /*
+   * (non-Javadoc)
+   *
+   * @see java.lang.Object#toString()
+   */
+  @Override
+  public String toString() {
+    List<MetadataEntry> metadata = new ArrayList<MetadataEntry>();
+    for (Map.Entry<String, String> entry : this.metadata.entrySet()) {
+      metadata.add(new MetadataEntry(entry.getKey(), entry.getValue()));
+    }
+    Map<String, List<MetadataEntry>> metadataMap = new HashMap<String, List<MetadataEntry>>();
+    metadataMap.put(METADATA, metadata);
+    return GsonSingleton.getGson().toJson(metadataMap);
+  }
+
+  private static class MetadataEntry extends GenericModel {
+    private String name, value;
+
+    MetadataEntry(String name, String value) {
+      this.name = name;
+      this.value = value;
+    }
+  }
+
+}

--- a/src/test/java/com/ibm/watson/developer_cloud/document_conversion/v1/DocumentConversionIT.java
+++ b/src/test/java/com/ibm/watson/developer_cloud/document_conversion/v1/DocumentConversionIT.java
@@ -1,11 +1,11 @@
 /**
  * Copyright 2015 IBM Corp. All Rights Reserved.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
@@ -14,7 +14,12 @@
 package com.ibm.watson.developer_cloud.document_conversion.v1;
 
 import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
 
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.ibm.watson.developer_cloud.document_conversion.v1.model.IndexDocumentOptions;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -30,10 +35,13 @@ public class DocumentConversionIT extends WatsonServiceTest {
   /** The service. */
   private DocumentConversion service;
   private File[] files;
+  private Map<String, String> metadata;
+  private JsonObject convertDocumentConfig;
+  private Boolean dryRun;
 
   /*
    * (non-Javadoc)
-   * 
+   *
    * @see com.ibm.watson.developer_cloud.WatsonServiceTest#setUp()
    */
   @Override
@@ -42,7 +50,7 @@ public class DocumentConversionIT extends WatsonServiceTest {
     super.setUp();
     service = new DocumentConversion(DocumentConversion.VERSION_DATE_2015_12_01);
     service.setUsernameAndPassword(
-        getExistingProperty("document_conversion.username"), 
+        getExistingProperty("document_conversion.username"),
         getExistingProperty("document_conversion.password")
     );
     service.setEndPoint(getExistingProperty("document_conversion.url"));
@@ -51,6 +59,11 @@ public class DocumentConversionIT extends WatsonServiceTest {
         new File("src/test/resources/document_conversion/word-document-heading-input.doc"),
         new File("src/test/resources/document_conversion/pdf-with-sections-input.pdf"),
         new File("src/test/resources/document_conversion/html-with-extra-content-input.htm"),};
+    metadata = new HashMap<String, String>();
+    metadata.put("SomeMetadataName", "SomeMetadataValue");
+    String convertDocumentConfigAsString = "{ \"normalized_html\" : { \"exclude_tags_completely\":[\"a\"] } }";
+    convertDocumentConfig = new JsonParser().parse(convertDocumentConfigAsString).getAsJsonObject();
+    dryRun = true;
   }
 
   /**
@@ -87,6 +100,77 @@ public class DocumentConversionIT extends WatsonServiceTest {
       final String text = service.convertDocumentToText(file).execute();
       Assert.assertNotNull(text);
       Assert.assertNotEquals(text, "");
+    }
+  }
+
+  /**
+   * Test a dry run of the index document api with document only.
+   */
+  @Test
+  public void testIndexDocumentDryRun() {
+    for (final File file : files) {
+      IndexDocumentOptions indexDocumentOptions = new IndexDocumentOptions.Builder()
+          .document(file)
+          .dryRun(dryRun)
+          .build();
+      final String response = service.indexDocument(indexDocumentOptions).execute();
+      Assert.assertNotNull(response);
+      Assert.assertNotEquals(response, "");
+    }
+  }
+
+  /**
+   * Test a dry run of the index document api with metadata only.
+   */
+  @Test
+  public void testIndexMetadataDryRun() {
+    IndexDocumentOptions indexDocumentOptions = new IndexDocumentOptions.Builder()
+        .metadata(metadata)
+        .dryRun(dryRun)
+        .build();
+    final String response = service.indexDocument(indexDocumentOptions).execute();
+    Assert.assertNotNull(response);
+    Assert.assertNotEquals(response, "");
+    Assert.assertTrue(response.contains("SomeMetadataName"));
+    Assert.assertTrue(response.contains("SomeMetadataValue"));
+  }
+
+  /**
+   * Test a dry run of the index document api with document and metadata.
+   */
+  @Test
+  public void testIndexDocumentAndMetadataDryRun() {
+    for (final File file : files) {
+      IndexDocumentOptions indexDocumentOptions = new IndexDocumentOptions.Builder()
+          .document(file)
+          .metadata(metadata)
+          .dryRun(dryRun)
+          .build();
+      final String response = service.indexDocument(indexDocumentOptions).execute();
+      Assert.assertNotNull(response);
+      Assert.assertNotEquals(response, "");
+      Assert.assertTrue(response.contains("SomeMetadataName"));
+      Assert.assertTrue(response.contains("SomeMetadataValue"));
+    }
+  }
+
+  /**
+   * Test a dry run of the index document api with document, metadata, and convert document config.
+   */
+  @Test
+  public void testIndexDocumentAndMetadataAndConvertDocConfig() {
+    for (final File file : files) {
+      IndexDocumentOptions indexDocumentOptions = new IndexDocumentOptions.Builder()
+          .document(file)
+          .metadata(metadata)
+          .dryRun(dryRun)
+          .convertDocumentConfig(convertDocumentConfig)
+          .build();
+      final String response = service.indexDocument(indexDocumentOptions).execute();
+      Assert.assertNotNull(response);
+      Assert.assertNotEquals(response, "");
+      Assert.assertTrue(response.contains("SomeMetadataName"));
+      Assert.assertTrue(response.contains("SomeMetadataValue"));
     }
   }
 }

--- a/src/test/resources/document_conversion/html-with-extra-content-input-index-dry-run.json
+++ b/src/test/resources/document_conversion/html-with-extra-content-input-index-dry-run.json
@@ -1,0 +1,26 @@
+{
+  "converted_document" : {
+    "media_type_detected" : "text/html",
+    "metadata" : [ ],
+    "answer_units" : [ {
+      "id" : "0588503a-8db7-4572-a1bb-01e25c2c5c9f",
+      "type" : "body",
+      "title" : "no-title",
+      "direction" : "ltr",
+      "content" : [ {
+        "media_type" : "text/html",
+        "text" : "This is text inside font tag! <center><h1>Sample HTML Formats</h1></center> <center><h1><img border=\"0\" height=\"39\" width=\"334\"></img></h1></center> <h2 start=\"2\">TEXT</h2> <b>This is a sample of text typed with no tags:</b> HTML file <br></br> This is a sample of text typed in with no special formatting. This is a sample of text typed in with no special formatting This is a sample of text typed in with no special formatting This is a sample of text typed in with no special formatting. This is a sample of text typed in with no special formatting <div id=\"maincontent\">This is main content</div> <div id=\"content\">This is content <p></p> <div id=\"adv\">This is advertisement</div> <p><a class=\"gototop\" href=\"#top\">Go to top</a> This is a sample of text typed in with no special formatting. This is a sample of text typed in with no special formatting This is a sample of text typed in with no special formatting This is a sample of text typed in with no special formatting. This is a sample of text typed in with no special formatting</p> This is text inside font tag!</div> <p><a name=\"PRE\"></a> This is text inside font tag! <a class=\"gototop\" href=\"#top\">Go to top</a></p> <div id=\"footer\">This is footer</div>"
+      }, {
+        "media_type" : "text/plain",
+        "text" : "This is text inside font tag! Sample HTML Formats TEXT This is a sample of text typed with no tags: HTML file This is a sample of text typed in with no special formatting. This is a sample of text typed in with no special formatting This is a sample of text typed in with no special formatting This is a sample of text typed in with no special formatting. This is a sample of text typed in with no special formatting This is main content This is content This is advertisement Go to top This is a sample of text typed in with no special formatting. This is a sample of text typed in with no special formatting This is a sample of text typed in with no special formatting This is a sample of text typed in with no special formatting. This is a sample of text typed in with no special formatting This is text inside font tag! This is text inside font tag! Go to top This is footer"
+      } ]
+    } ]
+  },
+  "solr_document" : {
+    "SomeMetadataName" : "SomeMetadataValue",
+    "body" : "This is text inside font tag! Sample HTML Formats TEXT This is a sample of text typed with no tags: HTML file This is a sample of text typed in with no special formatting. This is a sample of text typed in with no special formatting This is a sample of text typed in with no special formatting This is a sample of text typed in with no special formatting. This is a sample of text typed in with no special formatting This is main content This is content This is advertisement Go to top This is a sample of text typed in with no special formatting. This is a sample of text typed in with no special formatting This is a sample of text typed in with no special formatting This is a sample of text typed in with no special formatting. This is a sample of text typed in with no special formatting This is text inside font tag! This is text inside font tag! Go to top This is footer",
+    "contentHtml" : "This is text inside font tag! <center><h1>Sample HTML Formats</h1></center> <center><h1><img border=\"0\" height=\"39\" width=\"334\"></img></h1></center> <h2 start=\"2\">TEXT</h2> <b>This is a sample of text typed with no tags:</b> HTML file <br></br> This is a sample of text typed in with no special formatting. This is a sample of text typed in with no special formatting This is a sample of text typed in with no special formatting This is a sample of text typed in with no special formatting. This is a sample of text typed in with no special formatting <div id=\"maincontent\">This is main content</div> <div id=\"content\">This is content <p></p> <div id=\"adv\">This is advertisement</div> <p><a class=\"gototop\" href=\"#top\">Go to top</a> This is a sample of text typed in with no special formatting. This is a sample of text typed in with no special formatting This is a sample of text typed in with no special formatting This is a sample of text typed in with no special formatting. This is a sample of text typed in with no special formatting</p> This is text inside font tag!</div> <p><a name=\"PRE\"></a> This is text inside font tag! <a class=\"gototop\" href=\"#top\">Go to top</a></p> <div id=\"footer\">This is footer</div>",
+    "id" : "123",
+    "title" : "no-title"
+  }
+}


### PR DESCRIPTION
### Summary

This submission includes new API calls for the Document Conversion Service that will allow you to access the index_document endpoint:

```java
public ServiceCall<String> indexDocument(final IndexDocumentOptions indexDocumentOptions)
```
This is a synchronous call that will allow you to convert and index a document into a SOLR collection (via the Retrieve and Rank service) in one operation.  A "dry run" of the indexing can be submitted to preview the indexed results prior to actual indexing.