### PR TITLE
add check for javax.naming.InitialContext

### DIFF
--- a/core/src/main/java/com/ibm/watson/developer_cloud/util/CredentialUtils.java
+++ b/core/src/main/java/com/ibm/watson/developer_cloud/util/CredentialUtils.java
@@ -112,7 +112,7 @@ public final class CredentialUtils {
    * @return The encoded API Key
    */
   private static String getKeyUsingJNDI(String serviceName) {
-    if (!isClassAvailable("javax.naming.Context")) {
+    if (!isClassAvailable("javax.naming.Context") || !isClassAvailable("javax.naming.InitialContext")) {
       log.info("JNDI string lookups is not available.");
       return null;
     }


### PR DESCRIPTION
I got an email that seems related to #167, from someone using version 3.5.3. Checking for both javax classes should hopefully resolve this.