### PR TITLE
Fix examples link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Snapshots of the development version are available in [Sonatype's snapshots repo
 
 Download the jar with dependencies [here][jar].
 
-Now, you are ready to see some [examples](https://github.com/watson-developer-cloud/java-sdk/tree/master/examples/java/com/ibm/watson/developer_cloud).
+Now, you are ready to see some [examples](https://github.com/watson-developer-cloud/java-sdk/tree/master/examples/src/main/java/com/ibm/watson/developer_cloud).
 
 
 ## Usage


### PR DESCRIPTION
The examples link is wrong and ends up in a 404 :-)
