### PR TITLE
Fix environment size enum serialization for Discovery

### DIFF
--- a/discovery/src/main/java/com/ibm/watson/developer_cloud/discovery/v1/Discovery.java
+++ b/discovery/src/main/java/com/ibm/watson/developer_cloud/discovery/v1/Discovery.java
@@ -190,6 +190,7 @@ public class Discovery extends WatsonService implements EnvironmentManager, Conf
     @Override
     public ServiceCall<CreateEnvironmentResponse> createEnvironment(CreateEnvironmentRequest createRequest) {
         Validator.notEmpty(createRequest.getName(), EnvironmentManager.NAME + " cannot be empty");
+        Validator.notNull(createRequest.getSize(), EnvironmentManager.SIZE + " cannot be null");
         RequestBuilder builder = RequestBuilder.post(String.format(PATH_ENVIRONMENTS));
         builder.bodyJson(GsonSingleton.getGson().toJsonTree(createRequest).getAsJsonObject());
         final Request request = createVersionedRequest(builder);

--- a/discovery/src/main/java/com/ibm/watson/developer_cloud/discovery/v1/model/environment/CreateEnvironmentRequest.java
+++ b/discovery/src/main/java/com/ibm/watson/developer_cloud/discovery/v1/model/environment/CreateEnvironmentRequest.java
@@ -13,6 +13,7 @@
 
 package com.ibm.watson.developer_cloud.discovery.v1.model.environment;
 
+import com.google.gson.annotations.SerializedName;
 import com.ibm.watson.developer_cloud.service.model.GenericModel;
 
 /**
@@ -64,9 +65,13 @@ public class CreateEnvironmentRequest extends GenericModel {
     }
 
     public enum Size {
+        @SerializedName("0")
         FREE(0),   //free plan
+        @SerializedName("1")
         ONE(1),    //standard plan
+        @SerializedName("2")
         TWO(2),    //standard plan
+        @SerializedName("3")
         THREE(3);  //standard plan
 
         private final int size;


### PR DESCRIPTION
### Summary

Fixes the environment size enum serialization issue (it was outputting `FREE` instead of `0`) see the API spec -> https://watson-api-explorer.mybluemix.net/apis/discovery-v1#!/Environments/post_v1_environments