### PR TITLE
Do not validate upper size limit when creating R&R clusters.

### DIFF
--- a/retrieve-and-rank/src/main/java/com/ibm/watson/developer_cloud/retrieve_and_rank/v1/RetrieveAndRank.java
+++ b/retrieve-and-rank/src/main/java/com/ibm/watson/developer_cloud/retrieve_and_rank/v1/RetrieveAndRank.java
@@ -452,8 +452,7 @@ public class RetrieveAndRank extends WatsonService implements ClusterLifecycleMa
   @Override
   public ServiceCall<SolrClusterSizeResponse> resizeSolrCluster(String solrClusterId, int requestedSize) {
     Validator.isTrue((solrClusterId != null) && !solrClusterId.isEmpty(), "solrClusterId cannot be null or empty");
-    Validator.isTrue((requestedSize > 0) && (requestedSize < 8),
-        "clusterSize cannot be lower than 0 or greater than 7");
+    Validator.isTrue((requestedSize > 0), "clusterSize cannot be lower than 0");
 
     final Request request = buildResizeRequest(solrClusterId, requestedSize);
     return createServiceCall(request, ResponseConverterUtils.getObject(SolrClusterSizeResponse.class));


### PR DESCRIPTION
### Summary

We currently support up to size 14 clusters and may increase that
in the future. We don't want to have to update the client code
every time we change the upper limit. Our service will respond
with appropriate error messages if the size passed in is too large.