### PR TITLE
Add addCorpus() method and correct allowOverride parameter

### DIFF
--- a/examples/java/com/ibm/watson/developer_cloud/speech_to_text/v1/CustomizationExample.java
+++ b/examples/java/com/ibm/watson/developer_cloud/speech_to_text/v1/CustomizationExample.java
@@ -49,7 +49,7 @@ public class CustomizationExample {
 
     try {
       // Add a corpus file to the model:
-      service.addTextToCustomizationCorpus(id, "corpus-1", false, new File(CORPUS_FILE)).execute();
+        service.addCorpus(id, "corpus-1", new File(CORPUS_FILE), false).execute();
 
       // Get corpus status
       for (int x = 0; x < 30 && (service.getCorpus(id, "corpus-1").execute()).getStatus() != Status.ANALYZED; x++) {

--- a/speech-to-text/src/main/java/com/ibm/watson/developer_cloud/speech_to_text/v1/SpeechToText.java
+++ b/speech-to-text/src/main/java/com/ibm/watson/developer_cloud/speech_to_text/v1/SpeechToText.java
@@ -272,7 +272,7 @@ public class SpeechToText extends WatsonService {
    * @param trainingData A plain text file that contains the training data for the corpus. Encode the file in UTF-8 if
    *        it contains non-ASCII characters; the service assumes UTF-8 encoding if it encounters non-ASCII characters.
    * @return the service call
-   * @deprecated use {@link #addCorpus()} instead.
+   * @deprecated use {@link #addCorpus(String, String, File, Boolean)} instead.
    */
   @Deprecated
   public ServiceCall<Void> addTextToCustomizationCorpus(String customizationId, String corpusName,

--- a/speech-to-text/src/test/java/com/ibm/watson/developer_cloud/speech_to_text/v1/SpeechToTextIT.java
+++ b/speech-to-text/src/test/java/com/ibm/watson/developer_cloud/speech_to_text/v1/SpeechToTextIT.java
@@ -480,7 +480,7 @@ public class SpeechToTextIT extends WatsonServiceTest {
   public void testCustomization() throws InterruptedException {
     // create customization
     Customization myCustomization =
-        service.createCustomization("IEEE-java-sdk-permanent", SpeechModel.EN_US_BROADBANDMODEL, null).execute();
+        service.createCustomization("IEEE-java-sdk-temporary", SpeechModel.EN_US_BROADBANDMODEL, "Temporary custom model for testing the Java SDK").execute();
     String id = myCustomization.getId();
 
     try {

--- a/speech-to-text/src/test/java/com/ibm/watson/developer_cloud/speech_to_text/v1/SpeechToTextTest.java
+++ b/speech-to-text/src/test/java/com/ibm/watson/developer_cloud/speech_to_text/v1/SpeechToTextTest.java
@@ -632,25 +632,25 @@ public class SpeechToTextTest extends WatsonServiceUnitTest {
   }
 
   /**
-   * Test add text to corpus.
+   * Test add corpus.
    *
    * @throws InterruptedException the interrupted exception
    * @throws FileNotFoundException the file not found exception
    */
   @Test
-  public void testAddTextToCorpus() throws InterruptedException, FileNotFoundException {
+  public void testAddCorpus() throws InterruptedException, FileNotFoundException {
     String id = "foo";
-    String corpus = "cName";
-    File trainingData = new File("src/test/resources/speech_to_text/corpus-text.txt");
+    String corpusName = "cName";
+    File corpusFile = new File("src/test/resources/speech_to_text/corpus-text.txt");
 
     server.enqueue(new MockResponse().addHeader(CONTENT_TYPE, HttpMediaType.APPLICATION_JSON).setBody("{}"));
 
-    service.addTextToCustomizationCorpus(id, corpus, true, trainingData).execute();
+    service.addCorpus(id, corpusName, corpusFile, true).execute();
     final RecordedRequest request = server.takeRequest();
 
     assertEquals("POST", request.getMethod());
-    assertEquals(String.format(PATH_CORPUS, id, corpus) + "?allow_override=true", request.getPath());
-    assertEquals(trainingData.length(), request.getBodySize());
+    assertEquals(String.format(PATH_CORPUS, id, corpusName) + "?allow_overwrite=true", request.getPath());
+    assertEquals(corpusFile.length(), request.getBodySize());
   }
 
   /**


### PR DESCRIPTION
This PR address two issues for the Speech to Text service:

- It changes the `allowOverride` parameter of the `addTextToCustomizationCorpus()` method to `allowOverwrite`.  This addresses issue https://github.com/watson-developer-cloud/java-sdk/issues/574.

- It adds the `addCorpus()` method to replace the `addTextToCustomizationCorpus()` method to match the service and the Node SDK.  It deprecates the old version of the method.  It also moves the `allowOverwrite` parameter to the end of the method signature, since it's the sole optional parameter.  This addresses issue https://github.com/watson-developer-cloud/java-sdk/issues/573.

The Speech to Text tests and examples have been modified to use the new version of the method.  I have tested the old version of the method independently of the SDK, and it still works fine.