### PR TITLE
Throw unchecked exception in ServiceCall interface

### DIFF
--- a/core/src/main/java/com/ibm/watson/developer_cloud/http/ServiceCall.java
+++ b/core/src/main/java/com/ibm/watson/developer_cloud/http/ServiceCall.java
@@ -25,8 +25,9 @@ public interface ServiceCall<T> {
    * Synchronous request.
    *
    * @return the generic type
+   * @throws RuntimeException the exception from HTTP request
    */
-  T execute();
+  T execute() throws RuntimeException;
 
   /**
    * Asynchronous requests, in this case, you receive a callback when the data has been received.


### PR DESCRIPTION
### Summary

Nice to tell developers that the implementation of ServiceCall.execute() will throw an unchecked exception (RuntimeException) that they can choose to handle or not