### PR TITLE
fix for VisualRecognitionExample

### DIFF
--- a/src/main/java/com/ibm/watson/developer_cloud/visual_recognition/v3/model/ClassifyImagesOptions.java
+++ b/src/main/java/com/ibm/watson/developer_cloud/visual_recognition/v3/model/ClassifyImagesOptions.java
@@ -128,7 +128,9 @@ public class ClassifyImagesOptions {
     /**
      * Instantiates a new builder.
      */
-    public Builder() {}
+    public Builder() {
+      this.classifierIds = new ArrayList<String>();
+    }
 
     /**
      * Builds the profile options.


### PR DESCRIPTION
simple fix for NullPointerException in `com.ibm.watson.developer_cloud.visual_recognition.v3.VisualRecognitionExample` "Classify using the 'Car' classifier" block