### PR TITLE
Deals with a situation where epoch seconds

### DIFF
--- a/core/src/main/java/com/ibm/watson/developer_cloud/util/DateDeserializer.java
+++ b/core/src/main/java/com/ibm/watson/developer_cloud/util/DateDeserializer.java
@@ -20,6 +20,8 @@ import java.util.Date;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonDeserializer;
@@ -74,6 +76,20 @@ public class DateDeserializer implements JsonDeserializer<Date> {
       } catch (ParseException e1) {
         e = e1;
       }
+    }
+
+    Pattern isJustNumber = Pattern.compile("^\\d+$");
+    Matcher foundMatch = isJustNumber.matcher(dateAsString);
+    if (foundMatch.find()) {
+      Long time_t = Long.parseLong(dateAsString);
+      Long msCheck = 1000000000000L;
+
+      // are we ms or seconds maybe?
+      if (time_t > msCheck) {
+        // assuming milliseconds
+        time_t = time_t / 1000;
+      }
+      return new Date(time_t);
     }
 
     LOG.log(Level.SEVERE, "Error parsing: " + dateAsString, e);

--- a/core/src/main/java/com/ibm/watson/developer_cloud/util/DateDeserializer.java
+++ b/core/src/main/java/com/ibm/watson/developer_cloud/util/DateDeserializer.java
@@ -81,15 +81,15 @@ public class DateDeserializer implements JsonDeserializer<Date> {
     Pattern isJustNumber = Pattern.compile("^\\d+$");
     Matcher foundMatch = isJustNumber.matcher(dateAsString);
     if (foundMatch.find()) {
-      Long time_t = Long.parseLong(dateAsString);
+      Long timeAsLong = Long.parseLong(dateAsString);
       Long msCheck = 1000000000000L;
 
       // are we ms or seconds maybe?
-      if (time_t > msCheck) {
+      if (timeAsLong > msCheck) {
         // assuming milliseconds
-        time_t = time_t / 1000;
+        timeAsLong = timeAsLong / 1000;
       }
-      return new Date(time_t);
+      return new Date(timeAsLong);
     }
 
     LOG.log(Level.SEVERE, "Error parsing: " + dateAsString, e);

--- a/tests/src/test/java/com/ibm/watson/developer_cloud/util/DateDeserializerTest.java
+++ b/tests/src/test/java/com/ibm/watson/developer_cloud/util/DateDeserializerTest.java
@@ -36,14 +36,16 @@ public class DateDeserializerTest {
             "2016-06-20T04:25:16",
             "2016-06-20T04:25:16.218Z",
             "2015-05-28T18:01:57Z",
-            "2016-06-20T04:25:16.218+0000"
+            "2016-06-20T04:25:16.218+0000",
+            "1477796981",
+            "1477796981000"
         };
 
         String jsonStr = "[\"" + StringUtils.join(dateStrings, "\",\"") + "\"]";
         JsonParser parser = new JsonParser();
         JsonElement element = parser.parse(jsonStr);
         DateDeserializer deserializer = new DateDeserializer();
-        for (int i = 0; i < 5; i++) {
+        for (int i = 0; i < dateStrings.length; i++) {
           System.out.println(deserializer.deserialize(element.getAsJsonArray().get(i), null, null));
             assertTrue(deserializer.deserialize(element.getAsJsonArray().get(i), null, null) != null);
         }


### PR DESCRIPTION
It appears that sometimes epoch seconds are used in dates instead of
a normal string date.  The date deserialize was modified to include
the ability to accept both epoch seconds and epoch milliseconds as
well as normal dates.

Fixes #474