### PR TITLE
Enable customization for Speech to Test WebSocket recognition requests

### DIFF
--- a/speech-to-text/src/main/java/com/ibm/watson/developer_cloud/speech_to_text/v1/model/RecognizeOptions.java
+++ b/speech-to-text/src/main/java/com/ibm/watson/developer_cloud/speech_to_text/v1/model/RecognizeOptions.java
@@ -201,7 +201,6 @@ public class RecognizeOptions {
       return this;
     }
 
-
     /**
      * Specifies a minimum level of confidence that the service must have to report a matching keyword in the input
      * audio. Specify a probability value between 0 and 1 inclusive. A match must have at least the specified confidence
@@ -288,7 +287,6 @@ public class RecognizeOptions {
       return this;
     }
 
-
     /**
      * If true, confidence measure per word is returned if available.
      *
@@ -303,10 +301,9 @@ public class RecognizeOptions {
 
   @SerializedName("content-type")
   private String contentType;
-
   private Boolean continuous;
-
   private Integer inactivityTimeout;
+
   @SerializedName("interim_results")
   private Boolean interimResults;
   private String[] keywords;
@@ -318,15 +315,20 @@ public class RecognizeOptions {
   private String model;
   private String sessionId;
   private Boolean timestamps;
+
   @SerializedName("word_alternatives_threshold")
   private Double wordAlternativesThreshold;
+
   @SerializedName("word_confidence")
   private Boolean wordConfidence;
+
   @SerializedName("smart_formatting")
   private Boolean smartFormatting;
+
   @SerializedName("customization_id")
   private String customizationId;
-  @SerializedName("diarization")
+
+  @SerializedName("speaker_labels")
   private Boolean speakerLabels;
 
   private RecognizeOptions(Builder builder) {

--- a/speech-to-text/src/main/java/com/ibm/watson/developer_cloud/speech_to_text/v1/websocket/WebSocketManager.java
+++ b/speech-to-text/src/main/java/com/ibm/watson/developer_cloud/speech_to_text/v1/websocket/WebSocketManager.java
@@ -70,6 +70,7 @@ public class WebSocketManager {
     private static final String ERROR = "error";
     private static final String RESULTS = "results";
     private static final String SPEAKER_LABELS = "speaker_labels";
+    private static final String CUSTOMIZATION_ID = "customization_id";
 
     private static final String TIMEOUT_PREFIX = "No speech detected for";
 
@@ -226,6 +227,7 @@ public class WebSocketManager {
     private String buildStartMessage(RecognizeOptions options) {
       JsonObject startMessage = new JsonParser().parse(new Gson().toJson(options)).getAsJsonObject();
       startMessage.remove(MODEL);
+      startMessage.remove(CUSTOMIZATION_ID);
       startMessage.addProperty(ACTION, START);
       return startMessage.toString();
     }
@@ -265,6 +267,9 @@ public class WebSocketManager {
    */
   private Request prepareRequest(RecognizeOptions options) {
     String speechModel = options.model() == null ? "" : "?model=" + options.model();
+    if (options.customizationId() != null) {
+      speechModel += "&customization_id=" + options.customizationId();
+    }
     Builder builder = new Request.Builder().url(url + speechModel);
 
     if (token != null) {


### PR DESCRIPTION
Move the `customization_id` from the `start` message to a query parameter of the connection request for a WebSocket `recognize` call.  This addresses issue https://github.com/watson-developer-cloud/java-sdk/issues/540.