### PR TITLE
Add ability to indicate no sentence-level analysis with tone() method

### DIFF
--- a/tone-analyzer/src/main/java/com/ibm/watson/developer_cloud/tone_analyzer/v3/model/ToneOptions.java
+++ b/tone-analyzer/src/main/java/com/ibm/watson/developer_cloud/tone_analyzer/v3/model/ToneOptions.java
@@ -36,7 +36,6 @@ public class ToneOptions {
     private Boolean includeSentences;
     private List<Tone> tones;
 
-
     /**
      * Instantiates a new builder.
      */
@@ -56,7 +55,7 @@ public class ToneOptions {
     /**
      * Sets the text as HTML.
      *
-     * @param isHtml set the text as html
+     * @param isHtml sets the text as html
      * @return the builder
      */
     public Builder html(Boolean isHtml) {
@@ -65,9 +64,20 @@ public class ToneOptions {
     }
 
     /**
+     * Indicates whether to return sentence-level tone analysis.
+     *
+     * @param sentences sets sentence-level analysis.
+     * @return the builder
+     */
+    public Builder includeSentences(Boolean sentences) {
+      this.includeSentences = sentences;
+      return this;
+    }
+
+    /**
      * Adds the tone.
      *
-     * @param tone the tone
+     * @param tone the tone to add
      * @return the builder
      */
     public Builder addTone(Tone tone) {
@@ -83,7 +93,7 @@ public class ToneOptions {
     /**
      * Builds the {@link ToneOptions} object.
      *
-     * @return the gets the tone options
+     * @return the tone options object
      */
     public ToneOptions build() {
       return new ToneOptions(this);
@@ -97,22 +107,30 @@ public class ToneOptions {
   }
 
   /**
-   * Gets the html.
+   * Gets the isHtml.
    *
-   * @return the html
+   * @return the isHtml attribute
    */
   public Boolean html() {
     return isHtml;
   }
 
-
   /**
-   * include sentences.
+   * Get the includeSentences.
    *
-   * @return the text
+   * @return the includeSentences attribute
    */
   public Boolean includeSentences() {
     return includeSentences;
+  }
+
+  /**
+   * Gets the tones.
+   *
+   * @return the list of tones
+   */
+  public List<Tone> tones() {
+    return tones;
   }
 
   /**
@@ -122,15 +140,6 @@ public class ToneOptions {
    */
   public Builder newBuilder() {
     return new Builder(this);
-  }
-
-  /**
-   * Gets the tones.
-   *
-   * @return the tone list
-   */
-  public List<Tone> tones() {
-    return tones;
   }
 
 }

--- a/tone-analyzer/src/test/java/com/ibm/watson/developer_cloud/tone_analyzer/v3/ToneAnalyzerIT.java
+++ b/tone-analyzer/src/test/java/com/ibm/watson/developer_cloud/tone_analyzer/v3/ToneAnalyzerIT.java
@@ -71,15 +71,30 @@ public class ToneAnalyzerIT extends WatsonServiceTest {
   }
 
   /**
-   * Test get tone from text.
+   * Test get tone from text with sentences.
    */
   @Test
-  public void testGetToneFromText() {
+  public void testGetToneFromTextWithSentences() {
     ToneOptions options =
         new ToneOptions.Builder().addTone(Tone.EMOTION).addTone(Tone.LANGUAGE).addTone(Tone.SOCIAL).build();
 
     ToneAnalysis tone = service.getTone(text, options).execute();
     assertToneAnalysis(tone);
+  }
+
+  /**
+   * Test get tone from text without sentences.
+   */
+  @Test
+  public void testGetToneFromTextWithoutSentences() {
+    ToneOptions options =
+        new ToneOptions.Builder().includeSentences(false).build();
+
+    ToneAnalysis tone = service.getTone(text, options).execute();
+    Assert.assertNotNull(tone);
+    Assert.assertNotNull(tone.getDocumentTone());
+    Assert.assertEquals(3, tone.getDocumentTone().getTones().size());
+    Assert.assertNull(tone.getSentencesTone());
   }
 
   /**


### PR DESCRIPTION
Adds an `includeSentences() `method to the `ToneOptions.Builder` class that accepts a boolean to indicate the disposition of sentence-level analysis.  See issue https://github.com/watson-developer-cloud/java-sdk/issues/715.