### PR TITLE
[discovery] :new: Provide a specific document Id when creating a document

### DIFF
--- a/discovery/src/main/java/com/ibm/watson/developer_cloud/discovery/v1/Discovery.java
+++ b/discovery/src/main/java/com/ibm/watson/developer_cloud/discovery/v1/Discovery.java
@@ -348,9 +348,19 @@ public class Discovery extends WatsonService implements EnvironmentManager, Conf
     public ServiceCall<CreateDocumentResponse> createDocument(CreateDocumentRequest createRequest) {
         Validator.notEmpty(createRequest.getEnvironmentId(), EnvironmentManager.ID + " cannot be empty");
         Validator.notEmpty(createRequest.getCollectionId(), CollectionManager.ID + " cannot be empty");
-        RequestBuilder builder = RequestBuilder
-                .post(String
-                        .format(PATH_DOCUMENTS, createRequest.getEnvironmentId(), createRequest.getCollectionId()));
+
+        String pathElements;
+        if (createRequest.getDocumentId() == null) {
+            pathElements = String.format(PATH_DOCUMENTS, createRequest.getEnvironmentId(),
+                                         createRequest.getCollectionId());
+        } else {
+            Validator.notEmpty(createRequest.getDocumentId(), DocumentManager.ID + " cannot be empty");
+            pathElements = String.format(PATH_DOCUMENT, createRequest.getEnvironmentId(),
+                                         createRequest.getCollectionId(), createRequest.getDocumentId());
+        }
+
+        RequestBuilder builder = RequestBuilder.post(pathElements);
+
         if (createRequest.getConfigurationId() != null) {
             builder.query(CollectionManager.CONFIGURATION_ID, createRequest.getConfigurationId());
         }

--- a/discovery/src/main/java/com/ibm/watson/developer_cloud/discovery/v1/model/document/CreateDocumentRequest.java
+++ b/discovery/src/main/java/com/ibm/watson/developer_cloud/discovery/v1/model/document/CreateDocumentRequest.java
@@ -28,6 +28,7 @@ public class CreateDocumentRequest extends GenericModel {
     private final String environmentId;
     private final String collectionId;
     private String configurationId;
+    private String documentId;
     private JsonObject metadata;
     private InputStream file;
     private String mediaType;
@@ -38,6 +39,7 @@ public class CreateDocumentRequest extends GenericModel {
         this.environmentId = builder.environmentId;
         this.collectionId = builder.collectionId;
         this.configurationId = builder.configurationId;
+        this.documentId = builder.documentId;
         this.metadata = builder.metadata;
         this.file = builder.file;
         this.mediaType = builder.mediaType;
@@ -50,6 +52,10 @@ public class CreateDocumentRequest extends GenericModel {
 
     public String getCollectionId() {
         return collectionId;
+    }
+
+    public String getDocumentId() {
+        return documentId;
     }
 
     public String getConfigurationId() {
@@ -76,6 +82,7 @@ public class CreateDocumentRequest extends GenericModel {
         private final String environmentId;
         private final String collectionId;
         private String configurationId;
+        private String documentId;
         private JsonObject metadata;
         private InputStream file;
         private String mediaType;
@@ -85,6 +92,11 @@ public class CreateDocumentRequest extends GenericModel {
             this.environmentId = environmentId;
             this.collectionId = collectionId;
             this.fileName = this.fileName == null || this.fileName.isEmpty() ? "file_name_not_provided" : this.fileName;
+        }
+
+        public Builder documentId(String documentId) {
+            this.documentId = documentId;
+            return this;
         }
 
         public Builder configurationId(String configurationId) {

--- a/discovery/src/test/java/com/ibm/watson/developer_cloud/discovery/v1/DiscoveryServiceTest.java
+++ b/discovery/src/test/java/com/ibm/watson/developer_cloud/discovery/v1/DiscoveryServiceTest.java
@@ -560,6 +560,35 @@ public class DiscoveryServiceTest extends WatsonServiceUnitTest {
   }
 
   @Test
+  public void createDocumentFromFileWithGivenIdIsSuccessful() throws InterruptedException {
+    server.enqueue(jsonResponse(createDocResp));
+    String myDocumentJson = "{\"field\":\"value\"}";
+    JsonObject myMetadata = new JsonObject();
+    myMetadata.add("foo", new JsonPrimitive("bar"));
+
+    CreateDocumentRequest.Builder builder = new CreateDocumentRequest.Builder(environmentId, collectionId);
+    try {
+      File tempFile = File.createTempFile("CreateDocTest3", ".json");
+      tempFile.deleteOnExit();
+      BufferedWriter out = new BufferedWriter(new FileWriter(tempFile));
+      out.write(myDocumentJson);
+      out.close();
+
+      builder.file(tempFile);
+      builder.metadata(myMetadata);
+      builder.documentId(documentId);
+      CreateDocumentResponse response = discoveryService.createDocument(builder.build()).execute();
+      RecordedRequest request = server.takeRequest();
+
+      assertEquals(DOCS2_PATH, request.getPath());
+      assertEquals(POST, request.getMethod());
+      assertEquals(createDocResp, response);
+    } catch (final IOException e) {
+      e.printStackTrace();
+    }
+  }
+
+  @Test
   public void updateDocumentIsSuccessful() throws InterruptedException {
     server.enqueue(jsonResponse(updateDocResp));
     UpdateDocumentRequest.Builder updateBuilder =


### PR DESCRIPTION
### Summary

Currently when the user creates a document the response returns an Id for the indexed document. We are adding a new functionality for the users that want to provide a specific document ID when creating a document. With this change the users can use their own ID, which may be from another system, to refer to a document.

### Other Information

Thanks for contributing to the Watson Developer Cloud!