### PR TITLE
Fix date serialization for old Android platforms

### DIFF
--- a/core/src/main/java/com/ibm/watson/developer_cloud/util/DateDeserializer.java
+++ b/core/src/main/java/com/ibm/watson/developer_cloud/util/DateDeserializer.java
@@ -37,11 +37,10 @@ public class DateDeserializer implements JsonDeserializer<Date> {
 
   /** The Constant DATE_UTC. */
   public static final String DATE_UTC = "yyyy-MM-dd'T'HH:mm:ss.SSS";
-  private static final String DATE_UTC_WITH_TS = "yyyy-MM-dd'T'HH:mm:ss.SSSZ";
   private static final String DATE_WITHOUT_SECONDS = "yyyy-MM-dd'T'HH:mm:ssZ";
   private static final String DATE_WITH_SECONDS = "yyyy-MM-dd'T'HH:mm:ss";
-  private static final String DATE_8601 = "yyyy-MM-dd'T'HH:mm:ss.SSSX";
-  private static final String DATE_8601_WITHOUT_MS = "yyyy-MM-dd'T'HH:mm:ssX";
+  private static final String DATE_822 = "yyyy-MM-dd'T'HH:mm:ss.SSSZ";
+  private static final String DATE_822_WITHOUT_MS = "yyyy-MM-dd'T'HH:mm:ssZ";
 
   // SimpleDateFormat is NOT thread safe - they require private visibility and synchronized access
   private final SimpleDateFormat alchemyDateFormatter = new SimpleDateFormat(DATE_FROM_ALCHEMY);
@@ -51,14 +50,15 @@ public class DateDeserializer implements JsonDeserializer<Date> {
   private final SimpleDateFormat utcWithSecondsDateFormatter = new SimpleDateFormat(DATE_WITH_SECONDS);
   private final SimpleDateFormat iso8601DateFormatter = new SimpleDateFormat(DATE_8601);
   private final SimpleDateFormat iso8601WithoutMsDateFormatter = new SimpleDateFormat(DATE_8601_WITHOUT_MS);
-  private final SimpleDateFormat utcWithTsFormatter = new SimpleDateFormat(DATE_UTC_WITH_TS);
+  private final SimpleDateFormat rfc822DateFormatter = new SimpleDateFormat(DATE_822);
+  private final SimpleDateFormat rfc822WithoutMsDateFormatter = new SimpleDateFormat(DATE_822_WITHOUT_MS);
 
   private final List<SimpleDateFormat> dateFormatters =
       Arrays.asList(utcDateFormatter, utcWithoutSecondsDateFormatter, dialogDateFormatter,
               alchemyDateFormatter, utcWithSecondsDateFormatter);
 
-  private final List<SimpleDateFormat> iso8601Formatters =
-      Arrays.asList(utcWithTsFormatter, iso8601DateFormatter, iso8601WithoutMsDateFormatter);
+  private final List<SimpleDateFormat> rfc822Formatters =
+      Arrays.asList(rfc822DateFormatter, rfc822WithoutMsDateFormatter);
 
   private static final Logger LOG = Logger.getLogger(DateDeserializer.class.getName());
 
@@ -80,9 +80,10 @@ public class DateDeserializer implements JsonDeserializer<Date> {
     ParseException e = null;
 
     if (dateAsString.endsWith("Z")) {
-      for (SimpleDateFormat format : iso8601Formatters) {
+      String dateWithTz = dateAsString.replaceAll("Z$", "+0000");
+      for (SimpleDateFormat format : rfc822Formatters) {
         try {
-          return format.parse(dateAsString);
+          return format.parse(dateWithTz);
         } catch (ParseException e1) {
           e = e1;
         }


### PR DESCRIPTION
Fix date serialization for old Android platforms that do not support iso8601 date format

### Summary

Fixes #677.
