### PR TITLE
Add Korean language for Personality Insights input

### DIFF
--- a/personality-insights/src/main/java/com/ibm/watson/developer_cloud/personality_insights/v3/model/ProfileOptions.java
+++ b/personality-insights/src/main/java/com/ibm/watson/developer_cloud/personality_insights/v3/model/ProfileOptions.java
@@ -52,6 +52,8 @@ public class ProfileOptions extends GenericModel {
     String ES = "es";
     /** ja. */
     String JA = "ja";
+    /** ko. */
+    String KO = "ko";
   }
 
   /**


### PR DESCRIPTION
### Summary

As written in the API documentation, Korean is now a supported input language for the Personality Insights API: https://www.ibm.com/watson/developercloud/personality-insights/api/v3/#JavaProfileOptions