### PR TITLE
Update Text to Speech customization interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,10 @@ Change Log
  * Fix: Speech to Text: Enable customization_id for recognizeUsingWebSocket() method
  * Fix: Speech to Text: Fix allowOverwrite parameter of addTextToCustomizationCorpus() method
  * Fix: Speech to Text: Fix error field for WordData object
+ * New: Text to Speech: Add createCustomVoiceModel() and updateCustomVoiceModel() methods, deprecate saveCustomVoiceModel() method
+ * New: Text to Speech: Add addWords() and addWord() methods, deprecate saveWords() method
  * New: Text to Speech: Add getWord() method
+ * New: Text to Speech: Add getCustomVoiceModel() method with CustomVoiceModel argument
  * New: Text to Speech: Add deleteWord() method with String argument
  * New: Text to Speech: Add part_of_speech to CustomTranslation object
  * Fix: Text to Speech: Enable customization results for getVoice() method

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Change Log
  * New: Text to Speech: Add getWord() method
  * New: Text to Speech: Add getCustomVoiceModel() method with CustomVoiceModel argument
  * New: Text to Speech: Add deleteWord() method with String argument
+ * New: Text to Speech: Add words to CustomVoiceModel object
  * New: Text to Speech: Add part_of_speech to CustomTranslation object
  * Fix: Text to Speech: Enable customization results for getVoice() method
  * New: Tradeoff Analytics: Add findPreferableOptions parameter to dilemmas() method

