### PR TITLE
Fix definition of error field for Speech to Text WordData object

### DIFF
--- a/speech-to-text/src/main/java/com/ibm/watson/developer_cloud/speech_to_text/v1/model/RecognitionJob.java
+++ b/speech-to-text/src/main/java/com/ibm/watson/developer_cloud/speech_to_text/v1/model/RecognitionJob.java
@@ -43,33 +43,16 @@ public class RecognitionJob extends GenericModel {
   }
 
   private String id;
-  private List<SpeechResults> results;
   private Status status;
   private Date created;
   private Date updated;
-
-  /**
-   * Gets the updated date.
-   *
-   * @return the updated
-   */
-  public Date getUpdated() {
-    return updated;
-  }
-
-  /**
-   * Sets the updated date.
-   *
-   * @param updated the new updated
-   */
-  public void setUpdated(Date updated) {
-    this.updated = updated;
-  }
-
   private String url;
 
   @SerializedName("user_token")
   private String userToken;
+
+  private List<SpeechResults> results;
+  private List<String> warnings;
 
   /**
    * Gets the id.
@@ -78,33 +61,6 @@ public class RecognitionJob extends GenericModel {
    */
   public String getId() {
     return id;
-  }
-
-  /**
-   * Gets the created date.
-   *
-   * @return the created
-   */
-  public Date getCreated() {
-    return created;
-  }
-
-  /**
-   * Sets the created date.
-   *
-   * @param created the new created
-   */
-  public void setCreated(Date created) {
-    this.created = created;
-  }
-
-  /**
-   * Gets the recognition results.
-   *
-   * @return the results
-   */
-  public List<SpeechResults> getResults() {
-    return results;
   }
 
   /**
@@ -117,7 +73,25 @@ public class RecognitionJob extends GenericModel {
   }
 
   /**
-   * Gets the url.
+   * Gets the created date.
+   *
+   * @return the created
+   */
+  public Date getCreated() {
+    return created;
+  }
+
+  /**
+   * Gets the updated date.
+   *
+   * @return the updated
+   */
+  public Date getUpdated() {
+    return updated;
+  }
+
+  /**
+   * Gets the callback url.
    *
    * @return the url
    */
@@ -135,6 +109,24 @@ public class RecognitionJob extends GenericModel {
   }
 
   /**
+   * Gets the recognition results.
+   *
+   * @return the results
+   */
+  public List<SpeechResults> getResults() {
+    return results;
+  }
+
+  /**
+   * Gets the warnings if present.
+   *
+   * @return the warnings
+   */
+  public List<String> getWarnings() {
+    return warnings;
+  }
+
+  /**
    * Sets the id.
    *
    * @param id the new id
@@ -144,21 +136,30 @@ public class RecognitionJob extends GenericModel {
   }
 
   /**
-   * Sets the recognition results.
-   *
-   * @param results the new results
-   */
-  public void setResults(List<SpeechResults> results) {
-    this.results = results;
-  }
-
-  /**
    * Sets the status.
    *
    * @param status the new status
    */
   public void setStatus(Status status) {
     this.status = status;
+  }
+
+  /**
+   * Sets the created date.
+   *
+   * @param created the new created
+   */
+  public void setCreated(Date created) {
+    this.created = created;
+  }
+
+  /**
+   * Sets the updated date.
+   *
+   * @param updated the new updated
+   */
+  public void setUpdated(Date updated) {
+    this.updated = updated;
   }
 
   /**
@@ -177,5 +178,23 @@ public class RecognitionJob extends GenericModel {
    */
   public void setUserToken(String userToken) {
     this.userToken = userToken;
+  }
+
+  /**
+   * Sets the recognition results.
+   *
+   * @param results the new results
+   */
+  public void setResults(List<SpeechResults> results) {
+    this.results = results;
+  }
+
+  /**
+   * Sets the warnings if present.
+   *
+   * @params warnings the new warnings.
+   */
+  public void setWarnings(List<String> warnings) {
+    this.warnings = warnings;
   }
 }

