### PR TITLE
Improve how Word.Sort enum is handled and general enum comments

### DIFF
--- a/speech-to-text/src/main/java/com/ibm/watson/developer_cloud/speech_to_text/v1/SpeechToText.java
+++ b/speech-to-text/src/main/java/com/ibm/watson/developer_cloud/speech_to_text/v1/SpeechToText.java
@@ -707,33 +707,8 @@ public class SpeechToText extends WatsonService {
     if (type != null) {
       requestBuilder.query(WORD_TYPE, type.toString().toLowerCase());
     }
-
-    /**
-     * The Word.Sort enumerated type cannot match the service arguments directly, so we need to convert
-     * to one of the required values. Although they do the same thing now, We keep ALPHA and PLUS_ALPHA
-     * separate in case the service defaults ever change; the same is true of COUNT and MINUS_COUNT.
-     */
     if (sort != null) {
-        switch (sort) {
-        case ALPHA:
-            requestBuilder.query(WORD_SORT, WORD_SORT_ALPHA);
-            break;
-        case PLUS_ALPHA:
-            requestBuilder.query(WORD_SORT, WORD_SORT_PLUS_ALPHA);
-            break;
-        case MINUS_ALPHA:
-            requestBuilder.query(WORD_SORT, WORD_SORT_MINUS_ALPHA);
-            break;
-        case COUNT:
-            requestBuilder.query(WORD_SORT, WORD_SORT_COUNT);
-            break;
-        case PLUS_COUNT:
-            requestBuilder.query(WORD_SORT, WORD_SORT_PLUS_COUNT);
-            break;
-        case MINUS_COUNT:
-            requestBuilder.query(WORD_SORT, WORD_SORT_MINUS_COUNT);
-            break;
-        }
+      requestBuilder.query(WORD_SORT, sort.getSort());
     }
 
     ResponseConverter<List<WordData>> converter = ResponseConverterUtils.getGenericObject(TYPE_WORDS, WORDS);

--- a/speech-to-text/src/main/java/com/ibm/watson/developer_cloud/speech_to_text/v1/model/Customization.java
+++ b/speech-to-text/src/main/java/com/ibm/watson/developer_cloud/speech_to_text/v1/model/Customization.java
@@ -33,11 +33,10 @@ public class Customization extends GenericModel {
    * </ul>
    */
   public enum WordTypeToAdd {
-
-    /** The all. */
-    ALL, /** The user. */
-    USER
+    ALL, /** The corpora and user words. */
+    USER /** The user words. */
   }
+
   /**
    * Customization Status.
    */

--- a/speech-to-text/src/main/java/com/ibm/watson/developer_cloud/speech_to_text/v1/model/Word.java
+++ b/speech-to-text/src/main/java/com/ibm/watson/developer_cloud/speech_to_text/v1/model/Word.java
@@ -25,26 +25,46 @@ import com.ibm.watson.developer_cloud.speech_to_text.v1.SpeechToText;
 public class Word extends GenericModel {
 
   /**
-   * The Enum Type.
+   * The Enum Type to specify the type of words to be listed. The default is ALL.
    */
   public enum Type {
-    /** The default is ALL. */
-    ALL, /** The corpora. */
-    CORPORA, /** The user. */
-    USER
+    ALL, /** The corpora and user words. */
+    CORPORA, /** The corpora words. */
+    USER /** The user words. */
   }
 
   /**
-   * The Enum Sort.
+   * The Enum Sort to specify how words are to be sorted when listed. The default is ALPHA.
    */
   public enum Sort {
-    /** The default is ALPHA. */
-    ALPHA, /** Lexicographically (in ascending order). */
-    PLUS_ALPHA, /** Lexicographically in ascending order. */
-    MINUS_ALPHA, /** Lexicographically in descending order. */
-    COUNT, /** By count (in descending order). */
-    PLUS_COUNT, /** By count in ascending order. */
-    MINUS_COUNT /** By count in descending order. */
+
+    /** Lexicographically (in ascending order). */
+    ALPHA("alphabetical"),
+
+    /** Lexicographically in ascending order. */
+    PLUS_ALPHA("+alphabetical"),
+
+    /** Lexicographically in descending order. */
+    MINUS_ALPHA("-alphabetical"),
+
+    /** By count (in descending order). */
+    COUNT("count"),
+
+    /** By count in ascending order. */
+    PLUS_COUNT("+count"),
+
+    /** By count in descending order. */
+    MINUS_COUNT("-count");
+
+    private String sort;
+
+    private Sort(String s) {
+      sort = s;
+    }
+
+    public String getSort() {
+      return sort;
+    }
   }
 
   @SerializedName("display_as")

--- a/speech-to-text/src/test/java/com/ibm/watson/developer_cloud/speech_to_text/v1/SpeechToTextIT.java
+++ b/speech-to-text/src/test/java/com/ibm/watson/developer_cloud/speech_to_text/v1/SpeechToTextIT.java
@@ -480,7 +480,7 @@ public class SpeechToTextIT extends WatsonServiceTest {
   public void testCustomization() throws InterruptedException {
     // create customization
     Customization myCustomization =
-        service.createCustomization("IEEE-java-sdk-temporary", SpeechModel.EN_US_BROADBANDMODEL, "Temporary custom model for testing the Java SDK").execute();
+        service.createCustomization("java-sdk-temporary", SpeechModel.EN_US_BROADBANDMODEL, "Temporary custom model for testing the Java SDK").execute();
     String id = myCustomization.getId();
 
     try {

--- a/text-to-speech/src/main/java/com/ibm/watson/developer_cloud/text_to_speech/v1/model/CustomVoiceModel.java
+++ b/text-to-speech/src/main/java/com/ibm/watson/developer_cloud/text_to_speech/v1/model/CustomVoiceModel.java
@@ -95,7 +95,7 @@ public class CustomVoiceModel extends GenericModel {
   }
 
   /**
-   * Returns the language code (e.g. en-us)
+   * Returns the language code (for example, en-us)
    *
    * @return the language code
    */
@@ -104,7 +104,7 @@ public class CustomVoiceModel extends GenericModel {
   }
 
   /**
-   * Sets the language code (e.g. en-us)
+   * Sets the language code (for example, en-us)
    *
    * @param language the language code
    */

--- a/text-to-speech/src/main/java/com/ibm/watson/developer_cloud/text_to_speech/v1/model/Voice.java
+++ b/text-to-speech/src/main/java/com/ibm/watson/developer_cloud/text_to_speech/v1/model/Voice.java
@@ -69,7 +69,6 @@ public class Voice extends GenericModel {
     public void setVoiceTransformation(Boolean voiceTransformation) {
       this.voiceTransformation = voiceTransformation;
     }
-
   }
 
   private static final String FEMALE = "female";
@@ -147,11 +146,13 @@ public class Voice extends GenericModel {
   private String gender;
   private String language;
   private String name;
+  private String url;
 
   @SerializedName("supported_features")
   private SupportedFeatures supportedFeatures;
 
-  private String url;
+  @SerializedName("customization")
+  private CustomVoiceModel customVoiceModel;
 
   /**
    * Instantiates a new voice.
@@ -208,6 +209,15 @@ public class Voice extends GenericModel {
   }
 
   /**
+   * Gets the url.
+   *
+   * @return the url
+   */
+  public String getUrl() {
+    return url;
+  }
+
+  /**
    * Gets the supported features.
    *
    * @return the supported features
@@ -217,12 +227,12 @@ public class Voice extends GenericModel {
   }
 
   /**
-   * Gets the url.
+   * Gets the custom voice model if present.
    *
-   * @return the url
+   * @return the custom voice model
    */
-  public String getUrl() {
-    return url;
+  public CustomVoiceModel getCustomVoiceModel() {
+    return customVoiceModel;
   }
 
   /**
@@ -262,6 +272,15 @@ public class Voice extends GenericModel {
   }
 
   /**
+   * Sets the url.
+   *
+   * @param url the new url
+   */
+  public void setUrl(final String url) {
+    this.url = url;
+  }
+
+  /**
    * Sets the supported features.
    *
    * @param supportedFeatures the new supported features
@@ -271,11 +290,12 @@ public class Voice extends GenericModel {
   }
 
   /**
-   * Sets the url.
+   * Sets the custom voice model if present.
    *
-   * @param url the new url
+   * @param customVoiceModel the new custom voice model
    */
-  public void setUrl(final String url) {
-    this.url = url;
+  public void setCustomVoiceModel(CustomVoiceModel customVoiceModel) {
+    this.customVoiceModel = customVoiceModel;
   }
+
 }

--- a/text-to-speech/src/test/java/com/ibm/watson/developer_cloud/text_to_speech/v1/CustomizationsIT.java
+++ b/text-to-speech/src/test/java/com/ibm/watson/developer_cloud/text_to_speech/v1/CustomizationsIT.java
@@ -153,6 +153,20 @@ public class CustomizationsIT extends WatsonServiceTest {
   }
 
   /**
+   * Test get voice with customization.
+   */
+  @Test
+  public void testGetVoiceCustomization() {
+    model = createVoiceModel();
+    final CustomVoiceModel model2 = service.getCustomVoiceModel(model.getId()).execute();
+    final Voice voice = service.getVoice("en-US_AllisonVoice", model.getId()).execute();
+
+    assertNotNull(voice);
+    assertNotNull(model);
+    assertEquals(voice.getCustomVoiceModel(), model2);
+  }
+
+  /**
    * Test update voice model.
    */
   @Test

--- a/text-to-speech/src/test/java/com/ibm/watson/developer_cloud/text_to_speech/v1/CustomizationsTest.java
+++ b/text-to-speech/src/test/java/com/ibm/watson/developer_cloud/text_to_speech/v1/CustomizationsTest.java
@@ -25,6 +25,7 @@ import com.google.common.collect.ImmutableMap;
 import com.ibm.watson.developer_cloud.WatsonServiceUnitTest;
 import com.ibm.watson.developer_cloud.text_to_speech.v1.model.CustomTranslation;
 import com.ibm.watson.developer_cloud.text_to_speech.v1.model.CustomVoiceModel;
+import com.ibm.watson.developer_cloud.text_to_speech.v1.model.Voice;
 
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.RecordedRequest;
@@ -34,6 +35,7 @@ import okhttp3.mockwebserver.RecordedRequest;
  */
 public class CustomizationsTest extends WatsonServiceUnitTest {
 
+  private static final String VOICES_PATH = "/v1/voices";
   private static final String VOICE_MODELS_PATH = "/v1/customizations";
   private static final String WORDS_PATH = VOICE_MODELS_PATH + "/%s/words";
 
@@ -74,8 +76,36 @@ public class CustomizationsTest extends WatsonServiceUnitTest {
     return model;
   }
 
+  private static Voice instantiateVoice() {
+    final Voice voice = new Voice();
+    voice.setName("en-US_TestMaleVoice");
+    voice.setGender("male");
+    voice.setLanguage("en-US");
+    voice.setDescription("TestMale");
+    voice.setUrl("http://ibm.watson.com/text-to-speech/voices/en-US_TestMaleVoice");
+    voice.setCustomVoiceModel(instantiateVoiceModel());
+
+    return voice;
+  }
+
   private static List<CustomTranslation> instantiateWords() {
     return ImmutableList.of(new CustomTranslation("hodor", "hold the door"));
+  }
+
+  /**
+   * Test get voice with custom voice model.
+   */
+  @Test
+  public void testGetVoiceCustomization() throws InterruptedException {
+    final Voice expected = instantiateVoice();
+    server.enqueue(jsonResponse(expected));
+
+    final Voice result = service.getVoice(expected.getName(), expected.getCustomVoiceModel().getId()).execute();
+    final RecordedRequest request = server.takeRequest();
+
+    assertEquals(VOICES_PATH + "/" + expected.getName() + "?customization_id=" + expected.getCustomVoiceModel().getId(), request.getPath());
+    assertEquals("GET", request.getMethod());
+    assertEquals(expected, result);
   }
 
   /**


### PR DESCRIPTION
Changed the `Word.Sort` enum definition to improve how we access the strings associated with the different constants.  Got the idea from how Tradeoff Analytics defines `Column` types.  (And I really disliked the switch statement in the `getWords()` method.)

Also improved the comments for the enums `Word.Type`, `Word.Sort`, and `Customization.WordTypeToAdd`, and tweaked the definition of the IT custom model.