### PR TITLE
[discovery] Fix the usage example in Readme

### DIFF
--- a/discovery/README.md
+++ b/discovery/README.md
@@ -20,9 +20,9 @@
 The [Discovery][discovery] wraps the environment, collection, configuration, document, and query operations of the Discovery service.
 
 ```java
-Discovery service = new Discovery("2016-12-15");
-service.setEndpoint("https://gateway.watsonplatform.net/discovery/api/");
-service.setUsernameAndPassword("<username>", "<password>");
+Discovery discovery = new Discovery("2016-12-15");
+discovery.setEndPoint("https://gateway.watsonplatform.net/discovery/api/");
+discovery.setUsernameAndPassword("<username>", "<password>");
 
 //Build an empty query on an existing environment/collection
 String environmentId = "<environmentId>";


### PR DESCRIPTION
### Summary
This fixes the issue #525

#### Changes:
```
Object name changed from 'service' to 'discovery'
Line2: Method name changed from 'setEndpoint' to 'setEndPoint'
```
