### PR TITLE
Fix and expand constructors for Speech to Text Word object

### DIFF
--- a/speech-to-text/src/main/java/com/ibm/watson/developer_cloud/speech_to_text/v1/model/Word.java
+++ b/speech-to-text/src/main/java/com/ibm/watson/developer_cloud/speech_to_text/v1/model/Word.java
@@ -67,35 +67,60 @@ public class Word extends GenericModel {
     }
   }
 
-  @SerializedName("display_as")
-  private String displayAs;
-  @SerializedName("sounds_like")
-  private List<String> soundsLike;
   private String word;
 
+  @SerializedName("display_as")
+  private String displayAs;
+
+  @SerializedName("sounds_like")
+  private List<String> soundsLike;
+
   /**
-   * Instantiates a new word.
+   * Instantiates a new empty word.
    */
   public Word() { }
 
   /**
-   * Instantiates a new word.
+   * Instantiates a new word with a word name.
    *
-   * @param word the spelling of the word is used to train the model.
-   * @param displayAs the spelling of the custom word that the service uses to display the word in a transcript.
+   * @param word The spelling of the custom word that the service uses to train the model.
+   */
+  public Word(String word) {
+    this(word, null, (String[]) null);
+  }
+
+  /**
+   * Instantiates a new word with a word name and a display-as value.
+   *
+   * @param word The spelling of the custom word that the service uses to train the model.
+   * @param displayAs The spelling of the custom word that the service uses to display the word in a transcript.
+   */
+  public Word(String word, String displayAs) {
+    this(word, displayAs, (String[]) null);
+  }
+
+  /**
+   * Instantiates a new word with a word name, a display-as value, and one or more sounds-like values.
+   *
+   * @param word The spelling of the custom word that the service uses to train the model.
+   * @param displayAs The spelling of the custom word that the service uses to display the word in a transcript.
    * @param soundsLike An array of pronunciations for the custom word.
    */
   public Word(String word, String displayAs, String... soundsLike) {
-    this();
     this.word = word;
+    if (displayAs != null) {
+      this.displayAs = displayAs;
+    }
     this.displayAs = displayAs;
-    this.soundsLike = Arrays.asList(soundsLike);
+    if (soundsLike != null) {
+      this.soundsLike = Arrays.asList(soundsLike);
+    }
   }
 
   /**
    * Gets the spelling of the custom word that the service uses to display the word in a transcript.
    *
-   * @return The displayAs
+   * @return The display_as
    */
   public String getDisplayAs() {
     return displayAs;
@@ -104,7 +129,7 @@ public class Word extends GenericModel {
   /**
    * Gets the sounds like. An array of pronunciations for the custom word
    *
-   * @return The soundsLike
+   * @return The sounds_like
    */
   public List<String> getSoundsLike() {
     return soundsLike;

--- a/speech-to-text/src/test/java/com/ibm/watson/developer_cloud/speech_to_text/v1/SpeechToTextIT.java
+++ b/speech-to-text/src/test/java/com/ibm/watson/developer_cloud/speech_to_text/v1/SpeechToTextIT.java
@@ -542,6 +542,11 @@ public class SpeechToTextIT extends WatsonServiceTest {
       // Now add some user words to the custom model
       service.addWord(id, new Word("IEEE", "IEEE", "I. triple E.")).execute();
       service.addWord(id, new Word("hhonors", "IEEE", "H. honors", "Hilton honors")).execute();
+      service.addWord(id, new Word("aaa", "aaa", "aaa", "bbb")).execute();
+      service.addWord(id, new Word("bbb", null, "aaa", "bbb")).execute();
+      service.addWord(id, new Word("ccc", "ccc")).execute();
+      service.addWord(id, new Word("ddd")).execute();
+      service.addWord(id, new Word("eee", null, (String[]) null)).execute();
 
       // Display all words in the words resource (coming from OOVs from the corpus add and the new words just added)
       List<WordData> words = service.getWords(id, Word.Type.ALL).execute();


### PR DESCRIPTION
Fix an issue with an existing `Word` constructor that made it difficult to add a new word without a `sounds_like` field, and expand the list of constructors to make it simpler to add new `Word` objects with different combinations of supported parameters.  This PR addresses issue https://github.com/watson-developer-cloud/java-sdk/issues/584.