### PR TITLE
Update OkHttp to v3.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Change Log
 ==========
 
+## Version 3.5.4-SNAPSHOT
+
+* Change: Update OkHttp to v3.6.0
+
 ## Version 3.5.3
 
 _2016-12-15_

--- a/alchemy/build.gradle
+++ b/alchemy/build.gradle
@@ -43,7 +43,7 @@ dependencies {
     compile project(':core')
 
     testCompile project(path: ':core', configuration: 'tests')
-    testCompile group: 'com.squareup.okhttp3', name: 'mockwebserver', version: '3.3.1'
+    testCompile group: 'com.squareup.okhttp3', name: 'mockwebserver', version: '3.6.0'
     testCompile group: 'ch.qos.logback', name: 'logback-classic', version: '1.1.7'
     testCompile group: 'com.google.guava', name: 'guava', version: '19.0'
     testCompile group: 'junit', name: 'junit-dep', version: '4.11'

--- a/conversation/build.gradle
+++ b/conversation/build.gradle
@@ -43,7 +43,7 @@ dependencies {
     compile project(':core')
 
     testCompile project(path: ':core', configuration: 'tests')
-    testCompile group: 'com.squareup.okhttp3', name: 'mockwebserver', version: '3.3.1'
+    testCompile group: 'com.squareup.okhttp3', name: 'mockwebserver', version: '3.6.0'
     testCompile group: 'ch.qos.logback', name: 'logback-classic', version: '1.1.7'
     testCompile group: 'com.google.guava', name: 'guava', version: '19.0'
     testCompile group: 'junit', name: 'junit-dep', version: '4.11'

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -58,15 +58,14 @@ checkstyle {
   }
 
 dependencies {
-    compile group: 'com.squareup.okhttp3', name: 'okhttp', version: '3.3.1'
-    compile group: 'com.squareup.okhttp3', name: 'okhttp-ws', version: '3.3.1'
-    compile group: 'com.squareup.okhttp3', name: 'logging-interceptor', version: '3.3.1'
-    compile group: 'com.squareup.okhttp3', name: 'okhttp-urlconnection', version: '3.3.1'
+    compile group: 'com.squareup.okhttp3', name: 'okhttp', version: '3.6.0'
+    compile group: 'com.squareup.okhttp3', name: 'logging-interceptor', version: '3.6.0'
+    compile group: 'com.squareup.okhttp3', name: 'okhttp-urlconnection', version: '3.6.0'
     compile group: 'com.google.code.gson', name: 'gson', version: '2.6.2'
     compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.4'
     compile group: 'org.glassfish.jersey.bundles.repackaged', name: 'jersey-jsr166e', version: '2.22.2'
 
-    testCompile group: 'com.squareup.okhttp3', name: 'mockwebserver', version: '3.3.1'
+    testCompile group: 'com.squareup.okhttp3', name: 'mockwebserver', version: '3.6.0'
     testCompile group: 'ch.qos.logback', name: 'logback-classic', version: '1.1.7'
     testCompile group: 'com.google.guava', name: 'guava', version: '19.0'
     testCompile group: 'junit', name: 'junit-dep', version: '4.11'

--- a/dialog/build.gradle
+++ b/dialog/build.gradle
@@ -56,10 +56,9 @@ artifacts {
 
 dependencies {
     compile project(':conversation')
-    compile group: 'com.squareup.okhttp3', name: 'okhttp', version: '3.3.1'
-    compile group: 'com.squareup.okhttp3', name: 'okhttp-ws', version: '3.3.1'
-    compile group: 'com.squareup.okhttp3', name: 'logging-interceptor', version: '3.3.1'
-    compile group: 'com.squareup.okhttp3', name: 'okhttp-urlconnection', version: '3.3.1'
+    compile group: 'com.squareup.okhttp3', name: 'okhttp', version: '3.6.0'
+    compile group: 'com.squareup.okhttp3', name: 'logging-interceptor', version: '3.6.0'
+    compile group: 'com.squareup.okhttp3', name: 'okhttp-urlconnection', version: '3.6.0'
     compile group: 'com.google.code.gson', name: 'gson', version: '2.6.2'
     compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.4'
     compile group: 'org.glassfish.jersey.bundles.repackaged', name: 'jersey-jsr166e', version: '2.22.2'
@@ -76,7 +75,7 @@ dependencies {
     testCompile project(':tone-analyzer')
     testCompile project(':tradeoff-analytics')
     testCompile project(':visual-recognition')
-    testCompile group: 'com.squareup.okhttp3', name: 'mockwebserver', version: '3.3.1'
+    testCompile group: 'com.squareup.okhttp3', name: 'mockwebserver', version: '3.6.0'
     testCompile group: 'ch.qos.logback', name: 'logback-classic', version: '1.1.7'
     testCompile group: 'com.google.guava', name: 'guava', version: '19.0'
     testCompile group: 'junit', name: 'junit-dep', version: '4.11'

--- a/discovery/build.gradle
+++ b/discovery/build.gradle
@@ -48,7 +48,7 @@ dependencies {
     compile project(':core')
 
     testCompile project(path: ':core', configuration: 'tests')
-    testCompile group: 'com.squareup.okhttp3', name: 'mockwebserver', version: '3.3.1'
+    testCompile group: 'com.squareup.okhttp3', name: 'mockwebserver', version: '3.6.0'
     testCompile group: 'ch.qos.logback', name: 'logback-classic', version: '1.1.7'
     testCompile group: 'com.google.guava', name: 'guava', version: '19.0'
     testCompile group: 'junit', name: 'junit-dep', version: '4.11'

--- a/document-conversion/build.gradle
+++ b/document-conversion/build.gradle
@@ -44,7 +44,7 @@ dependencies {
 
     testCompile project(path: ':core', configuration: 'tests')
     testCompile project(':speech-to-text')
-    testCompile group: 'com.squareup.okhttp3', name: 'mockwebserver', version: '3.3.1'
+    testCompile group: 'com.squareup.okhttp3', name: 'mockwebserver', version: '3.6.0'
     testCompile group: 'ch.qos.logback', name: 'logback-classic', version: '1.1.7'
     testCompile group: 'com.google.guava', name: 'guava', version: '19.0'
     testCompile group: 'junit', name: 'junit-dep', version: '4.11'

--- a/language-translation/build.gradle
+++ b/language-translation/build.gradle
@@ -43,7 +43,7 @@ dependencies {
     compile project(':core')
 
     testCompile project(path: ':core', configuration: 'tests')
-    testCompile group: 'com.squareup.okhttp3', name: 'mockwebserver', version: '3.3.1'
+    testCompile group: 'com.squareup.okhttp3', name: 'mockwebserver', version: '3.6.0'
     testCompile group: 'ch.qos.logback', name: 'logback-classic', version: '1.1.7'
     testCompile group: 'com.google.guava', name: 'guava', version: '19.0'
     testCompile group: 'junit', name: 'junit-dep', version: '4.11'

--- a/language-translator/build.gradle
+++ b/language-translator/build.gradle
@@ -43,7 +43,7 @@ dependencies {
     compile project(':core')
 
     testCompile project(path: ':core', configuration: 'tests')
-    testCompile group: 'com.squareup.okhttp3', name: 'mockwebserver', version: '3.3.1'
+    testCompile group: 'com.squareup.okhttp3', name: 'mockwebserver', version: '3.6.0'
     testCompile group: 'ch.qos.logback', name: 'logback-classic', version: '1.1.7'
     testCompile group: 'com.google.guava', name: 'guava', version: '19.0'
     testCompile group: 'junit', name: 'junit-dep', version: '4.11'

--- a/natural-language-classifier/build.gradle
+++ b/natural-language-classifier/build.gradle
@@ -48,7 +48,7 @@ dependencies {
     compile project(':core')
 
     testCompile project(path: ':core', configuration: 'tests')
-    testCompile group: 'com.squareup.okhttp3', name: 'mockwebserver', version: '3.3.1'
+    testCompile group: 'com.squareup.okhttp3', name: 'mockwebserver', version: '3.6.0'
     testCompile group: 'ch.qos.logback', name: 'logback-classic', version: '1.1.7'
     testCompile group: 'com.google.guava', name: 'guava', version: '19.0'
     testCompile group: 'junit', name: 'junit-dep', version: '4.11'

--- a/personality-insights/build.gradle
+++ b/personality-insights/build.gradle
@@ -43,7 +43,7 @@ dependencies {
     compile project(':core')
 
     testCompile project(path: ':core', configuration: 'tests')
-    testCompile group: 'com.squareup.okhttp3', name: 'mockwebserver', version: '3.3.1'
+    testCompile group: 'com.squareup.okhttp3', name: 'mockwebserver', version: '3.6.0'
     testCompile group: 'ch.qos.logback', name: 'logback-classic', version: '1.1.7'
     testCompile group: 'com.google.guava', name: 'guava', version: '19.0'
     testCompile group: 'junit', name: 'junit-dep', version: '4.11'

--- a/retrieve-and-rank/build.gradle
+++ b/retrieve-and-rank/build.gradle
@@ -45,7 +45,7 @@ dependencies {
     testCompile project(path: ':core', configuration: 'tests')
     testCompile project(':document-conversion')
     testCompile project(':speech-to-text')
-    testCompile group: 'com.squareup.okhttp3', name: 'mockwebserver', version: '3.3.1'
+    testCompile group: 'com.squareup.okhttp3', name: 'mockwebserver', version: '3.6.0'
     testCompile group: 'ch.qos.logback', name: 'logback-classic', version: '1.1.7'
     testCompile group: 'com.google.guava', name: 'guava', version: '19.0'
     testCompile group: 'junit', name: 'junit-dep', version: '4.11'

--- a/speech-to-text/build.gradle
+++ b/speech-to-text/build.gradle
@@ -43,7 +43,7 @@ dependencies {
     compile project(':core')
 
     testCompile project(path: ':core', configuration: 'tests')
-    testCompile group: 'com.squareup.okhttp3', name: 'mockwebserver', version: '3.3.1'
+    testCompile group: 'com.squareup.okhttp3', name: 'mockwebserver', version: '3.6.0'
     testCompile group: 'ch.qos.logback', name: 'logback-classic', version: '1.1.7'
     testCompile group: 'com.google.guava', name: 'guava', version: '19.0'
     testCompile group: 'junit', name: 'junit-dep', version: '4.11'

--- a/speech-to-text/src/main/java/com/ibm/watson/developer_cloud/speech_to_text/v1/SpeechToText.java
+++ b/speech-to-text/src/main/java/com/ibm/watson/developer_cloud/speech_to_text/v1/SpeechToText.java
@@ -51,7 +51,7 @@ import com.ibm.watson.developer_cloud.util.Validator;
 import okhttp3.MediaType;
 import okhttp3.Request;
 import okhttp3.RequestBody;
-import okhttp3.ws.WebSocket;
+import okhttp3.WebSocket;
 
 /**
  * The Speech to Text service uses IBM's speech recognition capabilities to convert English speech into text. The

--- a/speech-to-text/src/main/java/com/ibm/watson/developer_cloud/speech_to_text/v1/websocket/RecognizeCallback.java
+++ b/speech-to-text/src/main/java/com/ibm/watson/developer_cloud/speech_to_text/v1/websocket/RecognizeCallback.java
@@ -16,7 +16,7 @@ package com.ibm.watson.developer_cloud.speech_to_text.v1.websocket;
 import com.ibm.watson.developer_cloud.speech_to_text.v1.SpeechToText;
 import com.ibm.watson.developer_cloud.speech_to_text.v1.model.SpeechResults;
 
-import okhttp3.ws.WebSocket;
+import okhttp3.WebSocket;
 
 
 /**

--- a/text-to-speech/build.gradle
+++ b/text-to-speech/build.gradle
@@ -44,7 +44,7 @@ dependencies {
 
     testCompile project(path: ':core', configuration: 'tests')
     testCompile project(':speech-to-text')
-    testCompile group: 'com.squareup.okhttp3', name: 'mockwebserver', version: '3.3.1'
+    testCompile group: 'com.squareup.okhttp3', name: 'mockwebserver', version: '3.6.0'
     testCompile group: 'ch.qos.logback', name: 'logback-classic', version: '1.1.7'
     testCompile group: 'com.google.guava', name: 'guava', version: '19.0'
     testCompile group: 'junit', name: 'junit-dep', version: '4.11'

--- a/tone-analyzer/build.gradle
+++ b/tone-analyzer/build.gradle
@@ -43,7 +43,7 @@ dependencies {
     compile project(':core')
 
     testCompile project(path: ':core', configuration: 'tests')
-    testCompile group: 'com.squareup.okhttp3', name: 'mockwebserver', version: '3.3.1'
+    testCompile group: 'com.squareup.okhttp3', name: 'mockwebserver', version: '3.6.0'
     testCompile group: 'ch.qos.logback', name: 'logback-classic', version: '1.1.7'
     testCompile group: 'com.google.guava', name: 'guava', version: '19.0'
     testCompile group: 'junit', name: 'junit-dep', version: '4.11'

--- a/tradeoff-analytics/build.gradle
+++ b/tradeoff-analytics/build.gradle
@@ -43,7 +43,7 @@ dependencies {
     compile project(':core')
 
     testCompile project(path: ':core', configuration: 'tests')
-    testCompile group: 'com.squareup.okhttp3', name: 'mockwebserver', version: '3.3.1'
+    testCompile group: 'com.squareup.okhttp3', name: 'mockwebserver', version: '3.6.0'
     testCompile group: 'ch.qos.logback', name: 'logback-classic', version: '1.1.7'
     testCompile group: 'com.google.guava', name: 'guava', version: '19.0'
     testCompile group: 'junit', name: 'junit-dep', version: '4.11'

--- a/visual-recognition/build.gradle
+++ b/visual-recognition/build.gradle
@@ -48,7 +48,7 @@ dependencies {
     compile project(':core')
 
     testCompile project(path: ':core', configuration: 'tests')
-    testCompile group: 'com.squareup.okhttp3', name: 'mockwebserver', version: '3.3.1'
+    testCompile group: 'com.squareup.okhttp3', name: 'mockwebserver', version: '3.6.0'
     testCompile group: 'ch.qos.logback', name: 'logback-classic', version: '1.1.7'
     testCompile group: 'com.google.guava', name: 'guava', version: '19.0'
     testCompile group: 'junit', name: 'junit-dep', version: '4.11'


### PR DESCRIPTION
okhttp-ws is gone, see https://github.com/square/okhttp/blob/master/CHANGELOG.md#version-350. Without an update to at least OkHttp 3.5 it's very hard to use the java-sdk with newer versions of OkHttp, especially on Android.

I've tried to keep the changes to a minimum.