### PR TITLE
add new tests for NLC

### DIFF
--- a/tests/src/test/java/com/ibm/watson/developer_cloud/natural_language_classifier/v1/NaturalLanguageClassifierIT.java
+++ b/tests/src/test/java/com/ibm/watson/developer_cloud/natural_language_classifier/v1/NaturalLanguageClassifierIT.java
@@ -38,121 +38,121 @@ import com.ibm.watson.developer_cloud.service.exception.NotFoundException;
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class NaturalLanguageClassifierIT extends WatsonServiceTest {
 
-	/** The classifier id. */
-	private static String classifierId = null;
-	private String preCreatedClassifierId;
+  /** The classifier id. */
+  private static String classifierId = null;
+  private String preCreatedClassifierId;
 
-	/** The service. */
-	private NaturalLanguageClassifier service;
+  /** The service. */
+  private NaturalLanguageClassifier service;
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see com.ibm.watson.developer_cloud.WatsonServiceTest#setUp()
-	 */
-	@Override
-	@Before
-	public void setUp() throws Exception {
-		super.setUp();
-		String username = getProperty("natural_language_classifier.username");
-		String password = getProperty("natural_language_classifier.password");
+  /*
+   * (non-Javadoc)
+   *
+   * @see com.ibm.watson.developer_cloud.WatsonServiceTest#setUp()
+   */
+  @Override
+  @Before
+  public void setUp() throws Exception {
+    super.setUp();
+    String username = getProperty("natural_language_classifier.username");
+    String password = getProperty("natural_language_classifier.password");
 
-		Assume.assumeFalse("config.properties doesn't have valid credentials.",
-				(username == null) || username.equals(PLACEHOLDER));
+    Assume.assumeFalse("config.properties doesn't have valid credentials.",
+        (username == null) || username.equals(PLACEHOLDER));
 
-		service = new NaturalLanguageClassifier();
-		service.setDefaultHeaders(getDefaultHeaders());
-		service.setUsernameAndPassword(username, password);
-		service.setEndPoint(getProperty("natural_language_classifier.url"));
+    service = new NaturalLanguageClassifier();
+    service.setDefaultHeaders(getDefaultHeaders());
+    service.setUsernameAndPassword(username, password);
+    service.setEndPoint(getProperty("natural_language_classifier.url"));
 
-		preCreatedClassifierId = getProperty("natural_language_classifier.classifier_id");
-	}
+    preCreatedClassifierId = getProperty("natural_language_classifier.classifier_id");
+  }
 
-	/**
-	 * Creates the classifier.
-	 *
-	 * @throws Exception the exception
-	 */
-	@Test
-	public void Acreate() throws Exception {
-		final File trainingData = new File("src/test/resources/natural_language_classifier/weather_data_train.csv");
-		final String classifierName = "devexp-available";
+  /**
+   * Creates the classifier.
+   *
+   * @throws Exception the exception
+   */
+  @Test
+  public void Acreate() throws Exception {
+    final File trainingData = new File("src/test/resources/natural_language_classifier/weather_data_train.csv");
+    final String classifierName = "devexp-available";
 
-		Classifier classifier = service.createClassifier(classifierName, "en", trainingData).execute();
+    Classifier classifier = service.createClassifier(classifierName, "en", trainingData).execute();
 
-		try {
-			assertNotNull(classifier);
-			assertEquals(Status.TRAINING, classifier.getStatus());
-			assertEquals(classifierName, classifier.getName());
-		} finally {
-			classifierId = classifier.getId();
-		}
+    try {
+      assertNotNull(classifier);
+      assertEquals(Status.TRAINING, classifier.getStatus());
+      assertEquals(classifierName, classifier.getName());
+    } finally {
+      classifierId = classifier.getId();
+    }
 
-	}
+  }
 
-	/**
-	 * Test get classifier.
-	 */
-	@Test
-	public void BgetClassifier() {
-		final Classifier classifier;
+  /**
+   * Test get classifier.
+   */
+  @Test
+  public void BgetClassifier() {
+    final Classifier classifier;
 
-		try {
-			classifier = service.getClassifier(classifierId).execute();
-		} catch (NotFoundException e) {
-			// #324: Classifiers may be empty, because of other tests interfering.
-			// The build should not fail here, because this is out of our control.
-			throw new AssumptionViolatedException(e.getMessage(), e);
-		}
-		assertNotNull(classifier);
-		assertEquals(classifierId, classifier.getId());
-		assertEquals(Classifier.Status.TRAINING, classifier.getStatus());
-	}
+    try {
+      classifier = service.getClassifier(classifierId).execute();
+    } catch (NotFoundException e) {
+      // #324: Classifiers may be empty, because of other tests interfering.
+      // The build should not fail here, because this is out of our control.
+      throw new AssumptionViolatedException(e.getMessage(), e);
+    }
+    assertNotNull(classifier);
+    assertEquals(classifierId, classifier.getId());
+    assertEquals(Classifier.Status.TRAINING, classifier.getStatus());
+  }
 
-	/**
-	 * Test get classifiers.
-	 */
-	@Test
-	public void CgetClassifiers() {
-		final Classifiers classifiers = service.getClassifiers().execute();
-		assertNotNull(classifiers);
+  /**
+   * Test get classifiers.
+   */
+  @Test
+  public void CgetClassifiers() {
+    final Classifiers classifiers = service.getClassifiers().execute();
+    assertNotNull(classifiers);
 
-		// #324: Classifiers may be empty, because of other tests interfering.
-		// The build should not fail here, because this is out of our control.
-		Assume.assumeFalse(classifiers.getClassifiers().isEmpty());
-	}
+    // #324: Classifiers may be empty, because of other tests interfering.
+    // The build should not fail here, because this is out of our control.
+    Assume.assumeFalse(classifiers.getClassifiers().isEmpty());
+  }
 
-	/**
-	 * Test classify.  Use the pre created classifier to avoid waiting for availability
-	 */
-	@Test
-	public void Dclassify() {
-		Classification classification = null;
+  /**
+   * Test classify. Use the pre created classifier to avoid waiting for availability
+   */
+  @Test
+  public void Dclassify() {
+    Classification classification = null;
 
-		try {
-			classification = service.classify(preCreatedClassifierId, "is it hot outside?").execute();
-		} catch (NotFoundException e) {
-			// #324: Classifiers may be empty, because of other tests interfering.
-			// The build should not fail here, because this is out of our control.
-			throw new AssumptionViolatedException(e.getMessage(), e);
-		} 
+    try {
+      classification = service.classify(preCreatedClassifierId, "is it hot outside?").execute();
+    } catch (NotFoundException e) {
+      // #324: Classifiers may be empty, because of other tests interfering.
+      // The build should not fail here, because this is out of our control.
+      throw new AssumptionViolatedException(e.getMessage(), e);
+    }
 
-		assertNotNull(classification);
-		assertEquals("temperature", classification.getTopClass());
-	}
+    assertNotNull(classification);
+    assertEquals("temperature", classification.getTopClass());
+  }
 
-	/**
-	 * Test delete classifier.  Do not delete the pre created classifier.  We need it for classify
-	 */
-	@Test
-	public void Edelete() {
-		List<Classifier> classifiers = service.getClassifiers().execute().getClassifiers();
+  /**
+   * Test delete classifier. Do not delete the pre created classifier. We need it for classify
+   */
+  @Test
+  public void Edelete() {
+    List<Classifier> classifiers = service.getClassifiers().execute().getClassifiers();
 
-		for (Classifier classifier : classifiers) {
-			if (!classifier.getId().equals(preCreatedClassifierId)) {
-				service.deleteClassifier(classifier.getId()).execute();
-			}
-		}
-	}
+    for (Classifier classifier : classifiers) {
+      if (!classifier.getId().equals(preCreatedClassifierId)) {
+        service.deleteClassifier(classifier.getId()).execute();
+      }
+    }
+  }
 
 }

