### PR TITLE
Automatic jar upload

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -30,7 +30,5 @@ current_version = 4.1.0
 [bumpversion:file:tradeoff-analytics/README.md]
 
 [bumpversion:file:visual-recognition/README.md]
-
-[bumpversion:file:.travis.yml]
 search = {current_version}
 replace = {new_version}

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,7 +1,5 @@
 [bumpversion]
 current_version = 4.1.0
-commit = True
-tag = True
 
 [bumpversion:file:README.md]
 
@@ -32,6 +30,7 @@ tag = True
 [bumpversion:file:tradeoff-analytics/README.md]
 
 [bumpversion:file:visual-recognition/README.md]
+
+[bumpversion:file:.travis.yml]
 search = {current_version}
 replace = {new_version}
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,8 +57,8 @@ deploy:
       jdk: oraclejdk7
 
   - provider: releases
-    api_key: $GITHUB_TOKEN_RELEASES
-    file: java-sdk/build/libs/jar-with-dependencies-$TRAVIS_BRANCH.jar
+    api_key: ${GITHUB_TOKEN_RELEASES}
+    file: java-sdk/build/libs/jar-with-dependencies-${TRAVIS_BRANCH}.jar
     skip_cleanup: true
     on:
       repo: watson-developer-cloud/java-sdk

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,5 +56,14 @@ deploy:
       repo: watson-developer-cloud/java-sdk
       jdk: oraclejdk7
 
+  - provider: releases
+    api_key:
+      secure: NhwGz9ppK1YM0M9Pr15b6fOHPpN09QrLvdK4z1PTRxAt+oVpzl3xM/CpGr+iRXT3aV+8q0xLtb4rjxdmgV7aDFY5WEcKkdHAlENpLk/ZVCswnl/MakNbupFbiml0aLcNRe90qvuMILjwSfzYU6BlxZ/W1Xz1eqwtQ1oP/A92MZM=
+    file: java-sdk/build/libs/jar-with-dependencies-4.1.0.jar
+    skip_cleanup: true
+    on:
+      repo: watson-developer-cloud/java-sdk
+      jdk: oraclejdk7
+      tags: true
 notifications:
   email: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,9 +57,8 @@ deploy:
       jdk: oraclejdk7
 
   - provider: releases
-    api_key:
-      secure: NhwGz9ppK1YM0M9Pr15b6fOHPpN09QrLvdK4z1PTRxAt+oVpzl3xM/CpGr+iRXT3aV+8q0xLtb4rjxdmgV7aDFY5WEcKkdHAlENpLk/ZVCswnl/MakNbupFbiml0aLcNRe90qvuMILjwSfzYU6BlxZ/W1Xz1eqwtQ1oP/A92MZM=
-    file: java-sdk/build/libs/jar-with-dependencies-4.1.0.jar
+    api_key: $GITHUB_TOKEN_RELEASES
+    file: java-sdk/build/libs/jar-with-dependencies-$TRAVIS_BRANCH.jar
     skip_cleanup: true
     on:
       repo: watson-developer-cloud/java-sdk

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -75,7 +75,7 @@ dependencies {
     compile group: 'com.google.code.gson', name: 'gson', version: '2.8.0'
     compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.5'
     compile group: 'org.glassfish.jersey.bundles.repackaged', name: 'jersey-jsr166e', version: '2.25.1'
-    compile group: 'simple-jndi', name: 'simple-jndi', version: '0.11.4.1'
+    testCompile group: 'simple-jndi', name: 'simple-jndi', version: '0.11.4.1'
 
     signature 'org.codehaus.mojo.signature:java17:1.0@signature'
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -75,6 +75,7 @@ dependencies {
     compile group: 'com.google.code.gson', name: 'gson', version: '2.8.0'
     compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.5'
     compile group: 'org.glassfish.jersey.bundles.repackaged', name: 'jersey-jsr166e', version: '2.25.1'
+    compile group: 'simple-jndi', name: 'simple-jndi', version: '0.11.4.1'
 
     signature 'org.codehaus.mojo.signature:java17:1.0@signature'
 

--- a/core/src/test/java/com/ibm/watson/developer_cloud/util/CredentialUtilsTest.java
+++ b/core/src/test/java/com/ibm/watson/developer_cloud/util/CredentialUtilsTest.java
@@ -131,7 +131,7 @@ public class CredentialUtilsTest extends WatsonServiceTest {
    */
   @Test
   public void testGetAPIUrlFromJDNI() {
-    assumeTrue(!System.getenv().containsKey("TRAVIS"));
+    //assumeTrue(!System.getenv().containsKey("TRAVIS"));
     assertEquals(CredentialUtils.getAPIUrlTest(SERVICE_NAME), PERSONALITY_INSIGHTS_URL);
   }
 }

--- a/core/src/test/java/com/ibm/watson/developer_cloud/util/CredentialUtilsTest.java
+++ b/core/src/test/java/com/ibm/watson/developer_cloud/util/CredentialUtilsTest.java
@@ -15,7 +15,6 @@ package com.ibm.watson.developer_cloud.util;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assume.assumeTrue;
 
 import java.io.InputStream;
 import java.util.Hashtable;
@@ -131,7 +130,6 @@ public class CredentialUtilsTest extends WatsonServiceTest {
    */
   @Test
   public void testGetAPIUrlFromJDNI() {
-    //assumeTrue(!System.getenv().containsKey("TRAVIS"));
     assertEquals(CredentialUtils.getAPIUrlTest(SERVICE_NAME), PERSONALITY_INSIGHTS_URL);
   }
 }


### PR DESCRIPTION
Fixes #831 

This PR ensures that upon making releases, the final jar with dependencies is automatically uploaded to the appropriate GitHub release.

It also fixes the missing dependency for one of the new core unit tests, which was previously being skipped in Travis. This should now run properly.