### PR TITLE
Add Speech to Text getCorpus() method

### DIFF
--- a/examples/java/com/ibm/watson/developer_cloud/speech_to_text/v1/CustomizationExample.java
+++ b/examples/java/com/ibm/watson/developer_cloud/speech_to_text/v1/CustomizationExample.java
@@ -63,6 +63,9 @@ public class CustomizationExample {
         Thread.sleep(5000);
       }
 
+      // Get corpus
+      Corpus corpus = service.getCorpus(id, "corpus-1").execute();
+
       // Now add some user words to the custom model
       service.addWord(id, new Word("IEEE", "IEEE", "I. triple E.")).execute();
       service.addWord(id, new Word("hhonors", "IEEE", "H. honors", "Hilton honors")).execute();

--- a/speech-to-text/src/main/java/com/ibm/watson/developer_cloud/speech_to_text/v1/SpeechToText.java
+++ b/speech-to-text/src/main/java/com/ibm/watson/developer_cloud/speech_to_text/v1/SpeechToText.java
@@ -516,6 +516,22 @@ public class SpeechToText extends WatsonService {
   }
 
   /**
+   * Gets the specified corpus for the customization.
+   *
+   * @param customizationId The GUID of the custom language model whose corpus is to be returned. You must make the
+   *        request with the service credentials of the model's owner.
+   * @param corpusName The name of the corpus that is to be returned.
+   * @return The customization corpus.
+   */
+
+  public ServiceCall<Corpus> getCorpus(String customizationId, String corpusName) {
+    Validator.notNull(customizationId, "customizationId cannot be null");
+    Validator.notNull(corpusName, "corpusName cannot be null");
+    RequestBuilder requestBuilder = RequestBuilder.get(String.format(PATH_CORPUS, customizationId, corpusName));
+    return createServiceCall(requestBuilder.build(), ResponseConverterUtils.getObject(Corpus.class));
+  }
+
+  /**
    * Gets the customization information.
    *
    * @param customizationId The GUID of the custom language model being queried. You must make the request with the

--- a/speech-to-text/src/test/java/com/ibm/watson/developer_cloud/speech_to_text/v1/SpeechToTextIT.java
+++ b/speech-to-text/src/test/java/com/ibm/watson/developer_cloud/speech_to_text/v1/SpeechToTextIT.java
@@ -371,6 +371,16 @@ public class SpeechToTextIT extends WatsonServiceTest {
     assertNotNull(result);
   }
 
+  /**
+   * Test get corpus.
+   *
+   */
+  @Test
+  @Ignore
+  public void testGetCorpus() {
+    Corpus result = service.getCorpus(customizationId, "foo3").execute();
+    assertNotNull(result);
+  }
 
   /**
    * Test add text to corpus.
@@ -378,7 +388,7 @@ public class SpeechToTextIT extends WatsonServiceTest {
    */
   @Test(expected = IllegalArgumentException.class)
   public void testAddTextToCorpus() {
-    service.addTextToCustomizationCorpus(customizationId, "foo3", null, null).execute();
+      service.addTextToCustomizationCorpus(customizationId, "foo3", null, null).execute();
   }
 
   /**

--- a/speech-to-text/src/test/java/com/ibm/watson/developer_cloud/speech_to_text/v1/SpeechToTextTest.java
+++ b/speech-to-text/src/test/java/com/ibm/watson/developer_cloud/speech_to_text/v1/SpeechToTextTest.java
@@ -581,6 +581,26 @@ public class SpeechToTextTest extends WatsonServiceUnitTest {
   }
 
   /**
+   * Test get corpus.
+   *
+   * @throws InterruptedException the interrupted exception
+   * @throws FileNotFoundException the file not found exception
+   */
+  @Test
+  public void testGetCorpus() throws InterruptedException, FileNotFoundException {
+    String id = "foo";
+    String corpus = "cName";
+
+    server.enqueue(new MockResponse().addHeader(CONTENT_TYPE, HttpMediaType.APPLICATION_JSON).setBody("{}"));
+
+    service.getCorpus(id, corpus).execute();
+    final RecordedRequest request = server.takeRequest();
+
+    assertEquals("GET", request.getMethod());
+    assertEquals(String.format(PATH_CORPUS, id, corpus), request.getPath());
+  }
+
+  /**
    * Test delete corpus.
    *
    * @throws InterruptedException the interrupted exception


### PR DESCRIPTION
Adds the Speech to Text getCorpus() method requested in issue https://github.com/watson-developer-cloud/java-sdk/issues/498.