--- a/tests/src/test/java/com/ibm/watson/developer_cloud/natural_language_classifier/v1/NaturalLanguageClassifierTest.java
+++ b/tests/src/test/java/com/ibm/watson/developer_cloud/natural_language_classifier/v1/NaturalLanguageClassifierTest.java
@@ -31,145 +31,146 @@ import okhttp3.mockwebserver.RecordedRequest;
  * The Class NaturalLanguageClassifierTest.
  */
 public class NaturalLanguageClassifierTest extends WatsonServiceUnitTest {
-	private static final String TEXT = "text";
-	private static final String CLASSIFIERS_PATH = "/v1/classifiers";
-	private static final String CLASSIFY_PATH = "/v1/classifiers/%s/classify";
-	private static final String RESOURCE = "src/test/resources/natural_language_classifier/";
+  private static final String TEXT = "text";
+  private static final String CLASSIFIERS_PATH = "/v1/classifiers";
+  private static final String CLASSIFY_PATH = "/v1/classifiers/%s/classify";
+  private static final String RESOURCE = "src/test/resources/natural_language_classifier/";
 
-	private Classifiers classifiers;
-	private Classifier classifier;
-	private Classification classification;
+  private Classifiers classifiers;
+  private Classifier classifier;
+  private Classification classification;
 
-	private String classifierId;
-	private NaturalLanguageClassifier service;
+  private String classifierId;
+  private NaturalLanguageClassifier service;
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see com.ibm.watson.developer_cloud.WatsonServiceTest#setUp()
-	 */
-	@Override
-	@Before
-	public void setUp() throws Exception {
-		super.setUp();
-		service = new NaturalLanguageClassifier();
-		service.setApiKey("");
-		service.setEndPoint(getMockWebServerUrl());
+  /*
+   * (non-Javadoc)
+   *
+   * @see com.ibm.watson.developer_cloud.WatsonServiceTest#setUp()
+   */
+  @Override
+  @Before
+  public void setUp() throws Exception {
+    super.setUp();
+    service = new NaturalLanguageClassifier();
+    service.setApiKey("");
+    service.setEndPoint(getMockWebServerUrl());
 
-		classifierId = "foo";
-		classifiers = loadFixture(RESOURCE + "classifiers.json", Classifiers.class);
-		classifier = loadFixture(RESOURCE + "classifier.json", Classifier.class);
-		classification = loadFixture(RESOURCE + "classification.json", Classification.class);
-	}
+    classifierId = "foo";
+    classifiers = loadFixture(RESOURCE + "classifiers.json", Classifiers.class);
+    classifier = loadFixture(RESOURCE + "classifier.json", Classifier.class);
+    classification = loadFixture(RESOURCE + "classification.json", Classification.class);
+  }
 
-	/**
-	 * Test classify.
-	 *
-	 * @throws InterruptedException the interrupted exception
-	 */
-	@Test
-	public void testClassify() throws InterruptedException {
-		final JsonObject contentJson = new JsonObject();
-		contentJson.addProperty(TEXT, classification.getText());
+  /**
+   * Test classify.
+   *
+   * @throws InterruptedException the interrupted exception
+   */
+  @Test
+  public void testClassify() throws InterruptedException {
+    final JsonObject contentJson = new JsonObject();
+    contentJson.addProperty(TEXT, classification.getText());
 
-		final String path = String.format(CLASSIFY_PATH, classifierId);
+    final String path = String.format(CLASSIFY_PATH, classifierId);
 
-		server.enqueue(jsonResponse(classification));
-		final Classification result = service.classify(classifierId, classification.getText()).execute();
-		final RecordedRequest request = server.takeRequest();
+    server.enqueue(jsonResponse(classification));
+    final Classification result = service.classify(classifierId, classification.getText()).execute();
+    final RecordedRequest request = server.takeRequest();
 
-		assertEquals(path, request.getPath());
-		assertEquals("POST", request.getMethod());
-		assertEquals(contentJson.toString(), request.getBody().readUtf8());
-		assertEquals(classification, result);
-	}
+    assertEquals(path, request.getPath());
+    assertEquals("POST", request.getMethod());
+    assertEquals(contentJson.toString(), request.getBody().readUtf8());
+    assertEquals(classification, result);
+  }
 
-	/**
-	 * Test get classifier.
-	 *
-	 * @throws InterruptedException the interrupted exception
-	 */
-	@Test
-	public void testGetClassifier() throws InterruptedException {
-		server.enqueue(jsonResponse(classifier));
-		final Classifier response = service.getClassifier(classifierId).execute();
-		final RecordedRequest request = server.takeRequest();
+  /**
+   * Test get classifier.
+   *
+   * @throws InterruptedException the interrupted exception
+   */
+  @Test
+  public void testGetClassifier() throws InterruptedException {
+    server.enqueue(jsonResponse(classifier));
+    final Classifier response = service.getClassifier(classifierId).execute();
+    final RecordedRequest request = server.takeRequest();
 
-		assertEquals(CLASSIFIERS_PATH + "/" + classifierId, request.getPath());
-		assertEquals(classifier, response);
-	}
+    assertEquals(CLASSIFIERS_PATH + "/" + classifierId, request.getPath());
+    assertEquals(classifier, response);
+  }
 
-	/**
-	 * Test get classifiers.
-	 *
-	 * @throws InterruptedException the interrupted exception
-	 */
-	@Test
-	public void testGetClassifiers() throws InterruptedException {
-		server.enqueue(jsonResponse(classifiers));
-		final Classifiers response = service.getClassifiers().execute();
-		final RecordedRequest request = server.takeRequest();
+  /**
+   * Test get classifiers.
+   *
+   * @throws InterruptedException the interrupted exception
+   */
+  @Test
+  public void testGetClassifiers() throws InterruptedException {
+    server.enqueue(jsonResponse(classifiers));
+    final Classifiers response = service.getClassifiers().execute();
+    final RecordedRequest request = server.takeRequest();
 
-		assertEquals(CLASSIFIERS_PATH, request.getPath());
-		assertEquals(classifiers, response);
-	}
+    assertEquals(CLASSIFIERS_PATH, request.getPath());
+    assertEquals(classifiers, response);
+  }
 
-	/**
-	 * Test create classifier.
-	 *
-	 * @throws InterruptedException the interrupted exception
-	 */
-	@Test
-	public void testCreateClassifier() throws InterruptedException {
-		server.enqueue(jsonResponse(classifier));
-		final Classifier response = service.createClassifier(classifierId, "en", new File("src/test/resources/natural_language_classifier/weather_data_train.csv")).execute();
-		final RecordedRequest request = server.takeRequest();
+  /**
+   * Test create classifier.
+   *
+   * @throws InterruptedException the interrupted exception
+   */
+  @Test
+  public void testCreateClassifier() throws InterruptedException {
+    server.enqueue(jsonResponse(classifier));
+    final Classifier response = service.createClassifier(classifierId, "en",
+        new File("src/test/resources/natural_language_classifier/weather_data_train.csv")).execute();
+    final RecordedRequest request = server.takeRequest();
 
-		assertEquals(CLASSIFIERS_PATH, request.getPath());
-		assertEquals(classifier, response);
-	}
+    assertEquals(CLASSIFIERS_PATH, request.getPath());
+    assertEquals(classifier, response);
+  }
 
-	/**
-	 * Test delete classifier.
-	 *
-	 * @throws InterruptedException the interrupted exception
-	 */
-	@Test
-	public void testDeleteClassifier() throws InterruptedException {   
-		service.deleteClassifier(classifierId);
-	}
+  /**
+   * Test delete classifier.
+   *
+   * @throws InterruptedException the interrupted exception
+   */
+  @Test
+  public void testDeleteClassifier() throws InterruptedException {
+    service.deleteClassifier(classifierId);
+  }
 
-	// START NEGATIVE TESTS 
-	/**
-	 * Test null classifier.
-	 */
-	@Test(expected = IllegalArgumentException.class)
-	public void testNullClassifier() {
-		service.classify("", "test");
-	}
+  // START NEGATIVE TESTS
+  /**
+   * Test null classifier.
+   */
+  @Test(expected = IllegalArgumentException.class)
+  public void testNullClassifier() {
+    service.classify("", "test");
+  }
 
-	/**
-	 * Test null text.
-	 */
-	@Test(expected = IllegalArgumentException.class)
-	public void testNullText() {
-		service.classify(classifierId, null);
-	}
+  /**
+   * Test null text.
+   */
+  @Test(expected = IllegalArgumentException.class)
+  public void testNullText() {
+    service.classify(classifierId, null);
+  }
 
-	/**
-	 * Test null delete classifier.
-	 */
-	@Test(expected = IllegalArgumentException.class)
-	public void testNullDeleteClassifier() {
-		service.deleteClassifier("");
-	}
+  /**
+   * Test null delete classifier.
+   */
+  @Test(expected = IllegalArgumentException.class)
+  public void testNullDeleteClassifier() {
+    service.deleteClassifier("");
+  }
 
-	/**
-	 * Test null training data file.
-	 */
-	@Test(expected = IllegalArgumentException.class)
-	public void testNullTrainingDataFile() {
-		service.createClassifier(null, null, new File("src/test/resources/notfound.txt"));
-	}
+  /**
+   * Test null training data file.
+   */
+  @Test(expected = IllegalArgumentException.class)
+  public void testNullTrainingDataFile() {
+    service.createClassifier(null, null, new File("src/test/resources/notfound.txt"));
+  }
 
 }