--- a/speech-to-text/src/main/java/com/ibm/watson/developer_cloud/speech_to_text/v1/model/RecognitionJob.java
+++ b/speech-to-text/src/main/java/com/ibm/watson/developer_cloud/speech_to_text/v1/model/RecognitionJob.java
@@ -55,9 +55,9 @@ public class RecognitionJob extends GenericModel {
   private List<String> warnings;
 
   /**
-   * Gets the id.
+   * Gets the job id.
    *
-   * @return the id
+   * @return the job id
    */
   public String getId() {
     return id;
@@ -75,7 +75,7 @@ public class RecognitionJob extends GenericModel {
   /**
    * Gets the created date.
    *
-   * @return the created
+   * @return the created date
    */
   public Date getCreated() {
     return created;
@@ -84,7 +84,7 @@ public class RecognitionJob extends GenericModel {
   /**
    * Gets the updated date.
    *
-   * @return the updated
+   * @return the updated date
    */
   public Date getUpdated() {
     return updated;
@@ -93,7 +93,7 @@ public class RecognitionJob extends GenericModel {
   /**
    * Gets the callback url.
    *
-   * @return the url
+   * @return the callback url
    */
   public String getUrl() {
     return url;
@@ -192,7 +192,7 @@ public class RecognitionJob extends GenericModel {
   /**
    * Sets the warnings if present.
    *
-   * @params warnings the new warnings.
+   * @param warnings the new warnings
    */
   public void setWarnings(List<String> warnings) {
     this.warnings = warnings;

--- a/speech-to-text/src/main/java/com/ibm/watson/developer_cloud/speech_to_text/v1/model/SpeechModel.java
+++ b/speech-to-text/src/main/java/com/ibm/watson/developer_cloud/speech_to_text/v1/model/SpeechModel.java
@@ -55,7 +55,7 @@ public class SpeechModel extends GenericModel {
      * @param customLanguageModel the new custom language model attribute
      * value.
      */
-    public void setCustomLanguageModel(Boolean customLanguageModel) {
+    public void setCustomLanguageModel(final Boolean customLanguageModel) {
       this.customLanguageModel = customLanguageModel;
     }
 
@@ -64,7 +64,7 @@ public class SpeechModel extends GenericModel {
      *
      * @param speakerLabels the new speaker labels attribute value.
      */
-    public void setSpeakerLabels(Boolean speakerLabels) {
+    public void setSpeakerLabels(final Boolean speakerLabels) {
       this.speakerLabels = speakerLabels;
     }
 
@@ -236,7 +236,7 @@ public class SpeechModel extends GenericModel {
    *
    * @param description The description
    */
-  public void setDescription(String description) {
+  public void setDescription(final String description) {
     this.description = description;
   }
 
@@ -254,7 +254,7 @@ public class SpeechModel extends GenericModel {
    *
    * @param supportedFeatures the new supported features
    */
-  public void setSupportedFeatures(SupportedFeatures supportedFeatures) {
+  public void setSupportedFeatures(final SupportedFeatures supportedFeatures) {
     this.supportedFeatures = supportedFeatures;
   }
 

--- a/speech-to-text/src/main/java/com/ibm/watson/developer_cloud/speech_to_text/v1/model/SpeechResults.java
+++ b/speech-to-text/src/main/java/com/ibm/watson/developer_cloud/speech_to_text/v1/model/SpeechResults.java
@@ -38,8 +38,6 @@ public class SpeechResults extends GenericModel {
     this.speakerLabels = speakerLabels;
   }
 
-
-
   /**
    * Gets the result index.
    *

--- a/speech-to-text/src/main/java/com/ibm/watson/developer_cloud/speech_to_text/v1/model/WordData.java
+++ b/speech-to-text/src/main/java/com/ibm/watson/developer_cloud/speech_to_text/v1/model/WordData.java
@@ -13,6 +13,9 @@
 package com.ibm.watson.developer_cloud.speech_to_text.v1.model;
 
 import java.util.List;
+import java.util.Map;
+
+import com.google.gson.annotations.SerializedName;
 
 /**
  * Represents a {@link Word} with error and source.
@@ -20,8 +23,10 @@ import java.util.List;
 public class WordData extends Word {
 
   private Integer count;
-  private String error;
   private List<String> source;
+
+  @SerializedName("error")
+  private List<Map> errors;
 
   /**
    * Gets the count for the number of sources from which the word has been added to the model's words resource.
@@ -30,15 +35,6 @@ public class WordData extends Word {
    */
   public Integer getCount() {
     return count;
-  }
-
-  /**
-   * Gets the error. If the service discovered a problem with the custom word's definition.
-   *
-   * @return The error
-   */
-  public String getError() {
-    return error;
   }
 
   /**
@@ -51,12 +47,12 @@ public class WordData extends Word {
   }
 
   /**
-   * Sets the error.
+   * Gets the errors if present.
    *
-   * @param error The error
+   * @return The errors
    */
-  public void setError(String error) {
-    this.error = error;
+  public List<Map> getErrors() {
+    return errors;
   }
 
   /**
@@ -75,6 +71,15 @@ public class WordData extends Word {
    */
   public void setCount(Integer count) {
     this.count = count;
+  }
+
+  /**
+   * Sets the errors if present.
+   *
+   * @param errors The errors
+   */
+  public void setErrors(List<Map> errors) {
+    this.errors = errors;
   }
 
 }

--- a/speech-to-text/src/test/java/com/ibm/watson/developer_cloud/speech_to_text/v1/SpeechToTextIT.java
+++ b/speech-to-text/src/test/java/com/ibm/watson/developer_cloud/speech_to_text/v1/SpeechToTextIT.java
@@ -38,6 +38,7 @@ import com.ibm.watson.developer_cloud.speech_to_text.v1.model.Corpus.Status;
 import com.ibm.watson.developer_cloud.speech_to_text.v1.model.Customization;
 import com.ibm.watson.developer_cloud.speech_to_text.v1.model.KeywordsResult;
 import com.ibm.watson.developer_cloud.speech_to_text.v1.model.RecognitionJob;
+import com.ibm.watson.developer_cloud.speech_to_text.v1.model.RecognitionJobOptions;
 import com.ibm.watson.developer_cloud.speech_to_text.v1.model.RecognizeOptions;
 import com.ibm.watson.developer_cloud.speech_to_text.v1.model.SpeechModel;
 import com.ibm.watson.developer_cloud.speech_to_text.v1.model.SpeechResults;
@@ -330,6 +331,32 @@ public class SpeechToTextIT extends WatsonServiceTest {
 
       assertNotNull(job.getResults());
 
+    } finally {
+      service.deleteRecognitionJob(job.getId());
+    }
+  }
+
+  /**
+   * Test create recognition job with a warning message.
+   *
+   * @throws InterruptedException the interrupted exception
+   * @throws FileNotFoundException the file not found exception
+   */
+  @Test
+  public void testCreateRecognitionJobWarning() throws InterruptedException, FileNotFoundException {
+    File audio = new File(SAMPLE_WAV);
+    RecognitionJobOptions jobOptions = new RecognitionJobOptions.Builder().userToken("job").build();
+    RecognitionJob job = service.createRecognitionJob(audio, null, jobOptions).execute();
+    try {
+      assertNotNull(job.getId());
+      assertNotNull(job.getWarnings());
+      for (int x = 0; x < 30 && job.getStatus() != RecognitionJob.Status.COMPLETED; x++) {
+        Thread.sleep(3000);
+        job = service.getRecognitionJob(job.getId()).execute();
+      }
+      job = service.getRecognitionJob(job.getId()).execute();
+      assertEquals(RecognitionJob.Status.COMPLETED, job.getStatus());
+      assertNotNull(job.getResults());
     } finally {
       service.deleteRecognitionJob(job.getId());
     }

--- a/speech-to-text/src/test/java/com/ibm/watson/developer_cloud/speech_to_text/v1/SpeechToTextTest.java
+++ b/speech-to-text/src/test/java/com/ibm/watson/developer_cloud/speech_to_text/v1/SpeechToTextTest.java
@@ -388,8 +388,7 @@ public class SpeechToTextTest extends WatsonServiceUnitTest {
     String id = "foo";
     RecognitionJob job = loadFixture("src/test/resources/speech_to_text/job.json", RecognitionJob.class);
 
-    server
-        .enqueue(new MockResponse().addHeader(CONTENT_TYPE, HttpMediaType.APPLICATION_JSON).setBody(GSON.toJson(job)));
+    server.enqueue(new MockResponse().addHeader(CONTENT_TYPE, HttpMediaType.APPLICATION_JSON).setBody(GSON.toJson(job)));
 
     RecognitionJob result = service.getRecognitionJob(id).execute();
     final RecordedRequest request = server.takeRequest();
@@ -410,8 +409,7 @@ public class SpeechToTextTest extends WatsonServiceUnitTest {
     String id = "foo";
     RecognitionJob job = loadFixture("src/test/resources/speech_to_text/job.json", RecognitionJob.class);
 
-    server
-        .enqueue(new MockResponse().addHeader(CONTENT_TYPE, HttpMediaType.APPLICATION_JSON).setBody(GSON.toJson(job)));
+    server.enqueue(new MockResponse().addHeader(CONTENT_TYPE, HttpMediaType.APPLICATION_JSON).setBody(GSON.toJson(job)));
 
     RecognitionJob result = service.getRecognitionJob(id).execute();
     final RecordedRequest request = server.takeRequest();

--- a/speech-to-text/src/test/resources/speech_to_text/job.json
+++ b/speech-to-text/src/test/resources/speech_to_text/job.json
@@ -1,4 +1,8 @@
 {
   "status": "waiting",
-  "id": "foo"
+  "id": "foo",
+  "warnings": [
+    "string"
+  ]
+
 }

--- a/speech-to-text/src/test/resources/speech_to_text/word.json
+++ b/speech-to-text/src/test/resources/speech_to_text/word.json
@@ -7,5 +7,7 @@
   "source": [
     "string"
   ],
-  "error": "string"
+  "error": [
+    {"string": "string"}
+  ]
 }

--- a/speech-to-text/src/test/resources/speech_to_text/words.json
+++ b/speech-to-text/src/test/resources/speech_to_text/words.json
@@ -8,8 +8,7 @@
       "display_as": "string",
       "source": [
         "string"
-      ],
-      "error": "string"
+      ]
     }
   ]
 }

--- a/text-to-speech/src/main/java/com/ibm/watson/developer_cloud/text_to_speech/v1/model/CustomVoiceModel.java
+++ b/text-to-speech/src/main/java/com/ibm/watson/developer_cloud/text_to_speech/v1/model/CustomVoiceModel.java
@@ -95,7 +95,7 @@ public class CustomVoiceModel extends GenericModel {
   }
 
   /**
-   * Returns the language code (for example, en-us)
+   * Returns the language code (for example, en-us).
    *
    * @return the language code
    */
@@ -104,7 +104,7 @@ public class CustomVoiceModel extends GenericModel {
   }
 
   /**
-   * Sets the language code (for example, en-us)
+   * Sets the language code (for example, en-us).
    *
    * @param language the language code
    */

--- a/text-to-speech/src/test/java/com/ibm/watson/developer_cloud/text_to_speech/v1/CustomizationsTest.java
+++ b/text-to-speech/src/test/java/com/ibm/watson/developer_cloud/text_to_speech/v1/CustomizationsTest.java
@@ -94,6 +94,8 @@ public class CustomizationsTest extends WatsonServiceUnitTest {
 
   /**
    * Test get voice with custom voice model.
+   *
+   * @throws InterruptedException the interrupted exception
    */
   @Test
   public void testGetVoiceCustomization() throws InterruptedException {


### PR DESCRIPTION
The `WordData` object was looking for a string for the `error` field, but the field is returned as an array of string-to-string mappings.  The fix prevents the object from throwing an exception when information about a word with a faulty definition is returned.  This PR addresses issue https://github.com/watson-developer-cloud/java-sdk/issues/564.

The PR also makes some small improvements to a few other files, none major.