### PR TITLE
Fix conversation testListLogsWithPaging by using a better query string

### DIFF
--- a/conversation/src/test/java/com/ibm/watson/developer_cloud/conversation/v1/ConversationServiceIT.java
+++ b/conversation/src/test/java/com/ibm/watson/developer_cloud/conversation/v1/ConversationServiceIT.java
@@ -1216,7 +1216,7 @@ public class ConversationServiceIT extends ConversationServiceTest {
     try {
       ListLogsOptions.Builder listOptionsBuilder = new ListLogsOptions.Builder(workspaceId);
       listOptionsBuilder.sort("-request_timestamp");
-      listOptionsBuilder.filter("request.input.text:wipers");
+      listOptionsBuilder.filter("request.intents:intent:off_topic");
       listOptionsBuilder.pageLimit(1L);
 
       LogCollectionResponse response = service.listLogs(listOptionsBuilder.build()).execute();


### PR DESCRIPTION
Changed query to use a query string that matches requests issued elsewhere in the test suite.