### PR TITLE
Change travis yml to run all tests -- not stop on first failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ before_install:
 script:
   - '[ "${TRAVIS_PULL_REQUEST}" = "false" ] && openssl aes-256-cbc -K $encrypted_a973fe4f8e79_key -iv $encrypted_a973fe4f8e79_iv -in .config.properties.enc -out core/src/test/resources/.config.properties -d || true'
   - ./gradlew install -x check
-  - ./gradlew test
+  - ./gradlew test --continue
   - ./gradlew codeCoverageReport
   - ./gradlew docs > /dev/null # build the javadoc
   - ./gradlew checkstyleMain


### PR DESCRIPTION
This PR adds the `--continue` option to the `./gradlew test` command in travis.yml so that travis will run the full test suite on a commit even when one or more tests fail.  This will make it easier to determine which commit is the root cause of a failing test.