### PR TITLE
added byte array support to classify an in memory image

### DIFF
--- a/tests/src/test/java/com/ibm/watson/developer_cloud/visual_recognition/v3/VisualRecognitionIT.java
+++ b/tests/src/test/java/com/ibm/watson/developer_cloud/visual_recognition/v3/VisualRecognitionIT.java
@@ -19,6 +19,9 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.List;
 
 import org.junit.Assume;
@@ -45,6 +48,7 @@ public class VisualRecognitionIT extends WatsonServiceTest {
   private static final String IMAGE_FACE_FILE = "src/test/resources/visual_recognition/faces.zip";
   private static final String IMAGE_FACE_URL = "https://watson-test-resources.mybluemix.net/resources/obama.jpg";
   private static final String IMAGE_FILE = "src/test/resources/visual_recognition/test.zip";
+  private static final String SINGLE_IMAGE_FILE = "src/test/resources/visual_recognition/car.png";
   private static final String IMAGE_TEXT_FILE = "src/test/resources/visual_recognition/open.png";
   private static final String IMAGE_TEXT_URL = "https://watson-test-resources.mybluemix.net/resources/open.png";
   private static final String IMAGE_URL = "https://watson-test-resources.mybluemix.net/resources/car.png";
@@ -144,6 +148,18 @@ public class VisualRecognitionIT extends WatsonServiceTest {
     ClassifyImagesOptions options = new ClassifyImagesOptions.Builder().url(IMAGE_URL).build();
     VisualClassification result = service.classify(options).execute();
     assertClassifyImage(result, options);
+  }
+  
+  /**
+   * Test classify images from bytes or stream.
+   */
+  @Test
+  public void testClassifyImagesFromBytes()throws IOException {
+	File images = new File(SINGLE_IMAGE_FILE);
+	byte[] fileBytes = Files.readAllBytes(Paths.get(images.getPath()));
+	ClassifyImagesOptions options = new ClassifyImagesOptions.Builder().images(fileBytes,"car.png").build();
+	VisualClassification result = service.classify(options).execute();
+	assertClassifyImage(result, options);
   }
 
   /**

--- a/visual-recognition/src/main/java/com/ibm/watson/developer_cloud/visual_recognition/v3/VisualRecognition.java
+++ b/visual-recognition/src/main/java/com/ibm/watson/developer_cloud/visual_recognition/v3/VisualRecognition.java
@@ -180,12 +180,12 @@ public class VisualRecognition extends WatsonService {
       RequestBody requestBody = RequestBody.create(HttpMediaType.BINARY_FILE, options.images());
       bodyBuilder.addFormDataPart(PARAM_IMAGES_FILE, options.images().getName(), requestBody);
     }
-    
+
     if (options.imagesBinary() != null) {
-    	RequestBody requestBody = RequestBody.create(HttpMediaType.BINARY_FILE, options.imagesBinary());
-    	bodyBuilder.addFormDataPart(PARAM_IMAGES_FILE, options.imageName(), requestBody);
+      RequestBody requestBody = RequestBody.create(HttpMediaType.BINARY_FILE, options.imagesBinary());
+      bodyBuilder.addFormDataPart(PARAM_IMAGES_FILE, options.imageName(), requestBody);
     }
-    
+
     bodyBuilder.addFormDataPart(PARAM_PARAMETERS, getParametersAsJson(options).toString());
 
     RequestBuilder requestBuilder = RequestBuilder.post(PATH_CLASSIFY);

--- a/visual-recognition/src/main/java/com/ibm/watson/developer_cloud/visual_recognition/v3/VisualRecognition.java
+++ b/visual-recognition/src/main/java/com/ibm/watson/developer_cloud/visual_recognition/v3/VisualRecognition.java
@@ -180,6 +180,12 @@ public class VisualRecognition extends WatsonService {
       RequestBody requestBody = RequestBody.create(HttpMediaType.BINARY_FILE, options.images());
       bodyBuilder.addFormDataPart(PARAM_IMAGES_FILE, options.images().getName(), requestBody);
     }
+    
+    if (options.imagesBinary() != null) {
+    	RequestBody requestBody = RequestBody.create(HttpMediaType.BINARY_FILE, options.imagesBinary());
+    	bodyBuilder.addFormDataPart(PARAM_IMAGES_FILE, options.imageName(), requestBody);
+    }
+    
     bodyBuilder.addFormDataPart(PARAM_PARAMETERS, getParametersAsJson(options).toString());
 
     RequestBuilder requestBuilder = RequestBuilder.post(PATH_CLASSIFY);

--- a/visual-recognition/src/main/java/com/ibm/watson/developer_cloud/visual_recognition/v3/model/ClassifyImagesOptions.java
+++ b/visual-recognition/src/main/java/com/ibm/watson/developer_cloud/visual_recognition/v3/model/ClassifyImagesOptions.java
@@ -39,7 +39,7 @@ public class ClassifyImagesOptions {
   private HttpUrl url;
   private List<String> classifierIds;
   private Double threshold;
-  private String imageName="placeholder.png";
+  private String imageName = "placeholder.png";
 
   /**
    * Classify Images Request Builder.
@@ -50,7 +50,7 @@ public class ClassifyImagesOptions {
     private List<String> classifierIds;
     private Double threshold;
     private byte[] imagesBinary;
-    private String imageName="placeholder.png";
+    private String imageName = "placeholder.png";
 
 
     private Builder(ClassifyImagesOptions options) {
@@ -73,7 +73,7 @@ public class ClassifyImagesOptions {
       this.imagesFile = imagesFile;
       return this;
     }
-    
+
     /**
      * Sets the images.
      *
@@ -159,7 +159,7 @@ public class ClassifyImagesOptions {
      * @return the profile options
      */
     public ClassifyImagesOptions build() {
-      Validator.isTrue((url != null) || (imagesFile != null || imagesBinary!=null), "url or imagesFile or imagesBinary should be specified");
+      Validator.isTrue((url != null) || (imagesFile != null || imagesBinary != null), "url or imagesFile or imagesBinary should be specified");
       return new ClassifyImagesOptions(this);
     }
 
@@ -184,7 +184,7 @@ public class ClassifyImagesOptions {
   }
   
   public String imageName() {
-	  return imageName;
+    return imageName;
   }
 
   /**

--- a/visual-recognition/src/main/java/com/ibm/watson/developer_cloud/visual_recognition/v3/model/ClassifyImagesOptions.java
+++ b/visual-recognition/src/main/java/com/ibm/watson/developer_cloud/visual_recognition/v3/model/ClassifyImagesOptions.java
@@ -153,14 +153,15 @@ public class ClassifyImagesOptions {
      */
     public Builder() { }
 
-    /**
-     * Builds the profile options.
-     *
-     * @return the profile options
-     */
-    public ClassifyImagesOptions build() {
-      Validator.isTrue((url != null) || (imagesFile != null || imagesBinary != null), "url or imagesFile or imagesBinary should be specified");
-      return new ClassifyImagesOptions(this);
+  /**
+   * Builds the profile options.
+   *
+   * @return the profile options
+   */
+  public ClassifyImagesOptions build() {
+    Validator.isTrue((url != null) || (imagesFile != null || imagesBinary != null),
+    "url or imagesFile or imagesBinary should be specified");
+    return new ClassifyImagesOptions(this);
     }
 
   }
@@ -173,7 +174,7 @@ public class ClassifyImagesOptions {
   public File images() {
     return imagesFile;
   }
-  
+
   /**
    * Returns the images binary.
    *
@@ -182,7 +183,7 @@ public class ClassifyImagesOptions {
   public byte[] imagesBinary() {
     return imagesBinary;
   }
-  
+
   public String imageName() {
     return imageName;
   }

--- a/visual-recognition/src/main/java/com/ibm/watson/developer_cloud/visual_recognition/v3/model/ClassifyImagesOptions.java
+++ b/visual-recognition/src/main/java/com/ibm/watson/developer_cloud/visual_recognition/v3/model/ClassifyImagesOptions.java
@@ -27,15 +27,19 @@ public class ClassifyImagesOptions {
 
   private ClassifyImagesOptions(Builder builder) {
     imagesFile = builder.imagesFile;
+    imagesBinary = builder.imagesBinary;
     url = builder.url;
     classifierIds = builder.classifierIds;
     threshold = builder.threshold;
+    imageName = builder.imageName;
   }
 
   private File imagesFile;
+  private byte[] imagesBinary;
   private HttpUrl url;
   private List<String> classifierIds;
   private Double threshold;
+  private String imageName="placeholder.png";
 
   /**
    * Classify Images Request Builder.
@@ -45,11 +49,14 @@ public class ClassifyImagesOptions {
     private HttpUrl url;
     private List<String> classifierIds;
     private Double threshold;
+    private byte[] imagesBinary;
+    private String imageName="placeholder.png";
 
 
     private Builder(ClassifyImagesOptions options) {
       this();
       imagesFile = options.imagesFile;
+      imagesBinary = options.imagesBinary;
       url = options.url;
       classifierIds = new ArrayList<String>(options.classifierIds);
       threshold = options.threshold;
@@ -64,6 +71,19 @@ public class ClassifyImagesOptions {
     public Builder images(File imagesFile) {
       Validator.notNull(imagesFile, "'imagesFile' cannot be null");
       this.imagesFile = imagesFile;
+      return this;
+    }
+    
+    /**
+     * Sets the images.
+     *
+     * @param imagesBinary the images bytes
+     * @return the builder
+     */
+    public Builder images(byte[] imagesBinary, String imageName) {
+      Validator.notNull(imagesBinary, "'imagesBinary' cannot be null");
+      this.imagesBinary = imagesBinary;
+      this.imageName = imageName;
       return this;
     }
 
@@ -139,7 +159,7 @@ public class ClassifyImagesOptions {
      * @return the profile options
      */
     public ClassifyImagesOptions build() {
-      Validator.isTrue((url != null) || (imagesFile != null), "url or imagesFile should be specified");
+      Validator.isTrue((url != null) || (imagesFile != null || imagesBinary!=null), "url or imagesFile or imagesBinary should be specified");
       return new ClassifyImagesOptions(this);
     }
 
@@ -152,6 +172,19 @@ public class ClassifyImagesOptions {
    */
   public File images() {
     return imagesFile;
+  }
+  
+  /**
+   * Returns the images binary.
+   *
+   * @return the images binary
+   */
+  public byte[] imagesBinary() {
+    return imagesBinary;
+  }
+  
+  public String imageName() {
+	  return imageName;
   }
 
   /**


### PR DESCRIPTION
Early today I asked a question about this, see here  [https://github.com/watson-developer-cloud/java-sdk/issues/481](url).

I decided to adjust the code to fit my purpose, but maybe others can benefit as well.

A simple example is based on a file, but the idea is that you do NOT have a file, only a stream:

```
byte[] fileBytes = Files.readAllBytes(Paths.get(filelocation));
					
		options = new ClassifyImagesOptions.Builder()
		    		        .images(fileBytes,"outsideDummy.png") 
		    		        .build(); 
```
