### PR TITLE
Generate Java 7 bytecode to be Android compatible

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,12 @@ task docs(type: Javadoc) {
   destinationDir = file("$buildDir/docs/all")
 }
 
+allprojects {
+  apply plugin: 'java' // *Compatibility has no effect before the 'java' plug-in is applied
+  sourceCompatibility = JavaVersion.VERSION_1_7
+  targetCompatibility = JavaVersion.VERSION_1_7
+}
+
 subprojects {
 
   checkstyleTest {


### PR DESCRIPTION
This restores the behaviour of the Maven build.