--- a/examples/java/com/ibm/watson/developer_cloud/text_to_speech/v1/CustomizationExample.java
+++ b/examples/java/com/ibm/watson/developer_cloud/text_to_speech/v1/CustomizationExample.java
@@ -39,7 +39,9 @@ public class CustomizationExample {
     System.out.println(customVoiceModels);
 
     // update custom voice model.
-    service.updateCustomVoiceModel(customVoiceModel, null, "the updated model for testing").execute();
+    customVoiceModel.setName("my updated model");
+    customVoiceModel.setDescription("the updated model for testing");
+    service.updateCustomVoiceModel(customVoiceModel).execute();
 
     // list custom voice models regardless of language.
     customVoiceModels = service.getCustomVoiceModels(null).execute();

--- a/examples/java/com/ibm/watson/developer_cloud/text_to_speech/v1/CustomizationExample.java
+++ b/examples/java/com/ibm/watson/developer_cloud/text_to_speech/v1/CustomizationExample.java
@@ -31,25 +31,27 @@ public class CustomizationExample {
     TextToSpeech service = new TextToSpeech("<username>", "<password>");
 
     // create custom voice model.
-    CustomVoiceModel model = new CustomVoiceModel();
-    model.setName("my model");
-    model.setLanguage("en-US");
-    model.setDescription("the model for testing");
-    CustomVoiceModel customVoiceModel = service.saveCustomVoiceModel(model).execute();
+    CustomVoiceModel customVoiceModel = service.createCustomVoiceModel("my model", "en-US", "the model for testing").execute();
     System.out.println(customVoiceModel);
 
     // list custom voice models for US English.
     List<CustomVoiceModel> customVoiceModels = service.getCustomVoiceModels("en-US").execute();
     System.out.println(customVoiceModels);
 
+    // update custom voice model.
+    service.updateCustomVoiceModel(customVoiceModel, null, "the updated model for testing").execute();
+
     // list custom voice models regardless of language.
     customVoiceModels = service.getCustomVoiceModels(null).execute();
     System.out.println(customVoiceModels);
 
-    // create custom word translations
+    // create multiple custom word translations
     CustomTranslation customTranslation1 = new CustomTranslation("hodor", "hold the door");
     CustomTranslation customTranslation2 = new CustomTranslation("plz", "please");
-    service.saveWords(customVoiceModel, customTranslation1, customTranslation2).execute();
+    service.addWords(customVoiceModel, customTranslation1, customTranslation2).execute();
+
+    // create a single custom word translation
+    service.addWord(customVoiceModel, new CustomTranslation("nat", "and that")).execute();
 
     // get custom word translations
     List<CustomTranslation> words = service.getWords(customVoiceModel).execute();
@@ -69,7 +71,11 @@ public class CustomizationExample {
     service.deleteWord(customVoiceModel, customTranslation2.getWord());
 
     // delete custom voice model
-    service.deleteCustomVoiceModel(customVoiceModel);
+    service.deleteCustomVoiceModel(customVoiceModel).execute();
+
+    // list custom voice models regardless of language.
+    customVoiceModels = service.getCustomVoiceModels(null).execute();
+    System.out.println(customVoiceModels);
   }
 
   private static void writeToFile(InputStream in, File file) {

--- a/text-to-speech/src/main/java/com/ibm/watson/developer_cloud/text_to_speech/v1/TextToSpeech.java
+++ b/text-to-speech/src/main/java/com/ibm/watson/developer_cloud/text_to_speech/v1/TextToSpeech.java
@@ -31,7 +31,6 @@ import com.ibm.watson.developer_cloud.text_to_speech.v1.model.Phoneme;
 import com.ibm.watson.developer_cloud.text_to_speech.v1.model.Pronunciation;
 import com.ibm.watson.developer_cloud.text_to_speech.v1.model.Voice;
 import com.ibm.watson.developer_cloud.util.GsonSingleton;
-import com.ibm.watson.developer_cloud.util.RequestUtils;
 import com.ibm.watson.developer_cloud.util.ResponseConverterUtils;
 import com.ibm.watson.developer_cloud.util.ResponseUtils;
 import com.ibm.watson.developer_cloud.util.Validator;
@@ -127,7 +126,7 @@ public class TextToSpeech extends WatsonService {
    * @param customizationId the customization id
    * @return the {@link Voice}
    */
-  public ServiceCall<Voice> getVoice(final String voiceName, String customizationId) {
+  public ServiceCall<Voice> getVoice(final String voiceName, final String customizationId) {
     Validator.notNull(voiceName, "name cannot be null");
 
     RequestBuilder requestBuilder = RequestBuilder.get(String.format(PATH_VOICE, voiceName));
@@ -148,7 +147,7 @@ public class TextToSpeech extends WatsonService {
    * @return the word pronunciation
    * @see Pronunciation
    */
-  public ServiceCall<Pronunciation> getPronunciation(String word, Voice voice, Phoneme phoneme) {
+  public ServiceCall<Pronunciation> getPronunciation(final String word, final Voice voice, final Phoneme phoneme) {
     return getPronunciation(word, voice, phoneme, null);
   }
 
@@ -162,8 +161,8 @@ public class TextToSpeech extends WatsonService {
    * @return the word pronunciation
    * @see Pronunciation
    */
-  public ServiceCall<Pronunciation> getPronunciation(String word, Voice voice, Phoneme phoneme,
-      String customizationId) {
+  public ServiceCall<Pronunciation> getPronunciation(final String word, final Voice voice, final Phoneme phoneme,
+      final String customizationId) {
     final RequestBuilder requestBuilder = RequestBuilder.get(PATH_GET_PRONUNCIATION).query(TEXT, word);
     if (voice != null) {
       requestBuilder.query(VOICE, voice.getName());
@@ -250,25 +249,39 @@ public class TextToSpeech extends WatsonService {
   }
 
   /**
-   * Gets the meta data of a specific CustomVoiceModel.
+   * Gets the metadata for a CustomVoiceModel specified by object.
    *
-   * @param id the customization id of the CustomVoiceModel
-   * @return the VoiceModel
+   * @param model the custom voice model object to be queried
+   * @return the CustomVoiceModel with full metadata
    */
-  public ServiceCall<CustomVoiceModel> getCustomVoiceModel(final String id) {
-    Validator.notNull(id, "id cannot be null");
+  public ServiceCall<CustomVoiceModel> getCustomVoiceModel(final CustomVoiceModel model) {
+    Validator.notNull(model, "model cannot be null");
+    Validator.notEmpty(model.getId(), "model id must not be empty");
 
-    final Request request = RequestBuilder.get(String.format(PATH_CUSTOMIZATION, id)).build();
+    return getCustomVoiceModel(model.getId());
+  }
+
+  /**
+   * Gets the metadata for a CustomVoiceModel specified by customization id.
+   *
+   * @param customizationId the id of the custom voice model to be queried
+   * @return the CustomVoiceModel with full metadata
+   */
+  public ServiceCall<CustomVoiceModel> getCustomVoiceModel(final String customizationId) {
+    Validator.notNull(customizationId, "customization id cannot be null");
+
+    final Request request = RequestBuilder.get(String.format(PATH_CUSTOMIZATION, customizationId)).build();
     return createServiceCall(request, ResponseConverterUtils.getObject(CustomVoiceModel.class));
   }
 
   /**
-   * Saves a CustomVoiceModel. If the given model has an id, this service will update an existing model. When no id is
-   * set, a new CustomVoiceModel is created and the id field set.
+   * Saves a CustomVoiceModel. If the given model has an id, the service updates an existing model. If no id is set,
+   * a new CustomVoiceModel is created and the id field set. You cannot specify a new language for an existing model.
    *
-   * @param model the model to be saved
-   * @return a reference to the given CustomVoiceModel. If a new CustomVoiceModel is created, the id field will be
-   *         populated.
+   * @param model the custom voice model object to be saved
+   * @return a reference to the given CustomVoiceModel. If a new model is created, the id field is populated.
+   * @deprecated use {@link #createCustomVoiceModel(String, String, String)} and
+   * {@link #updateCustomVoiceModel(CustomVoiceModel, String, String)} instead.
    */
   public ServiceCall<CustomVoiceModel> saveCustomVoiceModel(final CustomVoiceModel model) {
     final boolean isNew = model.getId() == null;
@@ -312,12 +325,65 @@ public class TextToSpeech extends WatsonService {
   }
 
   /**
-   * Deletes the given CustomVoiceModel (requires a valid id to be set).
+   * Creates a new CustomVoiceModel with the specified parameter values.
    *
-   * @param model the CustomVoiceModel
+   * @param name the name of the new model
+   * @param language the language of the new model (the default is "en-US")
+   * @param description a description of the new model
+   * @return a CustomVoiceModel that contains the id of the new model
+   */
+  public ServiceCall<CustomVoiceModel> createCustomVoiceModel(final String name, final String language,
+      final String description) {
+    Validator.notNull(name, "name cannot be null");
+
+    CustomVoiceModel model = new CustomVoiceModel();
+    model.setName(name);
+    if (language != null) {
+        model.setLanguage(language);
+    }
+    if (description != null) {
+        model.setDescription(description);
+    }
+
+    final RequestBody body = RequestBody.create(HttpMediaType.JSON, model.toString());
+    final Request request = RequestBuilder.post(PATH_CUSTOMIZATIONS).body(body).build();
+    return createServiceCall(request, ResponseConverterUtils.getObject(CustomVoiceModel.class));
+  }
+
+  /**
+   * Updates an existing CustomVoiceModel with the specified parameter values.
+   *
+   * @param model the custom voice model object to be updated
+   * @param name a new name for the model
+   * @param description a new description for the model
    * @return the service call
    */
-  public ServiceCall<Void> deleteCustomVoiceModel(CustomVoiceModel model) {
+  public ServiceCall<Void> updateCustomVoiceModel(final CustomVoiceModel model, final String name,
+      final String description) {
+    Validator.notNull(model, "model cannot be null");
+    Validator.notEmpty(model.getId(), "model id must not be empty");
+
+    if (name != null) {
+        model.setName(name);
+    }
+    if (description != null) {
+        model.setDescription(description);
+    }
+
+    final String path = String.format(PATH_CUSTOMIZATION, model.getId());
+    final RequestBody body = RequestBody.create(HttpMediaType.JSON, model.toString());
+    final Request request = RequestBuilder.post(path).body(body).build();
+    return createServiceCall(request, ResponseConverterUtils.getVoid());
+  }
+
+  /**
+   * Deletes the given CustomVoiceModel.
+   *
+   * @param model the custom voice model object to be deleted
+   * @return the service call
+   */
+  public ServiceCall<Void> deleteCustomVoiceModel(final CustomVoiceModel model) {
+    Validator.notNull(model, "model cannot be null");
     Validator.notEmpty(model.getId(), "model id must not be empty");
 
     final Request request = RequestBuilder.delete(String.format(PATH_CUSTOMIZATION, model.getId())).build();
@@ -327,10 +393,10 @@ public class TextToSpeech extends WatsonService {
   /**
    * Gets all custom word translation for the given CustomVoiceModel.
    *
-   * @param model the CustomVoiceModel
-   * @return a list of all CustomTranslations
+   * @param model the custom voice model object from which words are to be listed
+   * @return a list of all CustomTranslations for the model
    */
-  public ServiceCall<List<CustomTranslation>> getWords(CustomVoiceModel model) {
+  public ServiceCall<List<CustomTranslation>> getWords(final CustomVoiceModel model) {
     Validator.notNull(model.getId(), "model id cannot be null");
 
     final Request request = RequestBuilder.get(String.format(PATH_WORDS, model.getId())).build();
@@ -342,12 +408,13 @@ public class TextToSpeech extends WatsonService {
   /**
    * Gets a custom word translation for the given CustomVoiceModel.
    *
-   * @param model the CustomVoiceModel
+   * @param model the custom voice model object from which a word is to be listed
    * @param word a word from the CustomVoiceModel
    * @return the translation of the word
    */
-    public ServiceCall<CustomTranslation> getWord(CustomVoiceModel model, String word) {
-    Validator.notNull(model.getId(), "model id cannot be null");
+    public ServiceCall<CustomTranslation> getWord(final CustomVoiceModel model, final String word) {
+    Validator.notNull(model, "model cannot be null");
+    Validator.notEmpty(model.getId(), "model id must not be empty");
     Validator.notNull(word, "word cannot be null");
 
     final Request request = RequestBuilder.get(String.format(PATH_WORD, model.getId(), word)).build();
@@ -355,14 +422,17 @@ public class TextToSpeech extends WatsonService {
   }
 
   /**
-   * Saves or updates custom word translations. If no translation with the given word is existing, a new translation is
-   * created. Elsewise, the existing translation is updated.
+   * Saves or updates custom word translations for a CustomVoiceModel. If no translation with a given word exists,
+   * a new translation is created. Otherwise, the existing translation is updated.
    *
-   * @param model the CustomVoiceModel
+   * @param model the custom voice model object to which words are to be saved
    * @param translations the translations to be saved or updated
    * @return the service call
+   * @deprecated use {@link #addWords(CustomVoiceModel, CustomTranslation...)} and
+   * {@link #addWord(CustomVoiceModel, CustomTranslation)} instead.
    */
-  public ServiceCall<Void> saveWords(CustomVoiceModel model, CustomTranslation... translations) {
+  public ServiceCall<Void> saveWords(final CustomVoiceModel model, final CustomTranslation... translations) {
+    Validator.notNull(model, "model cannot be null");
     Validator.notEmpty(model.getId(), "model id must not be empty");
 
     final String json = GSON.toJson(Collections.singletonMap("words", translations));
@@ -373,29 +443,70 @@ public class TextToSpeech extends WatsonService {
   }
 
   /**
-   * Deletes a custom word based on a translation object.
+   * Adds or updates one or more custom word translations for a CustomVoiceModel. If no translation with a given word
+   * exists, a new translation is created. Otherwise, the existing translation is updated.
    *
-   * @param model the CustomVoiceModel
-   * @param translation the translation object
+   * @param model the custom voice model object for which words are to be added or updated
+   * @param translations the translations to be added or updated
    * @return the service call
    */
-  public ServiceCall<Void> deleteWord(CustomVoiceModel model, CustomTranslation translation) {
+  public ServiceCall<Void> addWords(final CustomVoiceModel model, final CustomTranslation... translations) {
+    Validator.notNull(model, "model cannot be null");
     Validator.notEmpty(model.getId(), "model id must not be empty");
-    Validator.notEmpty(translation.getWord(), "word must not be empty");
+    Validator.notNull(translations, "translations cannot be null");
 
-    final String path = String.format(PATH_WORD, model.getId(), RequestUtils.encode(translation.getWord()));
-    final Request request = RequestBuilder.delete(path).build();
+    final String json = GSON.toJson(Collections.singletonMap("words", translations));
+    final String path = String.format(PATH_WORDS, model.getId());
+    final RequestBody body = RequestBody.create(HttpMediaType.JSON, json);
+    final Request request = RequestBuilder.post(path).body(body).build();
     return createServiceCall(request, ResponseConverterUtils.getVoid());
+  }
+
+  /**
+   * Adds or updates a single custom word translation for a CustomVoiceModel. If no translation with the given word
+   * exists, a new translation is created. Otherwise, the existing translation is updated.
+   *
+   * @param model the custom voice model object for which a word is to be added or updated
+   * @param translation the translation to be added or updated
+   * @return the service call
+   */
+  public ServiceCall<Void> addWord(final CustomVoiceModel model, final CustomTranslation translation) {
+    Validator.notNull(model, "model cannot be null");
+    Validator.notEmpty(model.getId(), "model id must not be empty");
+    Validator.notNull(translation, "translation cannot be null");
+    Validator.notEmpty(translation.getWord(), "translation word cannot be empty");
+
+    final String path = String.format(PATH_WORD, model.getId(), translation.getWord());
+    final RequestBody body = RequestBody.create(HttpMediaType.JSON, translation.toString());
+    final Request request = RequestBuilder.put(path).body(body).build();
+    return createServiceCall(request, ResponseConverterUtils.getVoid());
+  }
+
+  /**
+   * Deletes a custom word based on a translation object.
+   *
+   * @param model the custom voice model object from which a word is to be deleted
+   * @param translation the translation object to be deleted
+   * @return the service call
+   */
+  public ServiceCall<Void> deleteWord(final CustomVoiceModel model, final CustomTranslation translation) {
+    Validator.notNull(model, "model cannot be null");
+    Validator.notEmpty(model.getId(), "model id must not be empty");
+    Validator.notNull(translation, "translation cannot be null");
+    Validator.notEmpty(translation.getWord(), "translation word must not be empty");
+
+    return deleteWord(model, translation.getWord());
   }
 
   /**
    * Deletes a custom word based on a string.
    *
-   * @param model the CustomVoiceModel
-   * @param word the word
+   * @param model the custom voice model object from which a word is to be deleted
+   * @param word the word to be deleted
    * @return the service call
    */
-  public ServiceCall<Void> deleteWord(CustomVoiceModel model, String word) {
+  public ServiceCall<Void> deleteWord(final CustomVoiceModel model, final String word) {
+    Validator.notNull(model, "model cannot be null");
     Validator.notEmpty(model.getId(), "model id must not be empty");
     Validator.notNull(word, "word cannot be null");
 

--- a/text-to-speech/src/main/java/com/ibm/watson/developer_cloud/text_to_speech/v1/TextToSpeech.java
+++ b/text-to-speech/src/main/java/com/ibm/watson/developer_cloud/text_to_speech/v1/TextToSpeech.java
@@ -281,7 +281,7 @@ public class TextToSpeech extends WatsonService {
    * @param model the custom voice model object to be saved
    * @return a reference to the given CustomVoiceModel. If a new model is created, the id field is populated.
    * @deprecated use {@link #createCustomVoiceModel(String, String, String)} and
-   * {@link #updateCustomVoiceModel(CustomVoiceModel, String, String)} instead.
+   * {@link #updateCustomVoiceModel(CustomVoiceModel)} instead.
    */
   public ServiceCall<CustomVoiceModel> saveCustomVoiceModel(final CustomVoiceModel model) {
     final boolean isNew = model.getId() == null;
@@ -325,11 +325,11 @@ public class TextToSpeech extends WatsonService {
   }
 
   /**
-   * Creates a new CustomVoiceModel with the specified parameter values.
+   * Creates a new CustomVoiceModel with the specified name, description, and language.
    *
    * @param name the name of the new model
    * @param language the language of the new model (the default is "en-US")
-   * @param description a description of the new model
+   * @param description a description of the new model (the default is no description)
    * @return a CustomVoiceModel that contains the id of the new model
    */
   public ServiceCall<CustomVoiceModel> createCustomVoiceModel(final String name, final String language,
@@ -351,24 +351,15 @@ public class TextToSpeech extends WatsonService {
   }
 
   /**
-   * Updates an existing CustomVoiceModel with the specified parameter values.
+   * Updates an existing CustomVoiceModel with new name, new description, and new custom word translations. If no
+   * translation with a given word exists, a new translation is created. Otherwise, the existing translation is updated.
    *
-   * @param model the custom voice model object to be updated
-   * @param name a new name for the model
-   * @param description a new description for the model
+   * @param model the custom voice model object to be updated with new name, description, and words
    * @return the service call
    */
-  public ServiceCall<Void> updateCustomVoiceModel(final CustomVoiceModel model, final String name,
-      final String description) {
+  public ServiceCall<Void> updateCustomVoiceModel(final CustomVoiceModel model) {
     Validator.notNull(model, "model cannot be null");
     Validator.notEmpty(model.getId(), "model id must not be empty");
-
-    if (name != null) {
-        model.setName(name);
-    }
-    if (description != null) {
-        model.setDescription(description);
-    }
 
     final String path = String.format(PATH_CUSTOMIZATION, model.getId());
     final RequestBody body = RequestBody.create(HttpMediaType.JSON, model.toString());
@@ -447,7 +438,7 @@ public class TextToSpeech extends WatsonService {
    * exists, a new translation is created. Otherwise, the existing translation is updated.
    *
    * @param model the custom voice model object for which words are to be added or updated
-   * @param translations the translations to be added or updated
+   * @param translations the custom translations to be added or updated
    * @return the service call
    */
   public ServiceCall<Void> addWords(final CustomVoiceModel model, final CustomTranslation... translations) {

--- a/text-to-speech/src/main/java/com/ibm/watson/developer_cloud/text_to_speech/v1/model/CustomVoiceModel.java
+++ b/text-to-speech/src/main/java/com/ibm/watson/developer_cloud/text_to_speech/v1/model/CustomVoiceModel.java
@@ -13,12 +13,13 @@
 package com.ibm.watson.developer_cloud.text_to_speech.v1.model;
 
 import java.util.Date;
+import java.util.List;
 
 import com.google.gson.annotations.SerializedName;
 import com.ibm.watson.developer_cloud.service.model.GenericModel;
 
 /**
- * A customized voice model, that allows users to specify custom pronunciations for Waton's Text to Speech API.
+ * A customized voice model that allows users to specify custom pronunciations for Waton's Text to Speech API.
  *
  * @see <a href= "http://www.ibm.com/watson/developercloud/doc/text-to-speech/custom-intro.shtml"> Customization</a>
  */
@@ -28,17 +29,16 @@ public class CustomVoiceModel extends GenericModel {
   private String id;
 
   private String name;
-
   private String description;
-
   private String language;
-
   private String owner;
-
   private Date created;
 
   @SerializedName("last_modified")
   private Date lastModified;
+
+  @SerializedName("words")
+  private List<CustomTranslation> customTranslations;
 
   /**
    * Returns the id.
@@ -137,6 +137,24 @@ public class CustomVoiceModel extends GenericModel {
    */
   public Date getLastModified() {
     return lastModified;
+  }
+
+  /**
+   * Returns the custom translations for a custom voice model.
+   *
+   * @return the list of custom translations for the model
+   */
+  public List<CustomTranslation> getCustomTranslations() {
+    return customTranslations;
+  }
+
+  /**
+   * Sets the custom translations for a custom voice model.
+   *
+   * @param customTranslations the list of custom translations for the model
+   */
+  public void setCustomTranslations(List<CustomTranslation> customTranslations) {
+    this.customTranslations = customTranslations;
   }
 
 }

--- a/text-to-speech/src/test/java/com/ibm/watson/developer_cloud/text_to_speech/v1/CustomizationsTest.java
+++ b/text-to-speech/src/test/java/com/ibm/watson/developer_cloud/text_to_speech/v1/CustomizationsTest.java
@@ -14,6 +14,8 @@ package com.ibm.watson.developer_cloud.text_to_speech.v1;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertNotNull;
 
 import java.util.List;
 
@@ -75,6 +77,17 @@ public class CustomizationsTest extends WatsonServiceUnitTest {
     model.setName(MODEL_NAME);
     model.setDescription(MODEL_DESCRIPTION);
     model.setLanguage(MODEL_LANGUAGE);
+
+    return model;
+  }
+
+  private static CustomVoiceModel instantiateVoiceModelWords() {
+    CustomVoiceModel model = new CustomVoiceModel();
+    model.setId("cafebabe-1234-5678-9abc-def012345678");
+    model.setName(MODEL_NAME);
+    model.setDescription(MODEL_DESCRIPTION);
+    model.setLanguage(MODEL_LANGUAGE);
+    model.setCustomTranslations(instantiateWords());
 
     return model;
   }
@@ -162,7 +175,7 @@ public class CustomizationsTest extends WatsonServiceUnitTest {
    */
   @Test
   public void testGetVoiceModel() throws InterruptedException {
-    final CustomVoiceModel expected = instantiateVoiceModel();
+    final CustomVoiceModel expected = instantiateVoiceModelWords();
 
     // Test with customization ID
     server.enqueue(jsonResponse(expected));
@@ -173,6 +186,8 @@ public class CustomizationsTest extends WatsonServiceUnitTest {
     assertEquals(String.format(VOICE_MODEL_PATH, expected.getId()), request.getPath());
     assertEquals("GET", request.getMethod());
     assertEquals(expected, result);
+    assertNotNull(expected.getCustomTranslations());
+    assertEquals(expected.getCustomTranslations(), result.getCustomTranslations());
 
     // Test with model object
     server.enqueue(jsonResponse(expected));
@@ -183,6 +198,7 @@ public class CustomizationsTest extends WatsonServiceUnitTest {
     assertEquals(String.format(VOICE_MODEL_PATH, expected.getId()), request.getPath());
     assertEquals("GET", request.getMethod());
     assertEquals(expected, result);
+    assertEquals(expected.getCustomTranslations(), result.getCustomTranslations());
   }
 
   /**
@@ -206,12 +222,15 @@ public class CustomizationsTest extends WatsonServiceUnitTest {
     // Compare expected with actual results.
     server.enqueue(jsonResponse(expected));
 
-    final CustomVoiceModel detailsResult = service.getCustomVoiceModel(expected.getId()).execute();
-    final RecordedRequest detailsRequest = server.takeRequest();
+    final CustomVoiceModel getResult = service.getCustomVoiceModel(expected.getId()).execute();
+    final RecordedRequest getRequest = server.takeRequest();
 
-    assertEquals(String.format(VOICE_MODEL_PATH, expected.getId()), detailsRequest.getPath());
-    assertEquals("GET", detailsRequest.getMethod());
-    assertEquals(expected, detailsResult);
+    assertEquals(String.format(VOICE_MODEL_PATH, expected.getId()), getRequest.getPath());
+    assertEquals("GET", getRequest.getMethod());
+    assertEquals(expected, getResult);
+    assertNull(expected.getCustomTranslations());
+    assertEquals(expected.getCustomTranslations(), getResult.getCustomTranslations());
+
   }
 
   /**
@@ -231,9 +250,7 @@ public class CustomizationsTest extends WatsonServiceUnitTest {
 
     // Update the custom voice model.
     server.enqueue(new MockResponse().setResponseCode(201));
-    //    server.enqueue(jsonResponse(ImmutableMap.of(ID, expected.getId())));
-
-    service.updateCustomVoiceModel(expected, expected.getName(), expected.getDescription()).execute();
+    service.updateCustomVoiceModel(expected).execute();
     final RecordedRequest updateRequest = server.takeRequest();
 
     assertEquals(String.format(VOICE_MODEL_PATH, expected.getId()), updateRequest.getPath());
@@ -242,12 +259,50 @@ public class CustomizationsTest extends WatsonServiceUnitTest {
     // Compare expected with actual results.
     server.enqueue(jsonResponse(expected));
 
-    final CustomVoiceModel detailsResult = service.getCustomVoiceModel(expected.getId()).execute();
-    final RecordedRequest detailsRequest = server.takeRequest();
+    final CustomVoiceModel getResult = service.getCustomVoiceModel(expected.getId()).execute();
+    final RecordedRequest getRequest = server.takeRequest();
 
-    assertEquals(String.format(VOICE_MODEL_PATH, expected.getId()), detailsRequest.getPath());
-    assertEquals("GET", detailsRequest.getMethod());
-    assertEquals(expected, detailsResult);
+    assertEquals(String.format(VOICE_MODEL_PATH, expected.getId()), getRequest.getPath());
+    assertEquals("GET", getRequest.getMethod());
+    assertEquals(expected, getResult);
+    assertNull(expected.getCustomTranslations());
+    assertEquals(expected.getCustomTranslations(), getResult.getCustomTranslations());
+  }
+
+  /**
+   * Test update voice model with new words.
+   *
+   * @throws InterruptedException the interrupted exception
+   */
+  @Test
+  public void testUpdateVoiceModelWords() throws InterruptedException {
+    // Create the custom voice model.
+    final CustomVoiceModel expected = instantiateVoiceModelWords();
+    server.enqueue(jsonResponse(ImmutableMap.of(ID, expected.getId())));
+
+    final CustomVoiceModel result = service.createCustomVoiceModel(expected.getId(), expected.getName(), expected.getDescription()).execute();
+    final RecordedRequest request = server.takeRequest();
+    assertEquals(expected.getId(), result.getId());
+
+    // Update the custom voice model with new words.
+    server.enqueue(new MockResponse().setResponseCode(201));
+    service.updateCustomVoiceModel(expected).execute();
+    final RecordedRequest updateRequest = server.takeRequest();
+
+    assertEquals(String.format(VOICE_MODEL_PATH, expected.getId()), updateRequest.getPath());
+    assertEquals("POST", request.getMethod());
+
+    // Compare expected with actual results.
+    server.enqueue(jsonResponse(expected));
+
+    final CustomVoiceModel getResult = service.getCustomVoiceModel(expected.getId()).execute();
+    final RecordedRequest getRequest = server.takeRequest();
+
+    assertEquals(String.format(VOICE_MODEL_PATH, expected.getId()), getRequest.getPath());
+    assertEquals("GET", getRequest.getMethod());
+    assertEquals(expected, getResult);
+    assertNotNull(expected.getCustomTranslations());
+    assertEquals(expected.getCustomTranslations(), getResult.getCustomTranslations());
   }
 
   /**


### PR DESCRIPTION
Update the Text to Speech customization interface to become more parallel with the service and with the Node SDK while maintaining the object-based approach to calling methods:

- Add `createCustomVoiceModel()` and `updateCustomVoiceModel()` methods, and deprecate `saveCustomVoiceModel()` method.  The new methods also prevent updating an existing model's language, and they make it possible to provide the capability to add words on an update.  This addresses issue https://github.com/watson-developer-cloud/java-sdk/issues/531.

- Add `addWords()` and `addWord()` method, and deprecate `saveWords()` method.  This is purely to make the interface parallel with the service.  This addresses issue https://github.com/watson-developer-cloud/java-sdk/issues/598.

- Add `getCustomVoiceModel()` method that accepts a model object instead of a customization ID.  The version that accepts an ID is preserved.  The new object-based signature brings the method in line with the other methods of the interface, which accept `CustomVoiceModel` objects to specify a model.

Miscellaneous improvements were also made to comments, JavaDoc, and parameter validation, and all tests and examples are updated accordingly.