### PR TITLE
[text to speech] Special Character failure resolution

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=3.7.1
+version=3.7.2-SNAPSHOT
 group = com.ibm.watson.developer_cloud

--- a/text-to-speech/src/main/java/com/ibm/watson/developer_cloud/text_to_speech/v1/TextToSpeech.java
+++ b/text-to-speech/src/main/java/com/ibm/watson/developer_cloud/text_to_speech/v1/TextToSpeech.java
@@ -31,7 +31,6 @@ import com.ibm.watson.developer_cloud.text_to_speech.v1.model.Phoneme;
 import com.ibm.watson.developer_cloud.text_to_speech.v1.model.Pronunciation;
 import com.ibm.watson.developer_cloud.text_to_speech.v1.model.Voice;
 import com.ibm.watson.developer_cloud.util.GsonSingleton;
-import com.ibm.watson.developer_cloud.util.RequestUtils;
 import com.ibm.watson.developer_cloud.util.ResponseConverterUtils;
 import com.ibm.watson.developer_cloud.util.ResponseUtils;
 import com.ibm.watson.developer_cloud.util.Validator;
@@ -216,10 +215,9 @@ public class TextToSpeech extends WatsonService {
       String customizationId) {
     Validator.isTrue((text != null) && !text.isEmpty(), "text cannot be null or empty");
     Validator.isTrue(voice != null, "voice cannot be null or empty");
-    String encodedText = RequestUtils.encode(text);
 
     final RequestBuilder request = RequestBuilder.get(PATH_SYNTHESIZE);
-    request.query(TEXT, encodedText);
+    request.query(TEXT, text);
     request.query(VOICE, voice.getName());
     request.query(ACCEPT, audioFormat != null ? audioFormat : AudioFormat.WAV);
 

--- a/text-to-speech/src/main/java/com/ibm/watson/developer_cloud/text_to_speech/v1/TextToSpeech.java
+++ b/text-to-speech/src/main/java/com/ibm/watson/developer_cloud/text_to_speech/v1/TextToSpeech.java
@@ -216,8 +216,9 @@ public class TextToSpeech extends WatsonService {
     Validator.isTrue((text != null) && !text.isEmpty(), "text cannot be null or empty");
     Validator.isTrue(voice != null, "voice cannot be null or empty");
 
+    String modifiedText = text.replace(";", "%3B");
     final RequestBuilder request = RequestBuilder.get(PATH_SYNTHESIZE);
-    request.query(TEXT, text);
+    request.query(TEXT, modifiedText);
     request.query(VOICE, voice.getName());
     request.query(ACCEPT, audioFormat != null ? audioFormat : AudioFormat.WAV);
 


### PR DESCRIPTION
Related to #635

Reverts the encoding so TTS won't read "+" when returning a space.