### PR TITLE
fix broken tts test

### DIFF
--- a/text-to-speech/src/test/java/com/ibm/watson/developer_cloud/text_to_speech/v1/TextToSpeechTest.java
+++ b/text-to-speech/src/test/java/com/ibm/watson/developer_cloud/text_to_speech/v1/TextToSpeechTest.java
@@ -197,10 +197,11 @@ public class TextToSpeechTest extends WatsonServiceUnitTest {
         service.synthesize(text, Voice.EN_LISA, new AudioFormat(HttpMediaType.AUDIO_PCM + "; rate=16000")).execute();
     final RecordedRequest request = server.takeRequest();
     final HttpUrl requestUrl = HttpUrl.parse("http://www.example.com" + request.getPath());
-    String encodedText = URLEncoder.encode(text, "UTF-8");
+    String modifiedText = text.replace(";", "%3B");
+    String encodedText = URLEncoder.encode(modifiedText, "UTF-8");
 
     assertEquals(SYNTHESIZE_PATH, requestUrl.encodedPath());
-    assertEquals(encodedText, requestUrl.queryParameter("text"));
+    assertEquals(modifiedText, requestUrl.queryParameter("text"));
     assertEquals(Voice.EN_LISA.getName(), requestUrl.queryParameter("voice"));
     assertEquals(HttpMediaType.AUDIO_PCM + "; rate=16000", requestUrl.queryParameter("accept"));
     assertNotNull(in);

--- a/text-to-speech/src/test/java/com/ibm/watson/developer_cloud/text_to_speech/v1/TextToSpeechTest.java
+++ b/text-to-speech/src/test/java/com/ibm/watson/developer_cloud/text_to_speech/v1/TextToSpeechTest.java
@@ -198,7 +198,6 @@ public class TextToSpeechTest extends WatsonServiceUnitTest {
     final RecordedRequest request = server.takeRequest();
     final HttpUrl requestUrl = HttpUrl.parse("http://www.example.com" + request.getPath());
     String modifiedText = text.replace(";", "%3B");
-    String encodedText = URLEncoder.encode(modifiedText, "UTF-8");
 
     assertEquals(SYNTHESIZE_PATH, requestUrl.encodedPath());
     assertEquals(modifiedText, requestUrl.queryParameter("text"));


### PR DESCRIPTION
The tts tests were broken when a fix was commited to change the
encoded that wasn't propogated to the tests.  I've added that change,
now they should work.