### PR TITLE
Add handwritten method for getting profile in CSV format

### DIFF
--- a/personality-insights/src/main/java/com/ibm/watson/developer_cloud/personality_insights/v3/PersonalityInsights.java
+++ b/personality-insights/src/main/java/com/ibm/watson/developer_cloud/personality_insights/v3/PersonalityInsights.java
@@ -122,9 +122,6 @@ public class PersonalityInsights extends WatsonService {
     if (profileOptions.rawScores() != null) {
       builder.query("raw_scores", String.valueOf(profileOptions.rawScores()));
     }
-    if (profileOptions.csvHeaders() != null) {
-      builder.query("csv_headers", String.valueOf(profileOptions.csvHeaders()));
-    }
     if (profileOptions.consumptionPreferences() != null) {
       builder.query("consumption_preferences", String.valueOf(profileOptions.consumptionPreferences()));
     }
@@ -149,9 +146,6 @@ public class PersonalityInsights extends WatsonService {
     }
     if (profileOptions.rawScores() != null) {
       builder.query("raw_scores", String.valueOf(profileOptions.rawScores()));
-    }
-    if (profileOptions.csvHeaders() != null) {
-      builder.query("csv_headers", String.valueOf(profileOptions.csvHeaders()));
     }
     if (profileOptions.consumptionPreferences() != null) {
       builder.query("consumption_preferences", String.valueOf(profileOptions.consumptionPreferences()));

--- a/personality-insights/src/main/java/com/ibm/watson/developer_cloud/personality_insights/v3/PersonalityInsights.java
+++ b/personality-insights/src/main/java/com/ibm/watson/developer_cloud/personality_insights/v3/PersonalityInsights.java
@@ -12,6 +12,8 @@
  */
 package com.ibm.watson.developer_cloud.personality_insights.v3;
 
+import com.ibm.watson.developer_cloud.http.HttpHeaders;
+import com.ibm.watson.developer_cloud.http.HttpMediaType;
 import com.ibm.watson.developer_cloud.http.RequestBuilder;
 import com.ibm.watson.developer_cloud.http.ServiceCall;
 import com.ibm.watson.developer_cloud.personality_insights.v3.model.Profile;
@@ -134,4 +136,35 @@ public class PersonalityInsights extends WatsonService {
     return createServiceCall(builder.build(), ResponseConverterUtils.getObject(Profile.class));
   }
 
+  public ServiceCall<String> getProfileAsCSV(ProfileOptions profileOptions, boolean includeHeaders) {
+    Validator.notNull(profileOptions, "profileOptions cannot be null");
+    RequestBuilder builder = RequestBuilder.post("/v3/profile");
+    builder.query(VERSION, versionDate);
+    builder.header("Content-Type", profileOptions.contentType());
+    if (profileOptions.contentLanguage() != null) {
+      builder.header("Content-Language", profileOptions.contentLanguage());
+    }
+    if (profileOptions.acceptLanguage() != null) {
+      builder.header("Accept-Language", profileOptions.acceptLanguage());
+    }
+    if (profileOptions.rawScores() != null) {
+      builder.query("raw_scores", String.valueOf(profileOptions.rawScores()));
+    }
+    if (profileOptions.csvHeaders() != null) {
+      builder.query("csv_headers", String.valueOf(profileOptions.csvHeaders()));
+    }
+    if (profileOptions.consumptionPreferences() != null) {
+      builder.query("consumption_preferences", String.valueOf(profileOptions.consumptionPreferences()));
+    }
+    if (profileOptions.contentType().equalsIgnoreCase(ProfileOptions.ContentType.APPLICATION_JSON)) {
+      builder.bodyJson(GsonSingleton.getGson().toJsonTree(profileOptions.content()).getAsJsonObject());
+    } else {
+      builder.bodyContent(profileOptions.body(), profileOptions.contentType());
+    }
+
+    builder.header(HttpHeaders.ACCEPT, HttpMediaType.TEXT_CSV);
+    builder.query("headers", includeHeaders);
+
+    return createServiceCall(builder.build(), ResponseConverterUtils.getString());
+  }
 }

--- a/personality-insights/src/main/java/com/ibm/watson/developer_cloud/personality_insights/v3/model/ProfileOptions.java
+++ b/personality-insights/src/main/java/com/ibm/watson/developer_cloud/personality_insights/v3/model/ProfileOptions.java
@@ -92,7 +92,6 @@ public class ProfileOptions extends GenericModel {
   private String contentLanguage;
   private String acceptLanguage;
   private Boolean rawScores;
-  private Boolean csvHeaders;
   private Boolean consumptionPreferences;
 
   /**
@@ -105,7 +104,6 @@ public class ProfileOptions extends GenericModel {
     private String contentLanguage;
     private String acceptLanguage;
     private Boolean rawScores;
-    private Boolean csvHeaders;
     private Boolean consumptionPreferences;
 
     private Builder(ProfileOptions profileOptions) {
@@ -115,7 +113,6 @@ public class ProfileOptions extends GenericModel {
       contentLanguage = profileOptions.contentLanguage;
       acceptLanguage = profileOptions.acceptLanguage;
       rawScores = profileOptions.rawScores;
-      csvHeaders = profileOptions.csvHeaders;
       consumptionPreferences = profileOptions.consumptionPreferences;
     }
 
@@ -164,17 +161,6 @@ public class ProfileOptions extends GenericModel {
      */
     public Builder rawScores(Boolean rawScores) {
       this.rawScores = rawScores;
-      return this;
-    }
-
-    /**
-     * Set the csvHeaders.
-     *
-     * @param csvHeaders the csvHeaders
-     * @return the ProfileOptions builder
-     */
-    public Builder csvHeaders(Boolean csvHeaders) {
-      this.csvHeaders = csvHeaders;
       return this;
     }
 
@@ -234,7 +220,6 @@ public class ProfileOptions extends GenericModel {
     contentLanguage = builder.contentLanguage;
     acceptLanguage = builder.acceptLanguage;
     rawScores = builder.rawScores;
-    csvHeaders = builder.csvHeaders;
     consumptionPreferences = builder.consumptionPreferences;
   }
 
@@ -326,18 +311,6 @@ public class ProfileOptions extends GenericModel {
    */
   public Boolean rawScores() {
     return rawScores;
-  }
-
-  /**
-   * Gets the csvHeaders.
-   *
-   * If `true`, column labels are returned with a CSV response; if `false` (the default), they are not. Applies only
-   * when the `Accept` header is set to `text/csv`.
-   *
-   * @return the csvHeaders
-   */
-  public Boolean csvHeaders() {
-    return csvHeaders;
   }
 
   /**


### PR DESCRIPTION
Before the Personality Insights service was being generated programmatically, there was a method to get the returned profile in CSV format. This was removed in the 4.0.0 release.

This PR adds that functionality back with a new `getProfileAsCSV()` method.