### PR TITLE
Fixed web socket options setting up typo with customizationId.

### DIFF
--- a/speech-to-text/src/main/java/com/ibm/watson/developer_cloud/speech_to_text/v1/SpeechToText.java
+++ b/speech-to-text/src/main/java/com/ibm/watson/developer_cloud/speech_to_text/v1/SpeechToText.java
@@ -823,7 +823,7 @@ public class SpeechToText extends WatsonService {
     }
 
     if (options.customizationId() != null && !options.customizationId().isEmpty()) {
-      urlBuilder.addQueryParameter(CUSTOMIZATION_ID, options.model());
+      urlBuilder.addQueryParameter(CUSTOMIZATION_ID, options.customizationId());
     }
 
     String url = urlBuilder.toString().replace("https://", "wss://");


### PR DESCRIPTION
### Summary

I believe there is typo of setting up the query options to use a customization for the method of recognizeUsingWebSocket in SpeechToText.  According to my testing, the change worked within my app. Anyone pls review and merge it maybe? Thanks.

### Other Information

If there's anything else that's important and relevant to your pull
request, mention that information here.


Thanks for contributing to the Watson Developer Cloud!