### PR TITLE
Adding customization weight for speech to text

### DIFF
--- a/speech-to-text/src/main/java/com/ibm/watson/developer_cloud/speech_to_text/v1/SpeechToText.java
+++ b/speech-to-text/src/main/java/com/ibm/watson/developer_cloud/speech_to_text/v1/SpeechToText.java
@@ -235,7 +235,7 @@ public class SpeechToText extends WatsonService {
     }
 
     if (options.customizationWeight() != null) {
-      requestBuilder.query(CUSTOMIZATION_WEIGHT, options.customizationWeight().toString());
+      requestBuilder.query(CUSTOMIZATION_WEIGHT, options.customizationWeight());
     }
   }
 
@@ -821,7 +821,7 @@ public class SpeechToText extends WatsonService {
     }
 
     if (options.customizationWeight() != null) {
-      urlBuilder.addQueryParameter(CUSTOMIZATION_WEIGHT, options.customizationWeight().toString());
+      urlBuilder.addQueryParameter(CUSTOMIZATION_WEIGHT, String.valueOf(options.customizationWeight()));
     }
 
     String url = urlBuilder.toString().replace("https://", "wss://");

--- a/speech-to-text/src/main/java/com/ibm/watson/developer_cloud/speech_to_text/v1/SpeechToText.java
+++ b/speech-to-text/src/main/java/com/ibm/watson/developer_cloud/speech_to_text/v1/SpeechToText.java
@@ -69,6 +69,7 @@ public class SpeechToText extends WatsonService {
   private static final String CALLBACK_URL = "callback_url";
   private static final String CONTINUOUS = "continuous";
   private static final String CUSTOMIZATION_ID = "customization_id";
+  private static final String CUSTOMIZATION_WEIGHT = "customization_weight";
   private static final String EVENTS = "events";
   private static final String INACTIVITY_TIMEOUT = "inactivity_timeout";
   private static final String KEYWORDS = "keywords";
@@ -231,6 +232,10 @@ public class SpeechToText extends WatsonService {
 
     if (options.customizationId() != null) {
       requestBuilder.query(CUSTOMIZATION_ID, options.customizationId());
+    }
+
+    if (options.customizationWeight() != null) {
+      requestBuilder.query(CUSTOMIZATION_WEIGHT, options.customizationWeight().toString());
     }
   }
 
@@ -813,6 +818,10 @@ public class SpeechToText extends WatsonService {
 
     if (options.customizationId() != null && !options.customizationId().isEmpty()) {
       urlBuilder.addQueryParameter(CUSTOMIZATION_ID, options.customizationId());
+    }
+
+    if (options.customizationWeight() != null) {
+      urlBuilder.addQueryParameter(CUSTOMIZATION_WEIGHT, options.customizationWeight().toString());
     }
 
     String url = urlBuilder.toString().replace("https://", "wss://");

--- a/speech-to-text/src/main/java/com/ibm/watson/developer_cloud/speech_to_text/v1/model/RecognizeOptions.java
+++ b/speech-to-text/src/main/java/com/ibm/watson/developer_cloud/speech_to_text/v1/model/RecognizeOptions.java
@@ -138,9 +138,9 @@ public class RecognizeOptions {
     }
 
     /**
-     * If a custom model is specified, this parameter tells the service how much weight to give 
+     * If a custom model is specified, this parameter tells the service how much weight to give
      * to words from the custom language model compared to those from the base model.
-     * Specify a value between 0.0 and 1.0 (inclusive). If value is null or omitted, the customization 
+     * Specify a value between 0.0 and 1.0 (inclusive). If value is null or omitted, the customization
      * weight from the model is used. If no customization weight is specified on the model, the default
      * value of the service will be used.
      *

--- a/speech-to-text/src/main/java/com/ibm/watson/developer_cloud/speech_to_text/v1/model/RecognizeOptions.java
+++ b/speech-to-text/src/main/java/com/ibm/watson/developer_cloud/speech_to_text/v1/model/RecognizeOptions.java
@@ -48,6 +48,7 @@ public class RecognizeOptions {
     private Boolean smartFormatting;
     private String customizationId;
     private Boolean speakerLabels;
+    private Double customizationWeight;
 
     private Builder(RecognizeOptions options) {
       contentType = options.contentType;
@@ -66,6 +67,7 @@ public class RecognizeOptions {
       smartFormatting = options.smartFormatting;
       customizationId = options.customizationId;
       speakerLabels = options.speakerLabels;
+      customizationWeight = options.customizationWeight;
     }
 
     /**
@@ -132,6 +134,21 @@ public class RecognizeOptions {
      */
     public Builder speakerLabels(Boolean speakerLabels) {
       this.speakerLabels = speakerLabels;
+      return this;
+    }
+
+    /**
+     * If a custom model is specified, this parameter tells the service how much weight to give 
+     * to words from the custom language model compared to those from the base model.
+     * Specify a value between 0.0 and 1.0 (inclusive). If value is null or omitted, the customization 
+     * weight from the model is used. If no customization weight is specified on the model, the default
+     * value of the service will be used.
+     *
+     * @param customizationWeight Labels or "diarization"
+     * @return the recognize options
+     */
+    public Builder customizationWeight(Double customizationWeight) {
+      this.customizationWeight = customizationWeight;
       return this;
     }
 
@@ -330,6 +347,9 @@ public class RecognizeOptions {
   @SerializedName("speaker_labels")
   private Boolean speakerLabels;
 
+  @SerializedName("customization_weight")
+  private Double customizationWeight;
+
   private RecognizeOptions(Builder builder) {
     contentType = builder.contentType;
     continuous = builder.continuous;
@@ -347,6 +367,7 @@ public class RecognizeOptions {
     smartFormatting = builder.smartFormatting;
     customizationId = builder.customizationId;
     speakerLabels = builder.speakerLabels;
+    customizationWeight = builder.customizationWeight;
   }
 
   /**
@@ -392,6 +413,15 @@ public class RecognizeOptions {
    */
   public Boolean speakerLabels() {
     return speakerLabels;
+  }
+
+  /**
+   * Gets the customizationWeight.
+   *
+   * @return the customizationWeight
+   */
+  public Double customizationWeight() {
+    return customizationWeight;
   }
 
   /**

--- a/speech-to-text/src/test/java/com/ibm/watson/developer_cloud/speech_to_text/v1/SpeechToTextTest.java
+++ b/speech-to-text/src/test/java/com/ibm/watson/developer_cloud/speech_to_text/v1/SpeechToTextTest.java
@@ -358,6 +358,29 @@ public class SpeechToTextTest extends WatsonServiceUnitTest {
     assertEquals(recognition, GSON.toJsonTree(result));
   }
 
+    /**
+   * Test recognize with customization weight.
+   *
+   * @throws FileNotFoundException the file not found exception
+   * @throws InterruptedException the interrupted exception
+   */
+  @Test
+  public void testRecognizeWithCustomizationWeight() throws FileNotFoundException, InterruptedException {
+    String id = "foo";
+    String recString =
+        getStringFromInputStream(new FileInputStream("src/test/resources/speech_to_text/recognition.json"));
+    JsonObject recognition = new JsonParser().parse(recString).getAsJsonObject();
+
+    server.enqueue(new MockResponse().addHeader(CONTENT_TYPE, HttpMediaType.APPLICATION_JSON).setBody(recString));
+
+    RecognizeOptions options = new RecognizeOptions.Builder().customizationId(id).customizationWeight(0.5).build();
+    SpeechResults result = service.recognize(SAMPLE_WAV, options).execute();
+    final RecordedRequest request = server.takeRequest();
+
+    assertEquals(PATH_RECOGNIZE + "?customization_id=" + id + "&customization_weight=0.5", request.getPath());
+    assertEquals(recognition, GSON.toJsonTree(result));
+  }
+
   /**
    * Test recognize -missing audio file, generate IllegalArgumentException.
    *


### PR DESCRIPTION
Added customization_weight parameter for speech to text. This is based on documentation here: https://www.ibm.com/watson/developercloud/speech-to-text/api/v1/#recognize_audio_websockets

Let me know if I messed anything up. Thanks!