--- a/tests/src/test/java/com/ibm/watson/developer_cloud/natural_language_classifier/v1/NaturalLanguageClassifierTest.java
+++ b/tests/src/test/java/com/ibm/watson/developer_cloud/natural_language_classifier/v1/NaturalLanguageClassifierTest.java
@@ -31,120 +31,145 @@ import okhttp3.mockwebserver.RecordedRequest;
  * The Class NaturalLanguageClassifierTest.
  */
 public class NaturalLanguageClassifierTest extends WatsonServiceUnitTest {
-  private static final String TEXT = "text";
-  private static final String CLASSIFIERS_PATH = "/v1/classifiers";
-  private static final String CLASSIFY_PATH = "/v1/classifiers/%s/classify";
-  private static final String RESOURCE = "src/test/resources/natural_language_classifier/";
+	private static final String TEXT = "text";
+	private static final String CLASSIFIERS_PATH = "/v1/classifiers";
+	private static final String CLASSIFY_PATH = "/v1/classifiers/%s/classify";
+	private static final String RESOURCE = "src/test/resources/natural_language_classifier/";
 
-  private Classifiers classifiers;
-  private Classifier classifier;
-  private Classification classification;
+	private Classifiers classifiers;
+	private Classifier classifier;
+	private Classification classification;
 
-  private String classifierId;
-  private NaturalLanguageClassifier service;
+	private String classifierId;
+	private NaturalLanguageClassifier service;
 
-  /*
-   * (non-Javadoc)
-   *
-   * @see com.ibm.watson.developer_cloud.WatsonServiceTest#setUp()
-   */
-  @Override
-  @Before
-  public void setUp() throws Exception {
-    super.setUp();
-    service = new NaturalLanguageClassifier();
-    service.setApiKey("");
-    service.setEndPoint(getMockWebServerUrl());
+	/*
+	 * (non-Javadoc)
+	 *
+	 * @see com.ibm.watson.developer_cloud.WatsonServiceTest#setUp()
+	 */
+	@Override
+	@Before
+	public void setUp() throws Exception {
+		super.setUp();
+		service = new NaturalLanguageClassifier();
+		service.setApiKey("");
+		service.setEndPoint(getMockWebServerUrl());
 
-    classifierId = "foo";
-    classifiers = loadFixture(RESOURCE + "classifiers.json", Classifiers.class);
-    classifier = loadFixture(RESOURCE + "classifier.json", Classifier.class);
-    classification = loadFixture(RESOURCE + "classification.json", Classification.class);
-  }
+		classifierId = "foo";
+		classifiers = loadFixture(RESOURCE + "classifiers.json", Classifiers.class);
+		classifier = loadFixture(RESOURCE + "classifier.json", Classifier.class);
+		classification = loadFixture(RESOURCE + "classification.json", Classification.class);
+	}
 
-  /**
-   * Test classify.
-   *
-   * @throws InterruptedException the interrupted exception
-   */
-  @Test
-  public void testClassify() throws InterruptedException {
-    final JsonObject contentJson = new JsonObject();
-    contentJson.addProperty(TEXT, classification.getText());
+	/**
+	 * Test classify.
+	 *
+	 * @throws InterruptedException the interrupted exception
+	 */
+	@Test
+	public void testClassify() throws InterruptedException {
+		final JsonObject contentJson = new JsonObject();
+		contentJson.addProperty(TEXT, classification.getText());
 
-    final String path = String.format(CLASSIFY_PATH, classifierId);
+		final String path = String.format(CLASSIFY_PATH, classifierId);
 
-    server.enqueue(jsonResponse(classification));
-    final Classification result = service.classify(classifierId, classification.getText()).execute();
-    final RecordedRequest request = server.takeRequest();
+		server.enqueue(jsonResponse(classification));
+		final Classification result = service.classify(classifierId, classification.getText()).execute();
+		final RecordedRequest request = server.takeRequest();
 
-    assertEquals(path, request.getPath());
-    assertEquals("POST", request.getMethod());
-    assertEquals(contentJson.toString(), request.getBody().readUtf8());
-    assertEquals(classification, result);
-  }
+		assertEquals(path, request.getPath());
+		assertEquals("POST", request.getMethod());
+		assertEquals(contentJson.toString(), request.getBody().readUtf8());
+		assertEquals(classification, result);
+	}
 
-  /**
-   * Test get classifier.
-   *
-   * @throws InterruptedException the interrupted exception
-   */
-  @Test
-  public void testGetClassifier() throws InterruptedException {
-    server.enqueue(jsonResponse(classifier));
-    final Classifier response = service.getClassifier(classifierId).execute();
-    final RecordedRequest request = server.takeRequest();
+	/**
+	 * Test get classifier.
+	 *
+	 * @throws InterruptedException the interrupted exception
+	 */
+	@Test
+	public void testGetClassifier() throws InterruptedException {
+		server.enqueue(jsonResponse(classifier));
+		final Classifier response = service.getClassifier(classifierId).execute();
+		final RecordedRequest request = server.takeRequest();
 
-    assertEquals(CLASSIFIERS_PATH + "/" + classifierId, request.getPath());
-    assertEquals(classifier, response);
-  }
+		assertEquals(CLASSIFIERS_PATH + "/" + classifierId, request.getPath());
+		assertEquals(classifier, response);
+	}
 
-  /**
-   * Test get classifiers.
-   *
-   * @throws InterruptedException the interrupted exception
-   */
-  @Test
-  public void testGetClassifiers() throws InterruptedException {
-    server.enqueue(jsonResponse(classifiers));
-    final Classifiers response = service.getClassifiers().execute();
-    final RecordedRequest request = server.takeRequest();
+	/**
+	 * Test get classifiers.
+	 *
+	 * @throws InterruptedException the interrupted exception
+	 */
+	@Test
+	public void testGetClassifiers() throws InterruptedException {
+		server.enqueue(jsonResponse(classifiers));
+		final Classifiers response = service.getClassifiers().execute();
+		final RecordedRequest request = server.takeRequest();
 
-    assertEquals(CLASSIFIERS_PATH, request.getPath());
-    assertEquals(classifiers, response);
-  }
+		assertEquals(CLASSIFIERS_PATH, request.getPath());
+		assertEquals(classifiers, response);
+	}
 
-  /**
-   * Test null classifier.
-   */
-  @Test(expected = IllegalArgumentException.class)
-  public void testNullClassifier() {
-    service.classify("", "test");
-  }
+	/**
+	 * Test create classifier.
+	 *
+	 * @throws InterruptedException the interrupted exception
+	 */
+	@Test
+	public void testCreateClassifier() throws InterruptedException {
+		server.enqueue(jsonResponse(classifier));
+		final Classifier response = service.createClassifier(classifierId, "en", new File("src/test/resources/natural_language_classifier/weather_data_train.csv")).execute();
+		final RecordedRequest request = server.takeRequest();
 
-  /**
-   * Test null delete classifier.
-   */
-  @Test(expected = IllegalArgumentException.class)
-  public void testNullDeleteClassifier() {
-    service.deleteClassifier("");
-  }
+		assertEquals(CLASSIFIERS_PATH, request.getPath());
+		assertEquals(classifier, response);
+	}
 
-  /**
-   * Test null text.
-   */
-  @Test(expected = IllegalArgumentException.class)
-  public void testNullText() {
-    service.classify(classifierId, null);
-  }
+	/**
+	 * Test delete classifier.
+	 *
+	 * @throws InterruptedException the interrupted exception
+	 */
+	@Test
+	public void testDeleteClassifier() throws InterruptedException {   
+		service.deleteClassifier(classifierId);
+	}
 
+	// START NEGATIVE TESTS 
+	/**
+	 * Test null classifier.
+	 */
+	@Test(expected = IllegalArgumentException.class)
+	public void testNullClassifier() {
+		service.classify("", "test");
+	}
 
-  /**
-   * Test null training data file.
-   */
-  @Test(expected = IllegalArgumentException.class)
-  public void testNullTrainingDataFile() {
-    service.createClassifier(null, null, new File("src/test/resources/notfound.txt"));
-  }
+	/**
+	 * Test null text.
+	 */
+	@Test(expected = IllegalArgumentException.class)
+	public void testNullText() {
+		service.classify(classifierId, null);
+	}
+
+	/**
+	 * Test null delete classifier.
+	 */
+	@Test(expected = IllegalArgumentException.class)
+	public void testNullDeleteClassifier() {
+		service.deleteClassifier("");
+	}
+
+	/**
+	 * Test null training data file.
+	 */
+	@Test(expected = IllegalArgumentException.class)
+	public void testNullTrainingDataFile() {
+		service.createClassifier(null, null, new File("src/test/resources/notfound.txt"));
+	}
 
 }


### PR DESCRIPTION
Add new Unit tests for NLC
refactor integration tests

I was not able to modify the . config.properties.enc file.  The classifier id it uses is no longer around.  Created a new one but need to modify that file.  So in that file can you replace it with the following
natural_language_classifier.classifier_id=e82f62x108-nlc-5806