### PR TITLE
Add part of speech support for the Text to Speech CustomTranslation object

### DIFF
--- a/text-to-speech/src/main/java/com/ibm/watson/developer_cloud/text_to_speech/v1/model/CustomTranslation.java
+++ b/text-to-speech/src/main/java/com/ibm/watson/developer_cloud/text_to_speech/v1/model/CustomTranslation.java
@@ -12,22 +12,49 @@
  */
 package com.ibm.watson.developer_cloud.text_to_speech.v1.model;
 
+import com.google.gson.annotations.SerializedName;
 import com.ibm.watson.developer_cloud.service.model.GenericModel;
 import com.ibm.watson.developer_cloud.util.Validator;
 
 /**
  * A customized word translation, assigning a specific pronunciation to a given word. The translation can be either a
  * simple String of the desired pronunciation ({@code "Sunday"} as translation for {@code "Sun."}), an International
- * Phonetic Alphabet (IPA) representation.
+ * Phonetic Alphabet (IPA) representation. A Japanese translation can also specify a part of speech.
  *
- * @see <a href= "http://www.ibm.com/watson/developercloud/doc/text-to-speech/custom-intro.shtml"> Customization</a>
+ * @see <a href= "http://www.ibm.com/watson/developercloud/doc/text-to-speech/custom-intro.shtml">Customization</a>
  *
  */
 public class CustomTranslation extends GenericModel {
 
+  /**
+   * The Enum PartOfSpeech for Japanese custom translations only.
+   */
+  public enum PartOfSpeech {
+    JOSI, /** Joshi: participle. */
+    MESI, /** Meishi: noun. */
+    KIGO, /** Kigou: symbol. */
+    GOBI, /** Gobi: inflection. */
+    DOSI, /** Doushi: verb. */
+    JODO, /** Jodoushi: auxiliary verb. */
+    KOYU, /** Koyuumeishi: proper noun. */
+    STBI, /** Setsubiji: suffix. */
+    SUJI, /** Suuji: numeral. */
+    KEDO, /** Keiyodoushi: adjective verb. */
+    FUKU, /** Fukishi: adverb. */
+    KEYO, /** Keiyoshi: adjective verb. */
+    STTO, /** Settoji: prefix. */
+    RETA, /** Rentaish: determiner. */
+    STZO, /** Setsuzokushi: conjunction. */
+    KATO, /** Kantoushi: interjection. */
+    HOKA  /** Hoka: other. */
+  }
+
   private String word;
 
   private String translation;
+
+  @SerializedName("part_of_speech")
+  private String partOfSpeech;
 
   /**
    * Instantiates a new custom translation.
@@ -37,15 +64,30 @@ public class CustomTranslation extends GenericModel {
   }
 
   /**
-   * Creates a new CustomTranslation.
+   * Creates a new CustomTranslation without a part of speech.
    *
    * @param word the word
    * @param translation the custom translation
    */
   public CustomTranslation(String word, String translation) {
+    this(word, translation, null);
+  }
+
+  /**
+   * Creates a new CustomTranslation with a part of speech.
+   *
+   * @param word the word
+   * @param translation the custom translation
+   * @param partOfSpeech the part of speech
+   */
+  public CustomTranslation(String word, String translation, CustomTranslation.PartOfSpeech partOfSpeech) {
     this();
     setWord(word);
     setTranslation(translation);
+    if (partOfSpeech != null) {
+      String pos = partOfSpeech.toString();
+      setPartOfSpeech(pos.charAt(0) + pos.substring(1).toLowerCase());
+    }
   }
 
   /**
@@ -81,10 +123,28 @@ public class CustomTranslation extends GenericModel {
    * Phonetic Alphabet (IPA) representation an IBM Symbolic Phonetic Representation (SPR), or a mix of them.
    *
    * @param translation the translation
-   * @see <a href= "http://www.ibm.com/watson/developercloud/doc/text-to-speech/custom-intro.shtml"> Customization</a>
+   * @see <a href= "http://www.ibm.com/watson/developercloud/doc/text-to-speech/custom-intro.shtml">Customization</a>
    */
   public void setTranslation(String translation) {
     this.translation = translation;
+  }
+
+  /**
+   * Returns the part of speech.
+   *
+   * @return the part of speech
+   */
+  public String getPartOfSpeech() {
+    return partOfSpeech;
+  }
+
+  /**
+   * Sets the original part of speech.
+   *
+   * @param partOfSpeech the part of speech
+   */
+  public void setPartOfSpeech(String partOfSpeech) {
+    this.partOfSpeech = partOfSpeech;
   }
 
 }

