### PR TITLE
setSkipAuthentication  fixes for STT

### DIFF
--- a/src/main/java/com/ibm/watson/developer_cloud/speech_to_text/v1/websocket/WebSocketManager.java
+++ b/src/main/java/com/ibm/watson/developer_cloud/speech_to_text/v1/websocket/WebSocketManager.java
@@ -265,10 +265,11 @@ public class WebSocketManager {
    */
   private WebSocketCall createConnection(RecognizeOptions options) {
     String speechModel = options.model() == null ? "" : "?model=" + options.model();
-    Request connectionRequest = new Request.Builder()
-      .url(url + speechModel)
-      .addHeader(HttpHeaders.X_WATSON_AUTHORIZATION_TOKEN, token)
-      .build();
+    Request.Builder connectionRequestBuilder = new Request.Builder();
+    connectionRequestBuilder.url(url + speechModel);
+    if (token != null)
+      connectionRequestBuilder.addHeader(HttpHeaders.X_WATSON_AUTHORIZATION_TOKEN, token);
+    Request connectionRequest = connectionRequestBuilder.build();
 
     return WebSocketCall.create(client, connectionRequest);
   }


### PR DESCRIPTION
### Summary

com.ibm.watson.developer_cloud.speech_to_text.v1.SpeechToText changes: recognizeUsingWebSocket method checks is skip authentication was set
com.ibm.watson.developer_cloud.speech_to_text.v1.websocket.WebSocketManager changes: createConnection method only sets X_WATSON_AUTHORIZATION_TOKEN header if token is not null

### Other Information

If there's anything else that's important and relevant to your pull
request, mention that information here.


Thanks for contributing to the Watson Developer Cloud!