### PR TITLE
Adds label field to NLU DocumentSentimentResult

### DIFF
--- a/natural-language-understanding/src/main/java/com/ibm/watson/developer_cloud/natural_language_understanding/v1/model/DocumentSentimentResults.java
+++ b/natural-language-understanding/src/main/java/com/ibm/watson/developer_cloud/natural_language_understanding/v1/model/DocumentSentimentResults.java
@@ -20,6 +20,7 @@ import com.ibm.watson.developer_cloud.service.model.GenericModel;
 public class DocumentSentimentResults extends GenericModel {
 
   private Double score;
+  private String label;
 
   /**
    * Gets the score.
@@ -39,5 +40,25 @@ public class DocumentSentimentResults extends GenericModel {
    */
   public void setScore(final Double score) {
     this.score = score;
+  }
+
+  /**
+   * Gets the label.
+   *
+   * Sentiment label
+   *
+   * @return the label
+   */
+  public String getLabel() {
+    return label;
+  }
+
+  /**
+   * Sets the label.
+   *
+   * @param label the new label
+   */
+  public void setLabel(String label) {
+    this.label = label;
   }
 }

--- a/natural-language-understanding/src/test/java/com/ibm/watson/developer_cloud/natural_language_understanding/v1/NaturalLanguageUnderstandingTest.java
+++ b/natural-language-understanding/src/test/java/com/ibm/watson/developer_cloud/natural_language_understanding/v1/NaturalLanguageUnderstandingTest.java
@@ -257,7 +257,9 @@ public class NaturalLanguageUnderstandingTest extends WatsonServiceUnitTest {
     // DocumentSentimentResults
     DocumentSentimentResults documentSentimentResults = new DocumentSentimentResults();
     documentSentimentResults.setScore(10.10);
+    documentSentimentResults.setLabel("neutral");
     assertEquals(documentSentimentResults.getScore(), 10.10, 0);
+    assertEquals(documentSentimentResults.getLabel(), "neutral");
 
     // EmotionOptions
     EmotionOptions emotionOptions = new EmotionOptions.Builder().document(true).targets(null).build();


### PR DESCRIPTION
### Summary

Matches the structure of the document field in sentiment results with the NLU documentation.
Adds a missing label field to DocumentSentimentResults class 

#814 