--- a/text-to-speech/src/test/java/com/ibm/watson/developer_cloud/text_to_speech/v1/CustomizationsIT.java
+++ b/text-to-speech/src/test/java/com/ibm/watson/developer_cloud/text_to_speech/v1/CustomizationsIT.java
@@ -44,6 +44,7 @@ public class CustomizationsIT extends WatsonServiceTest {
 
   private static final String MODEL_NAME = "test model";
   private static final String MODEL_LANGUAGE = "en-US";
+  private static final String MODEL_LANGUAGE_JAPANESE = "ja-JP";
   private static final String MODEL_DESCRIPTION = "a simple model for testing purposes";
 
   private CustomVoiceModel model;
@@ -76,17 +77,34 @@ public class CustomizationsIT extends WatsonServiceTest {
     return model;
   }
 
+  private CustomVoiceModel instantiateVoiceModelJapanese() {
+    final CustomVoiceModel model = new CustomVoiceModel();
+    model.setName(MODEL_NAME);
+    model.setDescription(MODEL_DESCRIPTION);
+    model.setLanguage(MODEL_LANGUAGE_JAPANESE);
+
+    return model;
+  }
+
   private List<CustomTranslation> instantiateCustomTranslations() {
     return ImmutableList.of(new CustomTranslation("hodor", "hold the door"),
-        /*
-         * The following IPA entry is causing a test failure:
-           new CustomTranslation("trinitroglycerin", "try<phoneme alphabet=\"ipa\" ph=\"nˈaɪtɹəglɪsəɹɨn\"></phoneme>"),
-        */
+      /** The following IPA entry is causing a test failure:
+       *  new CustomTranslation("trinitroglycerin", "try<phoneme alphabet=\"ipa\" ph=\"nˈaɪtɹəglɪsəɹɨn\"></phoneme>"),
+       */
         new CustomTranslation("shocking", "<phoneme alphabet='ibm' ph='.1Sa.0kIG'></phoneme>"));
+  }
+
+  private List<CustomTranslation> instantiateCustomTranslationsJapanese() {
+    return ImmutableList.of(new CustomTranslation("hodor", "hold the door", CustomTranslation.PartOfSpeech.JOSI),
+        new CustomTranslation("clodor", "Close the door", CustomTranslation.PartOfSpeech.HOKA));
   }
 
   private CustomVoiceModel createVoiceModel() {
     return service.saveCustomVoiceModel(instantiateVoiceModel()).execute();
+  }
+
+  private CustomVoiceModel createVoiceModelJapanese() {
+    return service.saveCustomVoiceModel(instantiateVoiceModelJapanese()).execute();
   }
 
   private void assertModelsEqual(CustomVoiceModel a, CustomVoiceModel b) {
@@ -216,7 +234,7 @@ public class CustomizationsIT extends WatsonServiceTest {
   }
 
   /**
-   * Test add words.
+   * Test add words and get words.
    */
   @Test
   public void testAddWords() {
@@ -230,12 +248,12 @@ public class CustomizationsIT extends WatsonServiceTest {
   }
 
   /**
-   * Test get words.
+   * Test add words and get words for Japanese.
    */
   @Test
-  public void testGetWords() {
-    model = createVoiceModel();
-    final List<CustomTranslation> expected = instantiateCustomTranslations();
+  public void testAddWordsJapanese() {
+    model = createVoiceModelJapanese();
+    final List<CustomTranslation> expected = instantiateCustomTranslationsJapanese();
 
     service.saveWords(model, expected.toArray(new CustomTranslation[] { })).execute();
 
@@ -255,6 +273,21 @@ public class CustomizationsIT extends WatsonServiceTest {
 
     final CustomTranslation word = service.getWord(model, expected.get(0).getWord()).execute();
     assertEquals(expected.get(0).getTranslation(), word.getTranslation());
+  }
+
+  /**
+   * Test get word for Japanese.
+   */
+  @Test
+  public void testGetWordJapanese() {
+    model = createVoiceModelJapanese();
+    final List<CustomTranslation> expected = instantiateCustomTranslationsJapanese();
+
+    service.saveWords(model, expected.toArray(new CustomTranslation[] { })).execute();
+
+    final CustomTranslation word = service.getWord(model, expected.get(0).getWord()).execute();
+    assertEquals(expected.get(0).getTranslation(), word.getTranslation());
+    assertEquals(expected.get(0).getPartOfSpeech(), word.getPartOfSpeech());
   }
 
   /**


### PR DESCRIPTION
Add support for the part of speech for Text to Speech `CustomTranslation` objects.  The part of speech is added by the `saveWords()` method and returned by the `getWords()` and `getWord()` methods.  The object has a constructor that accepts a `PartOfSpeech` constant.  Support is available only for Japanese; the service will soon handle errors related to invalid part of speech specifications and to use of the part of speech with languages other than Japanese.  This commit addresses issue https://github.com/watson-developer-cloud/java-sdk/issues/538.