### PR TITLE
Add metadata to Discovery document create/update

### DIFF
--- a/discovery/src/main/java/com/ibm/watson/developer_cloud/discovery/v1/Discovery.java
+++ b/discovery/src/main/java/com/ibm/watson/developer_cloud/discovery/v1/Discovery.java
@@ -357,6 +357,9 @@ public class Discovery extends WatsonService implements EnvironmentManager, Conf
         MultipartBody.Builder multipartBuilder = new MultipartBody.Builder();
         multipartBuilder.setType(MultipartBody.FORM);
         multipartBuilder.addFormDataPart(FILE, FILENAME, file);
+        if (createRequest.getMetadata() != null) {
+            multipartBuilder.addFormDataPart(METADATA, createRequest.getMetadata().toString());
+        }
         builder.body(multipartBuilder.build());
         final Request request = createVersionedRequest(builder);
         return createServiceCall(request, ResponseConverterUtils.getObject(CreateDocumentResponse.class));
@@ -392,6 +395,9 @@ public class Discovery extends WatsonService implements EnvironmentManager, Conf
         MultipartBody.Builder multipartBuilder = new MultipartBody.Builder();
         multipartBuilder.setType(MultipartBody.FORM);
         multipartBuilder.addFormDataPart(FILE, FILENAME, file);
+        if (updateRequest.getMetadata() != null) {
+            multipartBuilder.addFormDataPart(METADATA, updateRequest.getMetadata().toString());
+        }
         builder.body(multipartBuilder.build());
         final Request request = createVersionedRequest(builder);
         return createServiceCall(request, ResponseConverterUtils.getObject(UpdateDocumentResponse.class));

--- a/discovery/src/main/java/com/ibm/watson/developer_cloud/discovery/v1/model/document/DocumentManager.java
+++ b/discovery/src/main/java/com/ibm/watson/developer_cloud/discovery/v1/model/document/DocumentManager.java
@@ -29,6 +29,7 @@ public interface DocumentManager {
     String STATUS = "status";
     String STATUS_DESCRIPTION = "status_description";
     String FILE = "file";
+    String METADATA = "metadata";
 
     /**
      * Gets a {@link Document}.


### PR DESCRIPTION
### Summary

Adds the ability to add `metadata` during document create/update for Discovery service - see #510 