### PR TITLE
ENH:  Added the customization id for a custom language model

### DIFF
--- a/src/main/java/com/ibm/watson/developer_cloud/speech_to_text/v1/SpeechToText.java
+++ b/src/main/java/com/ibm/watson/developer_cloud/speech_to_text/v1/SpeechToText.java
@@ -54,6 +54,7 @@ import okhttp3.ws.WebSocket;
  */
 public class SpeechToText extends WatsonService {
 
+  private static final String CUSTOM_MODEL = "customization_id";
   private static final String CONTINUOUS = "continuous";
   private static final String INACTIVITY_TIMEOUT = "inactivity_timeout";
   private static final String KEYWORDS = "keywords";
@@ -108,6 +109,9 @@ public class SpeechToText extends WatsonService {
     if (options == null)
       return;
 
+    if (options.customizationID() != null)
+        requestBuilder.query(CUSTOM_MODEL, options.customizationID());
+    
     if (options.wordConfidence() != null)
       requestBuilder.query(WORD_CONFIDENCE, options.wordConfidence());
 

--- a/src/main/java/com/ibm/watson/developer_cloud/speech_to_text/v1/model/RecognizeOptions.java
+++ b/src/main/java/com/ibm/watson/developer_cloud/speech_to_text/v1/model/RecognizeOptions.java
@@ -104,6 +104,17 @@ public class RecognizeOptions {
     }
 
     /**
+     * The customization ID to enter for the model.
+     * 
+     * @param customizationId of the model
+     * @return the recognize options
+     */
+    public Builder customizationID(String customizationID){
+        this.customizationID = customizationID;
+        return this;
+    } 
+    
+    /**
      * If <code>true</code>, converts dates, times, series of digits and numbers, phone numbers, currency values,
      * and Internet addresses into more readable, conventional representations in the final
      * transcript of a recognition request. If <code>false</code> (the default), no formatting is performed.

--- a/src/main/java/com/ibm/watson/developer_cloud/speech_to_text/v1/model/RecognizeOptions.java
+++ b/src/main/java/com/ibm/watson/developer_cloud/speech_to_text/v1/model/RecognizeOptions.java
@@ -30,6 +30,7 @@ public class RecognizeOptions {
    * Builder.
    */
   public static class Builder {
+	private String customizationID;
     private String contentType;
     private Boolean continuous;
     private Integer inactivityTimeout;
@@ -46,6 +47,7 @@ public class RecognizeOptions {
     private Boolean smartFormatting;
 
     private Builder(RecognizeOptions options) {
+      this.customizationID = options.customizationID;
       this.contentType = options.contentType;
       this.continuous = options.continuous;
       this.inactivityTimeout = options.inactivityTimeout;
@@ -288,6 +290,9 @@ public class RecognizeOptions {
   private Boolean interimResults;
   private String[] keywords;
 
+  @SerializedName("customization_id")
+  private String customizationID;
+  
   @SerializedName("keywords_threshold")
   private Double keywordsThreshold;
   private Integer maxAlternatives;
@@ -303,6 +308,7 @@ public class RecognizeOptions {
   private Boolean smartFormatting;
   
   private RecognizeOptions(Builder builder) {
+	this.customizationID = builder.customizationID;
     this.contentType = builder.contentType;
     this.continuous = builder.continuous;
     this.inactivityTimeout = builder.inactivityTimeout;
@@ -319,6 +325,15 @@ public class RecognizeOptions {
     this.smartFormatting = builder.smartFormatting;
   }
 
+  /**
+   * Gets the customization id.
+   * 
+   * @return the customization id
+   */
+  public String customizationID() {
+    return customizationID;
+  }
+  
   /**
    * Gets the content type.
    * 


### PR DESCRIPTION
### Summary

I added the functionality to include a customization id so that we can specify a language model to use during the recognize service call.


Thanks for contributing to the Watson Developer Cloud!
… call to recognize the audio for speech to text.