### PR TITLE
Adds test for DateDeserializer parser

### DIFF
--- a/core/src/main/java/com/ibm/watson/developer_cloud/util/DateDeserializer.java
+++ b/core/src/main/java/com/ibm/watson/developer_cloud/util/DateDeserializer.java
@@ -46,7 +46,8 @@ public class DateDeserializer implements JsonDeserializer<Date> {
   private final SimpleDateFormat utcWithSecondsDateFormatter = new SimpleDateFormat(DATE_WITH_SECONDS);
 
   private final List<SimpleDateFormat> dateFormatters =
-      Arrays.asList(utcDateFormatter, utcWithoutSecondsDateFormatter, dialogDateFormatter, alchemyDateFormatter, utcWithSecondsDateFormatter);
+      Arrays.asList(utcDateFormatter, utcWithoutSecondsDateFormatter, dialogDateFormatter,
+              alchemyDateFormatter, utcWithSecondsDateFormatter);
 
   private static final Logger LOG = Logger.getLogger(DateDeserializer.class.getName());
 

--- a/core/src/main/java/com/ibm/watson/developer_cloud/util/DateDeserializer.java
+++ b/core/src/main/java/com/ibm/watson/developer_cloud/util/DateDeserializer.java
@@ -36,15 +36,17 @@ public class DateDeserializer implements JsonDeserializer<Date> {
   /** The Constant DATE_UTC. */
   protected static final String DATE_UTC = "yyyy-MM-dd'T'HH:mm:ss.SSS";
   private static final String DATE_WITHOUT_SECONDS = "yyyy-MM-dd'T'HH:mm:ssZ";
+  private static final String DATE_WITH_SECONDS = "yyyy-MM-dd'T'HH:mm:ss";
 
   // SimpleDateFormat is NOT thread safe - they require private visibility and synchronized access
   private final SimpleDateFormat alchemyDateFormatter = new SimpleDateFormat(DATE_FROM_ALCHEMY);
   private final SimpleDateFormat dialogDateFormatter = new SimpleDateFormat(DATE_FROM_DIALOG);
   private final SimpleDateFormat utcDateFormatter = new SimpleDateFormat(DATE_UTC);
   private final SimpleDateFormat utcWithoutSecondsDateFormatter = new SimpleDateFormat(DATE_WITHOUT_SECONDS);
+  private final SimpleDateFormat utcWithSecondsDateFormatter = new SimpleDateFormat(DATE_WITH_SECONDS);
 
   private final List<SimpleDateFormat> dateFormatters =
-      Arrays.asList(utcDateFormatter, utcWithoutSecondsDateFormatter, dialogDateFormatter, alchemyDateFormatter);
+      Arrays.asList(utcDateFormatter, utcWithoutSecondsDateFormatter, dialogDateFormatter, alchemyDateFormatter, utcWithSecondsDateFormatter);
 
   private static final Logger LOG = Logger.getLogger(DateDeserializer.class.getName());
 

--- a/src/test/java/com/ibm/watson/developer_cloud/util/DateDeserializerTest.java
+++ b/src/test/java/com/ibm/watson/developer_cloud/util/DateDeserializerTest.java
@@ -1,0 +1,21 @@
+package com.ibm.watson.developer_cloud.util;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class DateDeserializerTest {
+
+    @Test
+    public void testDeserialize() {
+        String jsonStr = "[\"2016-06-20T04:25:16.218+0000\", \"2016-06-20T04:25:16\", \"2016-06-20T04:25:16.218Z\",\"2015-05-28T18:01:57Z\",\"2016-06-20T04:25:16.218+0000\"]";
+        JsonParser parser = new JsonParser();
+        JsonElement element = parser.parse(jsonStr);
+        DateDeserializer deserializer = new DateDeserializer();
+        for (int i = 0; i < 5; i++) {
+            assertTrue(deserializer.deserialize(element.getAsJsonArray().get(i), null, null) != null);
+        }
+    }
+}

--- a/src/test/java/com/ibm/watson/developer_cloud/util/DateDeserializerTest.java
+++ b/src/test/java/com/ibm/watson/developer_cloud/util/DateDeserializerTest.java
@@ -2,6 +2,8 @@ package com.ibm.watson.developer_cloud.util;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
+import com.sun.tools.javac.util.List;
+import org.apache.commons.lang3.StringUtils;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
@@ -10,7 +12,13 @@ public class DateDeserializerTest {
 
     @Test
     public void testDeserialize() {
-        String jsonStr = "[\"2016-06-20T04:25:16.218+0000\", \"2016-06-20T04:25:16\", \"2016-06-20T04:25:16.218Z\",\"2015-05-28T18:01:57Z\",\"2016-06-20T04:25:16.218+0000\"]";
+        String[] dateStrings = {"2016-06-20T04:25:16.218+0000",
+                "2016-06-20T04:25:16",
+                "2016-06-20T04:25:16.218Z",
+                "2015-05-28T18:01:57Z",
+                "2016-06-20T04:25:16.218+0000"};
+
+        String jsonStr = "[\"" + StringUtils.join(dateStrings,"\",\"") + "\"]";
         JsonParser parser = new JsonParser();
         JsonElement element = parser.parse(jsonStr);
         DateDeserializer deserializer = new DateDeserializer();


### PR DESCRIPTION
The parser had no tests.  I was looking at #445 and thought I'd
add one (even though the test itself is trivial).  Also adds one
slightly more liberal date format for time parsing.