### PR TITLE
Updating links to documentation

### DIFF
--- a/language-translation/README.md
+++ b/language-translation/README.md
@@ -32,4 +32,4 @@ TranslationResult translationResult = service.translate(
 System.out.println(translationResult);
 ```
 
-[language_translator]: http://www.ibm.com/watson/developercloud/doc/language-translator/
+[language_translator]: http://www.ibm.com/watson/developercloud/doc/language-translator/index.html

--- a/language-translator/README.md
+++ b/language-translator/README.md
@@ -32,4 +32,4 @@ TranslationResult translationResult = service.translate(
 System.out.println(translationResult);
 ```
 
-[language_translator]: http://www.ibm.com/watson/developercloud/doc/language-translator/
+[language_translator]: http://www.ibm.com/watson/developercloud/doc/language-translator/index.html


### PR DESCRIPTION
Revised the links for the service documentation to go to the new markdown-sourced HTML pages for both the Language Translator and Language Translation service readmes. 