### PR TITLE
Add all supported languages to enum

### DIFF
--- a/language-translator/src/main/java/com/ibm/watson/developer_cloud/language_translator/v2/model/Language.java
+++ b/language-translator/src/main/java/com/ibm/watson/developer_cloud/language_translator/v2/model/Language.java
@@ -18,13 +18,191 @@ import com.ibm.watson.developer_cloud.language_translator.v2.LanguageTranslator;
  * The languages available in {@link LanguageTranslator}.
  */
 public enum Language {
-  /** arabic. */
-  ARABIC("ar"), /** english. */
-  ENGLISH("en"), /** spanish. */
-  SPANISH("es"), /** french. */
-  FRENCH("fr"), /** italian. */
-  ITALIAN("it"), /** portuguese. */
-  PORTUGUESE("pt");
+  /** Afrikaans. */
+  AFRIKAANS("af"),
+
+  /** Arabic. */
+  ARABIC("ar"),
+
+  /** Azerbaijani. */
+  AZERBAIJANI("az"),
+
+  /** Bashkir. */
+  BASHKIR("ba"),
+
+  /** Belarusian. */
+  BELARUSIAN("be"),
+
+  /** Bulgarian. */
+  BULGARIAN("bg"),
+
+  /** Bengali. */
+  BENGALI("bn"),
+
+  /** Bosnian. */
+  BOSNIAN("bs"),
+
+  /** Czech. */
+  CZECH("cs"),
+
+  /** Chuvash. */
+  CHUVASH("cv"),
+
+  /** Danish. */
+  DANISH("da"),
+
+  /** German. */
+  GERMAN("de"),
+
+  /** Greek. */
+  GREEK("el"),
+
+  /** English. */
+  ENGLISH("en"),
+
+  /** Esperanto. */
+  ESPERANTO("eo"),
+
+  /** Spanish. */
+  SPANISH("es"),
+
+  /** Estonian. */
+  ESTONIAN("et"),
+
+  /** Basque. */
+  BASQUE("eu"),
+
+  /** Persian. */
+  PERSIAN("fa"),
+
+  /** Finnish. */
+  FINNISH("fi"),
+
+  /** French. */
+  FRENCH("fr"),
+
+  /** Gujarati. */
+  GUJARATI("gu"),
+
+  /** Hebrew. */
+  HEBREW("he"),
+
+  /** Hindi. */
+  HINDI("hi"),
+
+  /** Haitian. */
+  HAITIAN("ht"),
+
+  /** Hungarian. */
+  HUNGARIAN("hu"),
+
+  /** Armenian. */
+  ARMENIAN("hy"),
+
+  /** Indonesian. */
+  INDONESIAN("id"),
+
+  /** Icelandic. */
+  ICELANDIC("is"),
+
+  /** Italian. */
+  ITALIAN("it"),
+
+  /** Japanese. */
+  JAPANESE("ja"),
+
+  /** Georgian. */
+  GEORGIAN("ka"),
+
+  /** Kazakh. */
+  KAZAKH("kk"),
+
+  /** Central Khmer. */
+  CENTRAL_KHMER("km"),
+
+  /** Korean. */
+  KOREAN("ko"),
+
+  /** Kurdish. */
+  KURDISH("ku"),
+
+  /** Kirghiz. */
+  KIRGHIZ("ky"),
+
+  /** Lithuanian. */
+  LITHUANIAN("lt"),
+
+  /** Latvian. */
+  LATVIAN("lv"),
+
+  /** Malayalam. */
+  MALAYALAM("ml"),
+
+  /** Mongolian. */
+  MONGOLIAN("mn"),
+
+  /** Norwegian Bokmal. */
+  NORWEGIAN_BOKMAL("nb"),
+
+  /** Dutch. */
+  DUTCH("nl"),
+
+  /** Norwegian Nynorsk. */
+  NORWEGIAN_NYNORSK("nn"),
+
+  /** Panjabi. */
+  PANJABI("pa"),
+
+  /** Polish. */
+  POLISH("pl"),
+
+  /** Pushto. */
+  PUSHTO("ps"),
+
+  /** Portuguese. */
+  PORTUGUESE("pt"),
+
+  /** Romanian. */
+  ROMANIAN("ro"),
+
+  /** Russian. */
+  RUSSIAN("ru"),
+
+  /** Slovakian. */
+  SLOVAKIAN("sk"),
+
+  /** Somali. */
+  SOMALI("so"),
+
+  /** Albanian. */
+  ALBANIAN("sq"),
+
+  /** Swedish. */
+  SWEDISH("sv"),
+
+  /** Tamil. */
+  TAMIL("ta"),
+
+  /** Telugu. */
+  TELUGU("te"),
+
+  /** Turkish. */
+  TURKISH("tr"),
+
+  /** Ukrainian. */
+  UKRAINIAN("uk"),
+
+  /** Urdu. */
+  URDU("ur"),
+
+  /** Vietnamese. */
+  VIETNAMESE("vi"),
+
+  /** Chinese. */
+  CHINESE("zh"),
+
+  /** Traditional Chinese. */
+  TRADITIONAL_CHINESE("zh-TW");
 
   /** language. */
   String language;


### PR DESCRIPTION
Translation without modelId specified is possible only with Language enum values. But currently there only several languages declared in the enum.
I added to enum all languages from https://gateway.watsonplatform.net/language-translator/api/v2/identifiable_languages response to be able to do all possible translations.