### PR TITLE
Add bumpversion to automate changing version numbers in READMEs

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,20 @@
+[bumpversion]
+current_version = 4.0.0
+
+[bumpversion:file:README.md]
+[bumpversion:file:alchemy/README.md]
+[bumpversion:file:conversation/README.md]
+[bumpversion:file:discovery/README.md]
+[bumpversion:file:document-conversion/README.md]
+[bumpversion:file:language-translator/README.md]
+[bumpversion:file:natural-language-classifier/README.md]
+[bumpversion:file:natural-language-understanding/README.md]
+[bumpversion:file:personality-insights/README.md]
+[bumpversion:file:retrieve-and-rank/README.md]
+[bumpversion:file:speech-to-text/README.md]
+[bumpversion:file:text-to-speech/README.md]
+[bumpversion:file:tone-analyzer/README.md]
+[bumpversion:file:tradeoff-analytics/README.md]
+[bumpversion:file:visual-recognition/README.md]
+search = {current_version}
+replace = {new_version}

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -17,9 +17,26 @@ If you are not familiar with Sonatype and/or the maven release process please re
 
 ### Release steps
 
-  1. Update `README.md` to include the new version number
+  1. Update all READMEs to include the new version number
+
+     This can be done using [bumpversion]. If necessary, it can be installed with the following command:
+
+     ```bash
+     pip install bumpversion
+     ```
+
+     To then update all version numbers, simply run:
+
+     ```bash
+     bumpversion major|minor|patch
+     ```
+
   1. Perform a release deployment to OSSRH (Staging) with:
 
-    `gradle release`
+     ```bash
+     `gradle release`
+     ```
 
-    You will have to answer prompts for versions and tags. That will tag and commit a new version into your repository automatically.
+     You will have to answer prompts for versions and tags. That will tag and commit a new version into your repository automatically.
+
+[bumpversion]: https://pypi.python.org/pypi/bumpversion


### PR DESCRIPTION
Closes [#805](https://github.com/watson-developer-cloud/java-sdk/issues/805)