### PR TITLE
Ignore tests without credentials

### DIFF
--- a/src/test/java/com/ibm/watson/developer_cloud/MultiThreadTest.java
+++ b/src/test/java/com/ibm/watson/developer_cloud/MultiThreadTest.java
@@ -87,9 +87,9 @@ public class MultiThreadTest extends WatsonServiceTest {
   public void setUp() throws Exception {
     super.setUp();
     service = new LanguageTranslation();
-    service.setUsernameAndPassword(getValidProperty("language_translation.username"),
-        getValidProperty("language_translation.password"));
-    service.setEndPoint(getValidProperty("language_translation.url"));
+    service.setUsernameAndPassword(getProperty("language_translation.username"),
+        getProperty("language_translation.password"));
+    service.setEndPoint(getProperty("language_translation.url"));
   }
 
   /**

--- a/src/test/java/com/ibm/watson/developer_cloud/WatsonServiceTest.java
+++ b/src/test/java/com/ibm/watson/developer_cloud/WatsonServiceTest.java
@@ -43,6 +43,8 @@ public abstract class WatsonServiceTest {
 
   private static final String DEFAULT_PROPERTIES = "config.properties";
   private static final String LOCAL_PROPERTIES = ".config.properties";
+  protected static final String PLACEHOLDER = "SERVICE_USERNAME";
+
   private static final Logger LOG = Logger.getLogger(WatsonServiceTest.class.getName());
 
   protected static final String CONTENT_TYPE = "Content-Type";
@@ -66,42 +68,6 @@ public abstract class WatsonServiceTest {
     headers.put(HttpHeaders.X_WATSON_LEARNING_OPT_OUT, String.valueOf(true));
     headers.put(HttpHeaders.X_WATSON_TEST, String.valueOf(true));
     return headers;
-  }
-
-  /**
-   * The Class EmptyPropertyException.
-   */
-  private class EmptyPropertyException extends IllegalStateException {
-
-    /** The Constant serialVersionUID. */
-    private static final long serialVersionUID = 1L;
-
-    /**
-     * Instantiates a new empty property exception.
-     * 
-     * @param property the property
-     */
-    EmptyPropertyException(String property) {
-      super("Property " + property + " is empty. It's probably unset.");
-    }
-  }
-
-  /**
-   * The Class MissingPropertyException.
-   */
-  private class MissingPropertyException extends IllegalStateException {
-
-    /** The Constant serialVersionUID. */
-    private static final long serialVersionUID = 1L;
-
-    /**
-     * Instantiates a new missing property exception.
-     * 
-     * @param property the property
-     */
-    MissingPropertyException(String property) {
-      super("A property expected to exist does not exist: " + property);
-    }
   }
 
   /**
@@ -142,44 +108,13 @@ public abstract class WatsonServiceTest {
   protected static Properties PROPERTIES = null;
 
   /**
-   * Gets the existing property.
-   * 
-   * @param property the property
-   * @return the existing property
-   */
-  public String getExistingProperty(String property) {
-    final String value = PROPERTIES.getProperty(property);
-    if (value == null)
-      throw new MissingPropertyException(property);
-    return value;
-  }
-
-  /**
-   * Gets the existing property if exists, otherwise it returns the defaultValue.
-   *
-   * @param property the property
-   * @param defaultValue the default value
-   * @return the existing property
-   */
-  public String getExistingProperty(String property, String defaultValue) {
-    try {
-      return getExistingProperty(property);
-    } catch (MissingPropertyException me) {
-      return defaultValue;
-    }
-  }
-
-  /**
    * Gets the valid property.
    * 
    * @param property the property
    * @return the valid property
    */
-  public String getValidProperty(String property) {
-    final String value = getExistingProperty(property);
-    if ("".equals(value))
-      throw new EmptyPropertyException(property);
-    return value;
+  public String getProperty(String property) {
+    return PROPERTIES.getProperty(property);
   }
 
   private void loadProperties() {
@@ -191,9 +126,10 @@ public abstract class WatsonServiceTest {
     } else {
       LOG.info("Using " + LOCAL_PROPERTIES);
     }
-    if (input == null)
-      throw new RuntimeException(DEFAULT_PROPERTIES + " was not found.");
-
+    if (input == null) {
+      LOG.warning(DEFAULT_PROPERTIES + " was not found.");
+      return;
+    }
     // load a properties file from class path, inside static method
     try {
       PROPERTIES.load(input);

--- a/src/test/java/com/ibm/watson/developer_cloud/alchemy/v1/AlchemyDataNewsIT.java
+++ b/src/test/java/com/ibm/watson/developer_cloud/alchemy/v1/AlchemyDataNewsIT.java
@@ -21,6 +21,7 @@ import java.util.Map;
 
 import org.apache.commons.lang3.StringUtils;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -44,8 +45,12 @@ public class AlchemyDataNewsIT extends WatsonServiceTest {
   @Before
   public void setUp() throws Exception {
     super.setUp();
+    String apiKey = getProperty("alchemy.alchemy");
+    Assume.assumeFalse("config.properties doesn't have valid credentials.",
+        apiKey == null || apiKey.equals("API_KEY"));
+    
     service = new AlchemyDataNews();
-    service.setApiKey(getValidProperty("alchemy.alchemy"));
+    service.setApiKey(apiKey);
     service.setDefaultHeaders(getDefaultHeaders());
   }
 

--- a/src/test/java/com/ibm/watson/developer_cloud/alchemy/v1/AlchemyLanguageIT.java
+++ b/src/test/java/com/ibm/watson/developer_cloud/alchemy/v1/AlchemyLanguageIT.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -63,8 +64,13 @@ public class AlchemyLanguageIT extends WatsonServiceTest {
   @Before
   public void setUp() throws Exception {
     super.setUp();
+
+    String apiKey = getProperty("alchemy.alchemy");
+    Assume.assumeFalse("config.properties doesn't have valid credentials.",
+        apiKey == null || apiKey.equals("API_KEY"));
+
     service = new AlchemyLanguage();
-    service.setApiKey(getValidProperty("alchemy.alchemy"));
+    service.setApiKey(apiKey);
     service.setDefaultHeaders(getDefaultHeaders());
     htmlExample =
         getStringFromInputStream(new FileInputStream("src/test/resources/alchemy/example.html"));

--- a/src/test/java/com/ibm/watson/developer_cloud/alchemy/v1/AlchemyVisionIT.java
+++ b/src/test/java/com/ibm/watson/developer_cloud/alchemy/v1/AlchemyVisionIT.java
@@ -17,6 +17,7 @@ import java.io.File;
 import java.io.FileInputStream;
 
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -57,8 +58,13 @@ public class AlchemyVisionIT extends WatsonServiceTest {
   @Before
   public void setUp() throws Exception {
     super.setUp();
+    
+    String apiKey = getProperty("alchemy.alchemy");
+    Assume.assumeFalse("config.properties doesn't have valid credentials.",
+        apiKey == null || apiKey.equals("API_KEY"));
+
     service = new AlchemyVision();
-    service.setApiKey(getValidProperty("alchemy.alchemy"));
+    service.setApiKey(apiKey);
     service.setDefaultHeaders(getDefaultHeaders());
     htmlExample =
         getStringFromInputStream(new FileInputStream("src/test/resources/alchemy/example.html"));
@@ -85,7 +91,7 @@ public class AlchemyVisionIT extends WatsonServiceTest {
   /**
    * Test get ranked image scene text from image.
    */
-  @Test
+  @Test(timeout=180000)
   public void testGetRankedImageSceneTextFromImage() {
     final File imageFile = new File(IMAGE_COLORADO);
     final ImageSceneText image = service.getImageSceneText(imageFile).execute();

--- a/src/test/java/com/ibm/watson/developer_cloud/concept_insights/v2/ConceptInsightsIT.java
+++ b/src/test/java/com/ibm/watson/developer_cloud/concept_insights/v2/ConceptInsightsIT.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import java.util.UUID;
 
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -77,10 +78,14 @@ public class ConceptInsightsIT extends WatsonServiceTest {
   @Before
   public void setUp() throws Exception {
     super.setUp();
+    String username = getProperty("concept_insights.username");
+    
+    Assume.assumeFalse("config.properties doesn't have valid credentials.",
+        username == null || username.equals(PLACEHOLDER));
+    
     service = new ConceptInsights();
-    service.setUsernameAndPassword(getValidProperty("concept_insights.username"),
-        getValidProperty("concept_insights.password"));
-    service.setEndPoint(getValidProperty("concept_insights.url"));
+    service.setUsernameAndPassword(username, getProperty("concept_insights.password"));
+    service.setEndPoint(getProperty("concept_insights.url"));
     service.setDefaultHeaders(getDefaultHeaders());
   }
 

--- a/src/test/java/com/ibm/watson/developer_cloud/conversation/v1/ConversationServiceIT.java
+++ b/src/test/java/com/ibm/watson/developer_cloud/conversation/v1/ConversationServiceIT.java
@@ -17,6 +17,7 @@ import static org.junit.Assert.assertNotNull;
 
 import java.util.Map;
 
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -42,12 +43,15 @@ public class ConversationServiceIT extends WatsonServiceTest {
   @Before
   public void setUp() throws Exception {
     super.setUp();
-    workspaceId = getValidProperty("conversation.v1.workspace_id");
-    String username = getValidProperty("conversation.v1.username");
-    String password = getValidProperty("conversation.v1.password");
+    String username = getProperty("conversation.v1.username");
+    String password = getProperty("conversation.v1.password");
+    workspaceId = getProperty("conversation.v1.workspace_id");
 
+    Assume.assumeFalse("config.properties doesn't have valid credentials.",
+        username == null || username.equals(PLACEHOLDER));
+    
     service = new ConversationService(ConversationService.VERSION_DATE_2016_07_11);
-    service.setEndPoint(getValidProperty("conversation.v1.url"));
+    service.setEndPoint(getProperty("conversation.v1.url"));
     service.setUsernameAndPassword(username, password);
     service.setDefaultHeaders(getDefaultHeaders());
   }

--- a/src/test/java/com/ibm/watson/developer_cloud/conversation/v1_experimental/ConversationServiceIT.java
+++ b/src/test/java/com/ibm/watson/developer_cloud/conversation/v1_experimental/ConversationServiceIT.java
@@ -17,6 +17,7 @@ import static org.junit.Assert.assertNotNull;
 
 import java.util.Map;
 
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -43,12 +44,15 @@ public class ConversationServiceIT extends WatsonServiceTest {
   @Before
   public void setUp() throws Exception {
     super.setUp();
-    workspaceId = getValidProperty("conversation.v1_experimental.workspace_id");
-    String username = getValidProperty("conversation.v1_experimental.username");
-    String password = getValidProperty("conversation.v1_experimental.password");
+    workspaceId = getProperty("conversation.v1_experimental.workspace_id");
+    String username = getProperty("conversation.v1_experimental.username");
+    String password = getProperty("conversation.v1_experimental.password");
+
+    Assume.assumeFalse("config.properties doesn't have valid credentials.",
+        username == null || username.equals(PLACEHOLDER));
 
     service = new ConversationService(ConversationService.VERSION_DATE_2016_05_19);
-    service.setEndPoint(getValidProperty("conversation.v1_experimental.url"));
+    service.setEndPoint(getProperty("conversation.v1_experimental.url"));
     service.setUsernameAndPassword(username, password);
     service.setDefaultHeaders(getDefaultHeaders());
   }

--- a/src/test/java/com/ibm/watson/developer_cloud/dialog/v1/DialogServiceIT.java
+++ b/src/test/java/com/ibm/watson/developer_cloud/dialog/v1/DialogServiceIT.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.UUID;
 
 import org.apache.commons.lang3.time.DateUtils;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -61,11 +62,17 @@ public class DialogServiceIT extends WatsonServiceTest {
   @Before
   public void setUp() throws Exception {
     super.setUp();
+    String username = getProperty("dialog.username");
+    String password = getProperty("dialog.password");
+    
+    Assume.assumeFalse("config.properties doesn't have valid credentials.",
+        username == null || username.equals(PLACEHOLDER));
+
     service = new DialogService();
-    service.setUsernameAndPassword(getValidProperty("dialog.username"), getValidProperty("dialog.password"));
-    service.setEndPoint(getValidProperty("dialog.url"));
+    service.setUsernameAndPassword(username, password);
+    service.setEndPoint(getProperty("dialog.url"));
     service.setDefaultHeaders(getDefaultHeaders());
-    dialogId = getValidProperty("dialog.dialog_id");
+    dialogId = getProperty("dialog.dialog_id");
   }
 
   /**

--- a/src/test/java/com/ibm/watson/developer_cloud/document_conversion/v1/DocumentConversionIT.java
+++ b/src/test/java/com/ibm/watson/developer_cloud/document_conversion/v1/DocumentConversionIT.java
@@ -23,6 +23,7 @@ import com.ibm.watson.developer_cloud.document_conversion.v1.model.IndexConfigur
 import com.ibm.watson.developer_cloud.document_conversion.v1.model.IndexDocumentOptions;
 import com.ibm.watson.developer_cloud.document_conversion.v1.model.IndexFields;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -52,11 +53,15 @@ public class DocumentConversionIT extends WatsonServiceTest {
   public void setUp() throws Exception {
     super.setUp();
     service = new DocumentConversion(DocumentConversion.VERSION_DATE_2015_12_01);
+    String username = getProperty("document_conversion.username");
+    Assume.assumeFalse("config.properties doesn't have valid credentials.",
+        username == null || username.equals("SERVICE_USERNAME"));
+    
     service.setUsernameAndPassword(
-        getExistingProperty("document_conversion.username"),
-        getExistingProperty("document_conversion.password")
+        username,
+        getProperty("document_conversion.password")
     );
-    service.setEndPoint(getExistingProperty("document_conversion.url"));
+    service.setEndPoint(getProperty("document_conversion.url"));
     service.setDefaultHeaders(getDefaultHeaders());
     files = new File[] {new File("src/test/resources/document_conversion/word-docx-heading-input.docx"),
         new File("src/test/resources/document_conversion/word-document-heading-input.doc"),

--- a/src/test/java/com/ibm/watson/developer_cloud/document_conversion/v1/DocumentConversionTest.java
+++ b/src/test/java/com/ibm/watson/developer_cloud/document_conversion/v1/DocumentConversionTest.java
@@ -255,7 +255,8 @@ public class DocumentConversionTest extends WatsonServiceUnitTest {
         
     // metadata
     assertTrue(body.contains("Content-Disposition: form-data; name=\"metadata\""));
-    assertTrue(body.contains("{\"metadata\":[{\"name\":\"id\",\"value\":\"123\"},{\"name\":\"SomeMetadataName\",\"value\":\"SomeMetadataValue\"}]}"));
-
+    assertTrue(body.contains("{\"metadata\""));
+    assertTrue(body.contains("{\"name\":\"id\",\"value\":\"123\"}"));
+    assertTrue(body.contains("{\"name\":\"SomeMetadataName\",\"value\":\"SomeMetadataValue\"}"));
   }
 }

--- a/src/test/java/com/ibm/watson/developer_cloud/language_translation/v2/LanguageTranslationIT.java
+++ b/src/test/java/com/ibm/watson/developer_cloud/language_translation/v2/LanguageTranslationIT.java
@@ -24,6 +24,7 @@ import java.io.File;
 import java.util.List;
 import java.util.Map;
 
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -60,10 +61,15 @@ public class LanguageTranslationIT extends WatsonServiceTest {
   @Before
   public void setUp() throws Exception {
     super.setUp();
+    String username = getProperty("language_translation.username");
+    String password = getProperty("language_translation.password");
+    
+    Assume.assumeFalse("config.properties doesn't have valid credentials.",
+        username == null || username.equals(PLACEHOLDER));
+
     service = new LanguageTranslation();
-    service.setUsernameAndPassword(getValidProperty("language_translation.username"),
-        getValidProperty("language_translation.password"));
-    service.setEndPoint(getValidProperty("language_translation.url"));
+    service.setUsernameAndPassword(username, password);
+    service.setEndPoint(getProperty("language_translation.url"));
     service.setDefaultHeaders(getDefaultHeaders());
   }
 

--- a/src/test/java/com/ibm/watson/developer_cloud/natural_language_classifier/v1/NaturalLanguageClassifierIT.java
+++ b/src/test/java/com/ibm/watson/developer_cloud/natural_language_classifier/v1/NaturalLanguageClassifierIT.java
@@ -112,12 +112,17 @@ public class NaturalLanguageClassifierIT extends WatsonServiceTest {
   @Before
   public void setUp() throws Exception {
     super.setUp();
+    String username = getProperty("natural_language_classifier.username");
+    String password = getProperty("natural_language_classifier.password");
+    
+    Assume.assumeFalse("config.properties doesn't have valid credentials.",
+        username == null || username.equals(PLACEHOLDER));
+    
     service = new NaturalLanguageClassifier();
     service.setDefaultHeaders(getDefaultHeaders());
-    service.setUsernameAndPassword(getValidProperty("natural_language_classifier.username"),
-        getValidProperty("natural_language_classifier.password"));
-    service.setEndPoint(getValidProperty("natural_language_classifier.url"));
-    classifierId = getValidProperty("natural_language_classifier.classifier_id");
+    service.setUsernameAndPassword(username, password);
+    service.setEndPoint(getProperty("natural_language_classifier.url"));
+    classifierId = getProperty("natural_language_classifier.classifier_id");
   }
 
   /**

--- a/src/test/java/com/ibm/watson/developer_cloud/personality_insights/v2/PersonalityInsightsIT.java
+++ b/src/test/java/com/ibm/watson/developer_cloud/personality_insights/v2/PersonalityInsightsIT.java
@@ -20,6 +20,7 @@ import java.io.FileInputStream;
 import java.util.Collections;
 import java.util.Date;
 
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -46,10 +47,15 @@ public class PersonalityInsightsIT extends WatsonServiceTest {
   @Before
   public void setUp() throws Exception {
     super.setUp();
+    String username = getProperty("personality_insights.username");
+    String password = getProperty("personality_insights.password");
+    
+    Assume.assumeFalse("config.properties doesn't have valid credentials.",
+        username == null || username.equals(PLACEHOLDER));
+    
     service = new PersonalityInsights();
-    service.setUsernameAndPassword(getValidProperty("personality_insights.username"),
-        getValidProperty("personality_insights.password"));
-    service.setEndPoint(getValidProperty("personality_insights.url"));
+    service.setUsernameAndPassword(username, password);
+    service.setEndPoint(getProperty("personality_insights.url"));
     service.setDefaultHeaders(getDefaultHeaders());
   }
 

--- a/src/test/java/com/ibm/watson/developer_cloud/retrieve_and_rank/v1/RetrieveAndRankIT.java
+++ b/src/test/java/com/ibm/watson/developer_cloud/retrieve_and_rank/v1/RetrieveAndRankIT.java
@@ -73,13 +73,18 @@ public class RetrieveAndRankIT extends WatsonServiceTest {
   @Before
   public void setUp() throws Exception {
     super.setUp();
+    String username = getProperty("retrieve_and_rank.username");
+    String password = getProperty("retrieve_and_rank.password");
+    
+    Assume.assumeFalse("config.properties doesn't have valid credentials.",
+        username == null || username.equals(PLACEHOLDER));
+
     service = new RetrieveAndRank();
-    service.setUsernameAndPassword(getValidProperty("retrieve_and_rank.username"),
-        getValidProperty("retrieve_and_rank.password"));
-    service.setEndPoint(getValidProperty("retrieve_and_rank.url"));
+    service.setUsernameAndPassword(username, password);
+    service.setEndPoint(getProperty("retrieve_and_rank.url"));
     service.setDefaultHeaders(getDefaultHeaders());
-    rankerId = getValidProperty("retrieve_and_rank.ranker_id");
-    clusterId = getValidProperty("retrieve_and_rank.cluster_id");
+    rankerId = getProperty("retrieve_and_rank.ranker_id");
+    clusterId = getProperty("retrieve_and_rank.cluster_id");
   }
 
   /**

--- a/src/test/java/com/ibm/watson/developer_cloud/speech_to_text/v1/SpeechToTextIT.java
+++ b/src/test/java/com/ibm/watson/developer_cloud/speech_to_text/v1/SpeechToTextIT.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -58,10 +59,16 @@ public class SpeechToTextIT extends WatsonServiceTest {
   @Before
   public void setUp() throws Exception {
     super.setUp();
+    
+    String username = getProperty("speech_to_text.username");
+    String password = getProperty("speech_to_text.password");
+    
+    Assume.assumeFalse("config.properties doesn't have valid credentials.",
+        username == null || username.equals(PLACEHOLDER));
+
     service = new SpeechToText();
-    service.setUsernameAndPassword(getValidProperty("speech_to_text.username"),
-        getValidProperty("speech_to_text.password"));
-    service.setEndPoint(getValidProperty("speech_to_text.url"));
+    service.setUsernameAndPassword(username, password);
+    service.setEndPoint(getProperty("speech_to_text.url"));
     service.setDefaultHeaders(getDefaultHeaders());
   }
 

--- a/src/test/java/com/ibm/watson/developer_cloud/text_to_speech/v1/CustomizationsIT.java
+++ b/src/test/java/com/ibm/watson/developer_cloud/text_to_speech/v1/CustomizationsIT.java
@@ -25,6 +25,7 @@ import java.io.InputStream;
 import java.util.List;
 
 import org.junit.After;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -57,11 +58,14 @@ public class CustomizationsIT extends WatsonServiceTest {
   @Before
   public void setUp() throws Exception {
     super.setUp();
-
+    String username = getProperty("text_to_speech.username");
+    Assume.assumeFalse("config.properties doesn't have valid credentials.",
+        username ==null || username.equals(PLACEHOLDER));
+    
     service = new TextToSpeech();
-    service.setUsernameAndPassword(getExistingProperty("text_to_speech.username"),
-        getExistingProperty("text_to_speech.password"));
-    service.setEndPoint(getExistingProperty("text_to_speech.url"));
+    service.setUsernameAndPassword(username,
+        getProperty("text_to_speech.password"));
+    service.setEndPoint(getProperty("text_to_speech.url"));
     service.setDefaultHeaders(getDefaultHeaders());
   }
 

--- a/src/test/java/com/ibm/watson/developer_cloud/text_to_speech/v1/TextToSpeechIT.java
+++ b/src/test/java/com/ibm/watson/developer_cloud/text_to_speech/v1/TextToSpeechIT.java
@@ -36,6 +36,7 @@ import javax.sound.sampled.AudioSystem;
 import javax.sound.sampled.UnsupportedAudioFileException;
 
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -63,13 +64,15 @@ public class TextToSpeechIT extends WatsonServiceTest {
   @Before
   public void setUp() throws Exception {
     super.setUp();
+    String username = getProperty("text_to_speech.username");
+    Assume.assumeFalse("config.properties doesn't have valid credentials.", 
+        username == null || username.equals(PLACEHOLDER));
+
     service = new TextToSpeech();
-    service.setUsernameAndPassword(
-        getExistingProperty("text_to_speech.username"),
-        getExistingProperty("text_to_speech.password"));
-    service.setEndPoint(getExistingProperty("text_to_speech.url"));
+    service.setUsernameAndPassword(username, getProperty("text_to_speech.password"));
+    service.setEndPoint(getProperty("text_to_speech.url"));
     service.setDefaultHeaders(getDefaultHeaders());
-    voiceName = getExistingProperty("text_to_speech.voice_name");
+    voiceName = getProperty("text_to_speech.voice_name");
   }
 
 

--- a/src/test/java/com/ibm/watson/developer_cloud/tone_analyzer/v3/ToneAnalyzerIT.java
+++ b/src/test/java/com/ibm/watson/developer_cloud/tone_analyzer/v3/ToneAnalyzerIT.java
@@ -16,6 +16,7 @@ package com.ibm.watson.developer_cloud.tone_analyzer.v3;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -45,10 +46,16 @@ public class ToneAnalyzerIT extends WatsonServiceTest {
   @Before
   public void setUp() throws Exception {
     super.setUp();
+    
+    String username = getProperty("tone_analyzer.v3.username");
+        
+    Assume.assumeFalse("config.properties doesn't have valid credentials.",
+        username == null || username.equals(PLACEHOLDER));
+    
     service = new ToneAnalyzer(ToneAnalyzer.VERSION_DATE_2016_05_19);
-    service.setUsernameAndPassword(getValidProperty("tone_analyzer.v3.username"),
-        getValidProperty("tone_analyzer.v3.password"));
-    service.setEndPoint(getValidProperty("tone_analyzer.v3.url"));
+    service.setUsernameAndPassword(username,
+        getProperty("tone_analyzer.v3.password"));
+    service.setEndPoint(getProperty("tone_analyzer.v3.url"));
     service.setDefaultHeaders(getDefaultHeaders());
 
   }

--- a/src/test/java/com/ibm/watson/developer_cloud/tradeoff_analytics/v1/TradeoffAnalyticsIT.java
+++ b/src/test/java/com/ibm/watson/developer_cloud/tradeoff_analytics/v1/TradeoffAnalyticsIT.java
@@ -20,6 +20,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -52,10 +53,16 @@ public class TradeoffAnalyticsIT extends WatsonServiceTest {
   @Before
   public void setUp() throws Exception {
     super.setUp();
+    
+    String username = getProperty("tradeoff_analytics.username");
+    
+    Assume.assumeFalse("config.properties doesn't have valid credentials.",
+        username == null || username.equals(PLACEHOLDER));
+    
     service = new TradeoffAnalytics();
-    service.setUsernameAndPassword(getValidProperty("tradeoff_analytics.username"),
-        getValidProperty("tradeoff_analytics.password"));
-    service.setEndPoint(getValidProperty("tradeoff_analytics.url"));
+    service.setUsernameAndPassword(username,
+        getProperty("tradeoff_analytics.password"));
+    service.setEndPoint(getProperty("tradeoff_analytics.url"));
     service.setDefaultHeaders(getDefaultHeaders());
     problem = loadFixture("src/test/resources/tradeoff_analytics/problem.json", Problem.class);
   }

--- a/src/test/java/com/ibm/watson/developer_cloud/visual_recognition/v3/VisualRecognitionIT.java
+++ b/src/test/java/com/ibm/watson/developer_cloud/visual_recognition/v3/VisualRecognitionIT.java
@@ -22,6 +22,7 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.util.List;
 
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -114,8 +115,12 @@ public class VisualRecognitionIT extends WatsonServiceTest {
   @Before
   public void setUp() throws Exception {
     super.setUp();
+    String apiKey = getProperty("visual_recognition.v3.api_key");
+    Assume.assumeFalse("config.properties doesn't have valid credentials.",
+        apiKey == null || apiKey.equals("API_KEY"));
+    
     service = new VisualRecognition(VisualRecognition.VERSION_DATE_2016_05_20);
-    service.setApiKey(getValidProperty("visual_recognition.v3.api_key"));
+    service.setApiKey(apiKey);
     service.setDefaultHeaders(getDefaultHeaders());
   }
 

--- a/src/test/resources/config.properties
+++ b/src/test/resources/config.properties
@@ -1,10 +1,6 @@
 # SERVICE CREDENTIALS
 
-alchemy.alchemy=ALCHEMY_API_KEY_HERE
-
-concept_insights.password=SERVICE_PASSWORD
-concept_insights.url=SERVICE_URL
-concept_insights.username=SERVICE_USERNAME
+alchemy.alchemy=API_KEY
 
 conversation.username=SERVICE_USERNAME
 conversation.password=SERVICE_PASSWORD
@@ -25,9 +21,6 @@ language_translation.password=SERVICE_PASSWORD
 language_translation.url=SERVICE_URL
 language_translation.username=SERVICE_USERNAME
 
-mock.server.host=PLACEHOLDER
-mock.server.port=PLACEHOLDER
-
 natural_language_classifier.classifier_id=PLACEHOLDER
 natural_language_classifier.password=SERVICE_PASSWORD
 natural_language_classifier.url=SERVICE_URL
@@ -36,10 +29,6 @@ natural_language_classifier.username=SERVICE_USERNAME
 personality_insights.password=SERVICE_PASSWORD
 personality_insights.url=SERVICE_URL
 personality_insights.username=SERVICE_USERNAME
-
-relationship_extraction.password=SERVICE_PASSWORD
-relationship_extraction.url=SERVICE_URL
-relationship_extraction.username=SERVICE_USERNAME
 
 retrieve_and_rank.cluster_id=PLACEHOLDER
 retrieve_and_rank.config_name=PLACEHOLDER

--- a/src/test/resources/logging.properties
+++ b/src/test/resources/logging.properties
@@ -4,5 +4,5 @@ java.util.logging.ConsoleHandler.formatter=java.util.logging.SimpleFormatter
 java.util.logging.SimpleFormatter.format=%1$tb %1$td, %1$tY %1$tl:%1$tM:%1$tS %1$Tp %2$s %4$s: %5$s%n
 .level=SEVERE
 okhttp3.level=FINE
-okhttp3.mockwebserver=WARNING
+okhttp3.mockwebserver.level=WARNING
 com.ibm.watson.level=FINE


### PR DESCRIPTION
This pull request will ignore integration tests if the `config.properties` file does’t have credentials to run them.