### PR TITLE
Release v4.2.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,7 +1,5 @@
 [bumpversion]
 current_version = 4.1.0
-commit = True
-tag = True
 
 [bumpversion:file:README.md]
 
@@ -34,4 +32,3 @@ tag = True
 [bumpversion:file:visual-recognition/README.md]
 search = {current_version}
 replace = {new_version}
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,7 @@ deploy:
     on:
       repo: watson-developer-cloud/java-sdk
       jdk: oraclejdk7
+      tags: true
 
   - provider: script
     script: .utility/deploy.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,5 +56,13 @@ deploy:
       repo: watson-developer-cloud/java-sdk
       jdk: oraclejdk7
 
+  - provider: releases
+    api_key: ${GITHUB_TOKEN_RELEASES}
+    file: java-sdk/build/libs/jar-with-dependencies-${TRAVIS_BRANCH}.jar
+    skip_cleanup: true
+    on:
+      repo: watson-developer-cloud/java-sdk
+      jdk: oraclejdk7
+      tags: true
 notifications:
   email: true

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -75,6 +75,7 @@ dependencies {
     compile group: 'com.google.code.gson', name: 'gson', version: '2.8.0'
     compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.5'
     compile group: 'org.glassfish.jersey.bundles.repackaged', name: 'jersey-jsr166e', version: '2.25.1'
+    testCompile group: 'simple-jndi', name: 'simple-jndi', version: '0.11.4.1'
 
     signature 'org.codehaus.mojo.signature:java17:1.0@signature'
 

--- a/core/src/test/java/com/ibm/watson/developer_cloud/util/CredentialUtilsTest.java
+++ b/core/src/test/java/com/ibm/watson/developer_cloud/util/CredentialUtilsTest.java
@@ -15,7 +15,6 @@ package com.ibm.watson.developer_cloud.util;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assume.assumeTrue;
 
 import java.io.InputStream;
 import java.util.Hashtable;
@@ -131,7 +130,6 @@ public class CredentialUtilsTest extends WatsonServiceTest {
    */
   @Test
   public void testGetAPIUrlFromJDNI() {
-    assumeTrue(!System.getenv().containsKey("TRAVIS"));
     assertEquals(CredentialUtils.getAPIUrlTest(SERVICE_NAME), PERSONALITY_INSIGHTS_URL);
   }
 }

--- a/discovery/src/main/java/com/ibm/watson/developer_cloud/discovery/v1/model/Enrichment.java
+++ b/discovery/src/main/java/com/ibm/watson/developer_cloud/discovery/v1/model/Enrichment.java
@@ -81,7 +81,8 @@ public class Enrichment extends GenericModel {
   /**
    * Gets the enrichmentName.
    *
-   * Name of the enrichment service to call. Currently the only valid value is `alchemy_language`.
+   * Name of the enrichment service to call. Currently the only valid value is `natural_language_understanding`.
+   * Previous API versions also supported `alchemy_language`.
    *
    * @return the enrichmentName
    */
@@ -104,7 +105,7 @@ public class Enrichment extends GenericModel {
   /**
    * Gets the options.
    *
-   * A list of options specific to the enrichment
+   * A list of options specific to the enrichment.
    *
    * @return the options
    */

--- a/discovery/src/main/java/com/ibm/watson/developer_cloud/discovery/v1/model/NluEnrichmentCategories.java
+++ b/discovery/src/main/java/com/ibm/watson/developer_cloud/discovery/v1/model/NluEnrichmentCategories.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2017 IBM Corp. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.ibm.watson.developer_cloud.discovery.v1.model;
+
+import com.ibm.watson.developer_cloud.service.model.DynamicModel;
+
+/**
+ * An object that indicates the Categories enrichment will be applied to the specified field.
+ */
+public class NluEnrichmentCategories extends DynamicModel {
+
+}

--- a/discovery/src/main/java/com/ibm/watson/developer_cloud/discovery/v1/model/NluEnrichmentEmotion.java
+++ b/discovery/src/main/java/com/ibm/watson/developer_cloud/discovery/v1/model/NluEnrichmentEmotion.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2017 IBM Corp. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.ibm.watson.developer_cloud.discovery.v1.model;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.ibm.watson.developer_cloud.service.model.GenericModel;
+import com.ibm.watson.developer_cloud.util.Validator;
+
+/**
+ * An object specifying the emotion detection enrichment and related parameters.
+ */
+public class NluEnrichmentEmotion extends GenericModel {
+
+  private Boolean document;
+  private List<String> targets;
+
+  /**
+   * Builder.
+   */
+  public static class Builder {
+    private Boolean document;
+    private List<String> targets;
+
+    private Builder(NluEnrichmentEmotion nluEnrichmentEmotion) {
+      document = nluEnrichmentEmotion.document;
+      targets = nluEnrichmentEmotion.targets;
+    }
+
+    /**
+     * Instantiates a new builder.
+     */
+    public Builder() {
+    }
+
+    /**
+     * Builds a NluEnrichmentEmotion.
+     *
+     * @return the nluEnrichmentEmotion
+     */
+    public NluEnrichmentEmotion build() {
+      return new NluEnrichmentEmotion(this);
+    }
+
+    /**
+     * Adds a target to targets.
+     *
+     * @param target the new target
+     * @return the NluEnrichmentEmotion builder
+     */
+    public Builder addTarget(String target) {
+      Validator.notNull(target, "target cannot be null");
+      if (this.targets == null) {
+        this.targets = new ArrayList<String>();
+      }
+      this.targets.add(target);
+      return this;
+    }
+
+    /**
+     * Set the document.
+     *
+     * @param document the document
+     * @return the NluEnrichmentEmotion builder
+     */
+    public Builder document(Boolean document) {
+      this.document = document;
+      return this;
+    }
+
+    /**
+     * Set the targets.
+     * Existing targets will be replaced.
+     *
+     * @param targets the targets
+     * @return the NluEnrichmentEmotion builder
+     */
+    public Builder targets(List<String> targets) {
+      this.targets = targets;
+      return this;
+    }
+  }
+
+  private NluEnrichmentEmotion(Builder builder) {
+    document = builder.document;
+    targets = builder.targets;
+  }
+
+  /**
+   * New builder.
+   *
+   * @return a NluEnrichmentEmotion builder
+   */
+  public Builder newBuilder() {
+    return new Builder(this);
+  }
+
+  /**
+   * Gets the document.
+   *
+   * When `true`, emotion detection is performed on the entire field.
+   *
+   * @return the document
+   */
+  public Boolean document() {
+    return document;
+  }
+
+  /**
+   * Gets the targets.
+   *
+   * A comma-separated list of target strings that will have any associated emotions detected.
+   *
+   * @return the targets
+   */
+  public List<String> targets() {
+    return targets;
+  }
+}

--- a/discovery/src/main/java/com/ibm/watson/developer_cloud/discovery/v1/model/NluEnrichmentEntities.java
+++ b/discovery/src/main/java/com/ibm/watson/developer_cloud/discovery/v1/model/NluEnrichmentEntities.java
@@ -1,0 +1,245 @@
+/*
+ * Copyright 2017 IBM Corp. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.ibm.watson.developer_cloud.discovery.v1.model;
+
+import com.google.gson.annotations.SerializedName;
+import com.ibm.watson.developer_cloud.service.model.GenericModel;
+
+/**
+ * An object speficying the Entities enrichment and related parameters.
+ */
+public class NluEnrichmentEntities extends GenericModel {
+
+  private Boolean sentiment;
+  private Boolean emotion;
+  private Long limit;
+  private Boolean mentions;
+  @SerializedName("mention_types")
+  private Boolean mentionTypes;
+  @SerializedName("sentence_location")
+  private Boolean sentenceLocation;
+  private String model;
+
+  /**
+   * Builder.
+   */
+  public static class Builder {
+    private Boolean sentiment;
+    private Boolean emotion;
+    private Long limit;
+    private Boolean mentions;
+    private Boolean mentionTypes;
+    private Boolean sentenceLocation;
+    private String model;
+
+    private Builder(NluEnrichmentEntities nluEnrichmentEntities) {
+      sentiment = nluEnrichmentEntities.sentiment;
+      emotion = nluEnrichmentEntities.emotion;
+      limit = nluEnrichmentEntities.limit;
+      mentions = nluEnrichmentEntities.mentions;
+      mentionTypes = nluEnrichmentEntities.mentionTypes;
+      sentenceLocation = nluEnrichmentEntities.sentenceLocation;
+      model = nluEnrichmentEntities.model;
+    }
+
+    /**
+     * Instantiates a new builder.
+     */
+    public Builder() {
+    }
+
+    /**
+     * Builds a NluEnrichmentEntities.
+     *
+     * @return the nluEnrichmentEntities
+     */
+    public NluEnrichmentEntities build() {
+      return new NluEnrichmentEntities(this);
+    }
+
+    /**
+     * Set the sentiment.
+     *
+     * @param sentiment the sentiment
+     * @return the NluEnrichmentEntities builder
+     */
+    public Builder sentiment(Boolean sentiment) {
+      this.sentiment = sentiment;
+      return this;
+    }
+
+    /**
+     * Set the emotion.
+     *
+     * @param emotion the emotion
+     * @return the NluEnrichmentEntities builder
+     */
+    public Builder emotion(Boolean emotion) {
+      this.emotion = emotion;
+      return this;
+    }
+
+    /**
+     * Set the limit.
+     *
+     * @param limit the limit
+     * @return the NluEnrichmentEntities builder
+     */
+    public Builder limit(long limit) {
+      this.limit = limit;
+      return this;
+    }
+
+    /**
+     * Set the mentions.
+     *
+     * @param mentions the mentions
+     * @return the NluEnrichmentEntities builder
+     */
+    public Builder mentions(Boolean mentions) {
+      this.mentions = mentions;
+      return this;
+    }
+
+    /**
+     * Set the mentionTypes.
+     *
+     * @param mentionTypes the mentionTypes
+     * @return the NluEnrichmentEntities builder
+     */
+    public Builder mentionTypes(Boolean mentionTypes) {
+      this.mentionTypes = mentionTypes;
+      return this;
+    }
+
+    /**
+     * Set the sentenceLocation.
+     *
+     * @param sentenceLocation the sentenceLocation
+     * @return the NluEnrichmentEntities builder
+     */
+    public Builder sentenceLocation(Boolean sentenceLocation) {
+      this.sentenceLocation = sentenceLocation;
+      return this;
+    }
+
+    /**
+     * Set the model.
+     *
+     * @param model the model
+     * @return the NluEnrichmentEntities builder
+     */
+    public Builder model(String model) {
+      this.model = model;
+      return this;
+    }
+  }
+
+  private NluEnrichmentEntities(Builder builder) {
+    sentiment = builder.sentiment;
+    emotion = builder.emotion;
+    limit = builder.limit;
+    mentions = builder.mentions;
+    mentionTypes = builder.mentionTypes;
+    sentenceLocation = builder.sentenceLocation;
+    model = builder.model;
+  }
+
+  /**
+   * New builder.
+   *
+   * @return a NluEnrichmentEntities builder
+   */
+  public Builder newBuilder() {
+    return new Builder(this);
+  }
+
+  /**
+   * Gets the sentiment.
+   *
+   * When `true`, sentiment analysis of entities will be performed on the specified field.
+   *
+   * @return the sentiment
+   */
+  public Boolean sentiment() {
+    return sentiment;
+  }
+
+  /**
+   * Gets the emotion.
+   *
+   * When `true`, emotion detection of entities will be performed on the specified field.
+   *
+   * @return the emotion
+   */
+  public Boolean emotion() {
+    return emotion;
+  }
+
+  /**
+   * Gets the limit.
+   *
+   * The maximum number of entities to extract for each instance of the specified field.
+   *
+   * @return the limit
+   */
+  public Long limit() {
+    return limit;
+  }
+
+  /**
+   * Gets the mentions.
+   *
+   * When `true`, the number of mentions of each identified entity is recorded. The default is `false`.
+   *
+   * @return the mentions
+   */
+  public Boolean mentions() {
+    return mentions;
+  }
+
+  /**
+   * Gets the mentionTypes.
+   *
+   * When `true`, the types of mentions for each idetifieid entity is recorded. The default is `false`.
+   *
+   * @return the mentionTypes
+   */
+  public Boolean mentionTypes() {
+    return mentionTypes;
+  }
+
+  /**
+   * Gets the sentenceLocation.
+   *
+   * When `true`, a list of sentence locations for each instance of each identified entity is recorded. The default is
+   * `false`.
+   *
+   * @return the sentenceLocation
+   */
+  public Boolean sentenceLocation() {
+    return sentenceLocation;
+  }
+
+  /**
+   * Gets the model.
+   *
+   * The enrichement model to use with entity extraction. May be a custom model provided by Watson Knowledge Studio, the
+   * public model for use with Knowledge Graph `en-news`, or the default public model `alchemy`.
+   *
+   * @return the model
+   */
+  public String model() {
+    return model;
+  }
+}

--- a/discovery/src/main/java/com/ibm/watson/developer_cloud/discovery/v1/model/NluEnrichmentFeatures.java
+++ b/discovery/src/main/java/com/ibm/watson/developer_cloud/discovery/v1/model/NluEnrichmentFeatures.java
@@ -1,0 +1,242 @@
+/*
+ * Copyright 2017 IBM Corp. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.ibm.watson.developer_cloud.discovery.v1.model;
+
+import com.google.gson.annotations.SerializedName;
+import com.ibm.watson.developer_cloud.service.model.GenericModel;
+
+/**
+ * NluEnrichmentFeatures.
+ */
+public class NluEnrichmentFeatures extends GenericModel {
+
+  private NluEnrichmentKeywords keywords;
+  private NluEnrichmentEntities entities;
+  private NluEnrichmentSentiment sentiment;
+  private NluEnrichmentEmotion emotion;
+  private NluEnrichmentCategories categories;
+  @SerializedName("semantic_roles")
+  private NluEnrichmentSemanticRoles semanticRoles;
+  private NluEnrichmentRelations relations;
+
+  /**
+   * Builder.
+   */
+  public static class Builder {
+    private NluEnrichmentKeywords keywords;
+    private NluEnrichmentEntities entities;
+    private NluEnrichmentSentiment sentiment;
+    private NluEnrichmentEmotion emotion;
+    private NluEnrichmentCategories categories;
+    private NluEnrichmentSemanticRoles semanticRoles;
+    private NluEnrichmentRelations relations;
+
+    private Builder(NluEnrichmentFeatures nluEnrichmentFeatures) {
+      keywords = nluEnrichmentFeatures.keywords;
+      entities = nluEnrichmentFeatures.entities;
+      sentiment = nluEnrichmentFeatures.sentiment;
+      emotion = nluEnrichmentFeatures.emotion;
+      categories = nluEnrichmentFeatures.categories;
+      semanticRoles = nluEnrichmentFeatures.semanticRoles;
+      relations = nluEnrichmentFeatures.relations;
+    }
+
+    /**
+     * Instantiates a new builder.
+     */
+    public Builder() {
+    }
+
+    /**
+     * Builds a NluEnrichmentFeatures.
+     *
+     * @return the nluEnrichmentFeatures
+     */
+    public NluEnrichmentFeatures build() {
+      return new NluEnrichmentFeatures(this);
+    }
+
+    /**
+     * Set the keywords.
+     *
+     * @param keywords the keywords
+     * @return the NluEnrichmentFeatures builder
+     */
+    public Builder keywords(NluEnrichmentKeywords keywords) {
+      this.keywords = keywords;
+      return this;
+    }
+
+    /**
+     * Set the entities.
+     *
+     * @param entities the entities
+     * @return the NluEnrichmentFeatures builder
+     */
+    public Builder entities(NluEnrichmentEntities entities) {
+      this.entities = entities;
+      return this;
+    }
+
+    /**
+     * Set the sentiment.
+     *
+     * @param sentiment the sentiment
+     * @return the NluEnrichmentFeatures builder
+     */
+    public Builder sentiment(NluEnrichmentSentiment sentiment) {
+      this.sentiment = sentiment;
+      return this;
+    }
+
+    /**
+     * Set the emotion.
+     *
+     * @param emotion the emotion
+     * @return the NluEnrichmentFeatures builder
+     */
+    public Builder emotion(NluEnrichmentEmotion emotion) {
+      this.emotion = emotion;
+      return this;
+    }
+
+    /**
+     * Set the categories.
+     *
+     * @param categories the categories
+     * @return the NluEnrichmentFeatures builder
+     */
+    public Builder categories(NluEnrichmentCategories categories) {
+      this.categories = categories;
+      return this;
+    }
+
+    /**
+     * Set the semanticRoles.
+     *
+     * @param semanticRoles the semanticRoles
+     * @return the NluEnrichmentFeatures builder
+     */
+    public Builder semanticRoles(NluEnrichmentSemanticRoles semanticRoles) {
+      this.semanticRoles = semanticRoles;
+      return this;
+    }
+
+    /**
+     * Set the relations.
+     *
+     * @param relations the relations
+     * @return the NluEnrichmentFeatures builder
+     */
+    public Builder relations(NluEnrichmentRelations relations) {
+      this.relations = relations;
+      return this;
+    }
+  }
+
+  private NluEnrichmentFeatures(Builder builder) {
+    keywords = builder.keywords;
+    entities = builder.entities;
+    sentiment = builder.sentiment;
+    emotion = builder.emotion;
+    categories = builder.categories;
+    semanticRoles = builder.semanticRoles;
+    relations = builder.relations;
+  }
+
+  /**
+   * New builder.
+   *
+   * @return a NluEnrichmentFeatures builder
+   */
+  public Builder newBuilder() {
+    return new Builder(this);
+  }
+
+  /**
+   * Gets the keywords.
+   *
+   * An object specifying the Keyword enrichment and related parameters.
+   *
+   * @return the keywords
+   */
+  public NluEnrichmentKeywords keywords() {
+    return keywords;
+  }
+
+  /**
+   * Gets the entities.
+   *
+   * An object speficying the Entities enrichment and related parameters.
+   *
+   * @return the entities
+   */
+  public NluEnrichmentEntities entities() {
+    return entities;
+  }
+
+  /**
+   * Gets the sentiment.
+   *
+   * An object specifying the sentiment extraction enrichment and related parameters.
+   *
+   * @return the sentiment
+   */
+  public NluEnrichmentSentiment sentiment() {
+    return sentiment;
+  }
+
+  /**
+   * Gets the emotion.
+   *
+   * An object specifying the emotion detection enrichment and related parameters.
+   *
+   * @return the emotion
+   */
+  public NluEnrichmentEmotion emotion() {
+    return emotion;
+  }
+
+  /**
+   * Gets the categories.
+   *
+   * An object specifying the categories enrichment and related parameters.
+   *
+   * @return the categories
+   */
+  public NluEnrichmentCategories categories() {
+    return categories;
+  }
+
+  /**
+   * Gets the semanticRoles.
+   *
+   * An object specifiying the semantic roles enrichment and related parameters.
+   *
+   * @return the semanticRoles
+   */
+  public NluEnrichmentSemanticRoles semanticRoles() {
+    return semanticRoles;
+  }
+
+  /**
+   * Gets the relations.
+   *
+   * An object specifying the relations enrichment and related parameters.
+   *
+   * @return the relations
+   */
+  public NluEnrichmentRelations relations() {
+    return relations;
+  }
+}

--- a/discovery/src/main/java/com/ibm/watson/developer_cloud/discovery/v1/model/NluEnrichmentKeywords.java
+++ b/discovery/src/main/java/com/ibm/watson/developer_cloud/discovery/v1/model/NluEnrichmentKeywords.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2017 IBM Corp. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.ibm.watson.developer_cloud.discovery.v1.model;
+
+import com.ibm.watson.developer_cloud.service.model.GenericModel;
+
+/**
+ * An object specifying the Keyword enrichment and related parameters.
+ */
+public class NluEnrichmentKeywords extends GenericModel {
+
+  private Boolean sentiment;
+  private Boolean emotion;
+  private Long limit;
+
+  /**
+   * Builder.
+   */
+  public static class Builder {
+    private Boolean sentiment;
+    private Boolean emotion;
+    private Long limit;
+
+    private Builder(NluEnrichmentKeywords nluEnrichmentKeywords) {
+      sentiment = nluEnrichmentKeywords.sentiment;
+      emotion = nluEnrichmentKeywords.emotion;
+      limit = nluEnrichmentKeywords.limit;
+    }
+
+    /**
+     * Instantiates a new builder.
+     */
+    public Builder() {
+    }
+
+    /**
+     * Builds a NluEnrichmentKeywords.
+     *
+     * @return the nluEnrichmentKeywords
+     */
+    public NluEnrichmentKeywords build() {
+      return new NluEnrichmentKeywords(this);
+    }
+
+    /**
+     * Set the sentiment.
+     *
+     * @param sentiment the sentiment
+     * @return the NluEnrichmentKeywords builder
+     */
+    public Builder sentiment(Boolean sentiment) {
+      this.sentiment = sentiment;
+      return this;
+    }
+
+    /**
+     * Set the emotion.
+     *
+     * @param emotion the emotion
+     * @return the NluEnrichmentKeywords builder
+     */
+    public Builder emotion(Boolean emotion) {
+      this.emotion = emotion;
+      return this;
+    }
+
+    /**
+     * Set the limit.
+     *
+     * @param limit the limit
+     * @return the NluEnrichmentKeywords builder
+     */
+    public Builder limit(long limit) {
+      this.limit = limit;
+      return this;
+    }
+  }
+
+  private NluEnrichmentKeywords(Builder builder) {
+    sentiment = builder.sentiment;
+    emotion = builder.emotion;
+    limit = builder.limit;
+  }
+
+  /**
+   * New builder.
+   *
+   * @return a NluEnrichmentKeywords builder
+   */
+  public Builder newBuilder() {
+    return new Builder(this);
+  }
+
+  /**
+   * Gets the sentiment.
+   *
+   * When `true`, sentiment analysis of keywords will be performed on the specified field.
+   *
+   * @return the sentiment
+   */
+  public Boolean sentiment() {
+    return sentiment;
+  }
+
+  /**
+   * Gets the emotion.
+   *
+   * When `true`, emotion detection of keywords will be performed on the specified field.
+   *
+   * @return the emotion
+   */
+  public Boolean emotion() {
+    return emotion;
+  }
+
+  /**
+   * Gets the limit.
+   *
+   * The maximum number of keywords to extract for each instance of the specified field.
+   *
+   * @return the limit
+   */
+  public Long limit() {
+    return limit;
+  }
+}

--- a/discovery/src/main/java/com/ibm/watson/developer_cloud/discovery/v1/model/NluEnrichmentRelations.java
+++ b/discovery/src/main/java/com/ibm/watson/developer_cloud/discovery/v1/model/NluEnrichmentRelations.java
@@ -15,20 +15,20 @@ package com.ibm.watson.developer_cloud.discovery.v1.model;
 import com.ibm.watson.developer_cloud.service.model.GenericModel;
 
 /**
- * Options which are specific to a particular enrichment.
+ * An object specifying the relations enrichment and related parameters.
  */
-public class EnrichmentOptions extends GenericModel {
+public class NluEnrichmentRelations extends GenericModel {
 
-  private NluEnrichmentFeatures features;
+  private String model;
 
   /**
    * Builder.
    */
   public static class Builder {
-    private NluEnrichmentFeatures features;
+    private String model;
 
-    private Builder(EnrichmentOptions enrichmentOptions) {
-      features = enrichmentOptions.features;
+    private Builder(NluEnrichmentRelations nluEnrichmentRelations) {
+      model = nluEnrichmentRelations.model;
     }
 
     /**
@@ -38,47 +38,48 @@ public class EnrichmentOptions extends GenericModel {
     }
 
     /**
-     * Builds a EnrichmentOptions.
+     * Builds a NluEnrichmentRelations.
      *
-     * @return the enrichmentOptions
+     * @return the nluEnrichmentRelations
      */
-    public EnrichmentOptions build() {
-      return new EnrichmentOptions(this);
+    public NluEnrichmentRelations build() {
+      return new NluEnrichmentRelations(this);
     }
 
     /**
-     * Set the features.
+     * Set the model.
      *
-     * @param features the features
-     * @return the EnrichmentOptions builder
+     * @param model the model
+     * @return the NluEnrichmentRelations builder
      */
-    public Builder features(NluEnrichmentFeatures features) {
-      this.features = features;
+    public Builder model(String model) {
+      this.model = model;
       return this;
     }
   }
 
-  private EnrichmentOptions(Builder builder) {
-    features = builder.features;
+  private NluEnrichmentRelations(Builder builder) {
+    model = builder.model;
   }
 
   /**
    * New builder.
    *
-   * @return a EnrichmentOptions builder
+   * @return a NluEnrichmentRelations builder
    */
   public Builder newBuilder() {
     return new Builder(this);
   }
 
   /**
-   * Gets the features.
+   * Gets the model.
    *
-   * An object representing the enrichment features that will be applied to the specified field.
+   * The enrichement model to use with relationship extraction. May be a custom model provided by Watson Knowledge
+   * Studio, the public model for use with Knowledge Graph `en-news`, the default is`en-news`.
    *
-   * @return the features
+   * @return the model
    */
-  public NluEnrichmentFeatures features() {
-    return features;
+  public String model() {
+    return model;
   }
 }

--- a/discovery/src/main/java/com/ibm/watson/developer_cloud/discovery/v1/model/NluEnrichmentSemanticRoles.java
+++ b/discovery/src/main/java/com/ibm/watson/developer_cloud/discovery/v1/model/NluEnrichmentSemanticRoles.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2017 IBM Corp. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.ibm.watson.developer_cloud.discovery.v1.model;
+
+import com.ibm.watson.developer_cloud.service.model.GenericModel;
+
+/**
+ * An object specifiying the semantic roles enrichment and related parameters.
+ */
+public class NluEnrichmentSemanticRoles extends GenericModel {
+
+  private Boolean entities;
+  private Boolean keywords;
+  private Long limit;
+
+  /**
+   * Builder.
+   */
+  public static class Builder {
+    private Boolean entities;
+    private Boolean keywords;
+    private Long limit;
+
+    private Builder(NluEnrichmentSemanticRoles nluEnrichmentSemanticRoles) {
+      entities = nluEnrichmentSemanticRoles.entities;
+      keywords = nluEnrichmentSemanticRoles.keywords;
+      limit = nluEnrichmentSemanticRoles.limit;
+    }
+
+    /**
+     * Instantiates a new builder.
+     */
+    public Builder() {
+    }
+
+    /**
+     * Builds a NluEnrichmentSemanticRoles.
+     *
+     * @return the nluEnrichmentSemanticRoles
+     */
+    public NluEnrichmentSemanticRoles build() {
+      return new NluEnrichmentSemanticRoles(this);
+    }
+
+    /**
+     * Set the entities.
+     *
+     * @param entities the entities
+     * @return the NluEnrichmentSemanticRoles builder
+     */
+    public Builder entities(Boolean entities) {
+      this.entities = entities;
+      return this;
+    }
+
+    /**
+     * Set the keywords.
+     *
+     * @param keywords the keywords
+     * @return the NluEnrichmentSemanticRoles builder
+     */
+    public Builder keywords(Boolean keywords) {
+      this.keywords = keywords;
+      return this;
+    }
+
+    /**
+     * Set the limit.
+     *
+     * @param limit the limit
+     * @return the NluEnrichmentSemanticRoles builder
+     */
+    public Builder limit(long limit) {
+      this.limit = limit;
+      return this;
+    }
+  }
+
+  private NluEnrichmentSemanticRoles(Builder builder) {
+    entities = builder.entities;
+    keywords = builder.keywords;
+    limit = builder.limit;
+  }
+
+  /**
+   * New builder.
+   *
+   * @return a NluEnrichmentSemanticRoles builder
+   */
+  public Builder newBuilder() {
+    return new Builder(this);
+  }
+
+  /**
+   * Gets the entities.
+   *
+   * When `true` entities are extracted from the identified sentence parts.
+   *
+   * @return the entities
+   */
+  public Boolean entities() {
+    return entities;
+  }
+
+  /**
+   * Gets the keywords.
+   *
+   * When `true`, keywords are extracted from the identified sentence parts.
+   *
+   * @return the keywords
+   */
+  public Boolean keywords() {
+    return keywords;
+  }
+
+  /**
+   * Gets the limit.
+   *
+   * The maximum number of semantic roles enrichments to extact from each instance of the specified field.
+   *
+   * @return the limit
+   */
+  public Long limit() {
+    return limit;
+  }
+}

--- a/discovery/src/main/java/com/ibm/watson/developer_cloud/discovery/v1/model/NluEnrichmentSentiment.java
+++ b/discovery/src/main/java/com/ibm/watson/developer_cloud/discovery/v1/model/NluEnrichmentSentiment.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2017 IBM Corp. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.ibm.watson.developer_cloud.discovery.v1.model;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.ibm.watson.developer_cloud.service.model.GenericModel;
+import com.ibm.watson.developer_cloud.util.Validator;
+
+/**
+ * An object specifying the sentiment extraction enrichment and related parameters.
+ */
+public class NluEnrichmentSentiment extends GenericModel {
+
+  private Boolean document;
+  private List<String> targets;
+
+  /**
+   * Builder.
+   */
+  public static class Builder {
+    private Boolean document;
+    private List<String> targets;
+
+    private Builder(NluEnrichmentSentiment nluEnrichmentSentiment) {
+      document = nluEnrichmentSentiment.document;
+      targets = nluEnrichmentSentiment.targets;
+    }
+
+    /**
+     * Instantiates a new builder.
+     */
+    public Builder() {
+    }
+
+    /**
+     * Builds a NluEnrichmentSentiment.
+     *
+     * @return the nluEnrichmentSentiment
+     */
+    public NluEnrichmentSentiment build() {
+      return new NluEnrichmentSentiment(this);
+    }
+
+    /**
+     * Adds a target to targets.
+     *
+     * @param target the new target
+     * @return the NluEnrichmentSentiment builder
+     */
+    public Builder addTarget(String target) {
+      Validator.notNull(target, "target cannot be null");
+      if (this.targets == null) {
+        this.targets = new ArrayList<String>();
+      }
+      this.targets.add(target);
+      return this;
+    }
+
+    /**
+     * Set the document.
+     *
+     * @param document the document
+     * @return the NluEnrichmentSentiment builder
+     */
+    public Builder document(Boolean document) {
+      this.document = document;
+      return this;
+    }
+
+    /**
+     * Set the targets.
+     * Existing targets will be replaced.
+     *
+     * @param targets the targets
+     * @return the NluEnrichmentSentiment builder
+     */
+    public Builder targets(List<String> targets) {
+      this.targets = targets;
+      return this;
+    }
+  }
+
+  private NluEnrichmentSentiment(Builder builder) {
+    document = builder.document;
+    targets = builder.targets;
+  }
+
+  /**
+   * New builder.
+   *
+   * @return a NluEnrichmentSentiment builder
+   */
+  public Builder newBuilder() {
+    return new Builder(this);
+  }
+
+  /**
+   * Gets the document.
+   *
+   * When `true`, sentiment analysis is performed on the entire field.
+   *
+   * @return the document
+   */
+  public Boolean document() {
+    return document;
+  }
+
+  /**
+   * Gets the targets.
+   *
+   * A comma-separated list of target strings that will have any associated sentiment analyzed.
+   *
+   * @return the targets
+   */
+  public List<String> targets() {
+    return targets;
+  }
+}

--- a/discovery/src/test/java/com/ibm/watson/developer_cloud/discovery/v1/DiscoveryServiceIT.java
+++ b/discovery/src/test/java/com/ibm/watson/developer_cloud/discovery/v1/DiscoveryServiceIT.java
@@ -56,6 +56,12 @@ import com.ibm.watson.developer_cloud.discovery.v1.model.ListConfigurationsRespo
 import com.ibm.watson.developer_cloud.discovery.v1.model.ListEnvironmentsOptions;
 import com.ibm.watson.developer_cloud.discovery.v1.model.ListEnvironmentsResponse;
 import com.ibm.watson.developer_cloud.discovery.v1.model.ListTrainingDataOptions;
+import com.ibm.watson.developer_cloud.discovery.v1.model.NluEnrichmentEmotion;
+import com.ibm.watson.developer_cloud.discovery.v1.model.NluEnrichmentEntities;
+import com.ibm.watson.developer_cloud.discovery.v1.model.NluEnrichmentFeatures;
+import com.ibm.watson.developer_cloud.discovery.v1.model.NluEnrichmentKeywords;
+import com.ibm.watson.developer_cloud.discovery.v1.model.NluEnrichmentSemanticRoles;
+import com.ibm.watson.developer_cloud.discovery.v1.model.NluEnrichmentSentiment;
 import com.ibm.watson.developer_cloud.discovery.v1.model.NormalizationOperation;
 import com.ibm.watson.developer_cloud.discovery.v1.model.NormalizationOperation.Operation;
 import com.ibm.watson.developer_cloud.discovery.v1.model.QueryAggregation;
@@ -496,15 +502,37 @@ public class DiscoveryServiceIT extends WatsonServiceTest {
     enrichment.setDescription("Erich foo to bar with baz");
     enrichment.setIgnoreDownstreamErrors(true);
     enrichment.setOverwrite(false);
-    EnrichmentOptions enrichmentOptions = new EnrichmentOptions();
-    enrichmentOptions.setSentiment(true);
-    enrichmentOptions.setExtract(Arrays.asList("qux"));
-    enrichmentOptions.setHierarchicalTypedRelations(false);
-    enrichmentOptions.setLanguage("en");
-    enrichmentOptions.setModel("WhatComesAfterQux");
-    enrichmentOptions.setQuotations(true);
-    enrichmentOptions.setShowSourceText(true);
-    enrichment.setOptions(enrichmentOptions);
+
+    NluEnrichmentSentiment sentiment = new NluEnrichmentSentiment.Builder()
+      .document(true)
+      .build();
+    NluEnrichmentEmotion emotion = new NluEnrichmentEmotion.Builder()
+      .document(true)
+      .build();
+    NluEnrichmentEntities entities = new NluEnrichmentEntities.Builder()
+      .emotion(true)
+      .sentiment(true)
+      .model("WhatComesAfterQux")
+      .build();
+    NluEnrichmentKeywords keywords = new NluEnrichmentKeywords.Builder()
+      .emotion(true)
+      .sentiment(true)
+      .build();
+    NluEnrichmentSemanticRoles semanticRoles = new NluEnrichmentSemanticRoles.Builder()
+      .entities(true)
+      .build();
+    NluEnrichmentFeatures features = new NluEnrichmentFeatures.Builder()
+      .sentiment(sentiment)
+      .emotion(emotion)
+      .entities(entities)
+      .keywords(keywords)
+      .semanticRoles(semanticRoles)
+      .build();
+    EnrichmentOptions options = new EnrichmentOptions.Builder()
+      .features(features)
+      .build();
+
+    enrichment.setOptions(options);
     List<Enrichment> enrichments = Arrays.asList(enrichment);
 
     CreateConfigurationOptions createOptions = new CreateConfigurationOptions.Builder()
@@ -606,15 +634,37 @@ public class DiscoveryServiceIT extends WatsonServiceTest {
     enrichment.setDescription("Erich foo to bar with baz");
     enrichment.setIgnoreDownstreamErrors(true);
     enrichment.setOverwrite(false);
-    EnrichmentOptions enrichmentOptions = new EnrichmentOptions();
-    enrichmentOptions.setSentiment(true);
-    enrichmentOptions.setExtract(Arrays.asList("qux"));
-    enrichmentOptions.setHierarchicalTypedRelations(false);
-    enrichmentOptions.setLanguage("en");
-    enrichmentOptions.setModel("WhatComesAfterQux");
-    enrichmentOptions.setQuotations(true);
-    enrichmentOptions.setShowSourceText(true);
-    enrichment.setOptions(enrichmentOptions);
+
+    NluEnrichmentSentiment sentiment = new NluEnrichmentSentiment.Builder()
+      .document(true)
+      .build();
+    NluEnrichmentEmotion emotion = new NluEnrichmentEmotion.Builder()
+      .document(true)
+      .build();
+    NluEnrichmentEntities entities = new NluEnrichmentEntities.Builder()
+      .emotion(true)
+      .sentiment(true)
+      .model("WhatComesAfterQux")
+      .build();
+    NluEnrichmentKeywords keywords = new NluEnrichmentKeywords.Builder()
+      .emotion(true)
+      .sentiment(true)
+      .build();
+    NluEnrichmentSemanticRoles semanticRoles = new NluEnrichmentSemanticRoles.Builder()
+      .entities(true)
+      .build();
+    NluEnrichmentFeatures features = new NluEnrichmentFeatures.Builder()
+      .sentiment(sentiment)
+      .emotion(emotion)
+      .entities(entities)
+      .keywords(keywords)
+      .semanticRoles(semanticRoles)
+      .build();
+    EnrichmentOptions options = new EnrichmentOptions.Builder()
+      .features(features)
+      .build();
+
+    enrichment.setOptions(options);
     List<Enrichment> updatedEnrichments = Arrays.asList(enrichment);
 
     UpdateConfigurationOptions.Builder updateBuilder =

--- a/personality-insights/src/main/java/com/ibm/watson/developer_cloud/personality_insights/v3/PersonalityInsights.java
+++ b/personality-insights/src/main/java/com/ibm/watson/developer_cloud/personality_insights/v3/PersonalityInsights.java
@@ -12,6 +12,8 @@
  */
 package com.ibm.watson.developer_cloud.personality_insights.v3;
 
+import com.ibm.watson.developer_cloud.http.HttpHeaders;
+import com.ibm.watson.developer_cloud.http.HttpMediaType;
 import com.ibm.watson.developer_cloud.http.RequestBuilder;
 import com.ibm.watson.developer_cloud.http.ServiceCall;
 import com.ibm.watson.developer_cloud.personality_insights.v3.model.Profile;
@@ -120,9 +122,6 @@ public class PersonalityInsights extends WatsonService {
     if (profileOptions.rawScores() != null) {
       builder.query("raw_scores", String.valueOf(profileOptions.rawScores()));
     }
-    if (profileOptions.csvHeaders() != null) {
-      builder.query("csv_headers", String.valueOf(profileOptions.csvHeaders()));
-    }
     if (profileOptions.consumptionPreferences() != null) {
       builder.query("consumption_preferences", String.valueOf(profileOptions.consumptionPreferences()));
     }
@@ -134,4 +133,32 @@ public class PersonalityInsights extends WatsonService {
     return createServiceCall(builder.build(), ResponseConverterUtils.getObject(Profile.class));
   }
 
+  public ServiceCall<String> getProfileAsCSV(ProfileOptions profileOptions, boolean includeHeaders) {
+    Validator.notNull(profileOptions, "profileOptions cannot be null");
+    RequestBuilder builder = RequestBuilder.post("/v3/profile");
+    builder.query(VERSION, versionDate);
+    builder.header("Content-Type", profileOptions.contentType());
+    if (profileOptions.contentLanguage() != null) {
+      builder.header("Content-Language", profileOptions.contentLanguage());
+    }
+    if (profileOptions.acceptLanguage() != null) {
+      builder.header("Accept-Language", profileOptions.acceptLanguage());
+    }
+    if (profileOptions.rawScores() != null) {
+      builder.query("raw_scores", String.valueOf(profileOptions.rawScores()));
+    }
+    if (profileOptions.consumptionPreferences() != null) {
+      builder.query("consumption_preferences", String.valueOf(profileOptions.consumptionPreferences()));
+    }
+    if (profileOptions.contentType().equalsIgnoreCase(ProfileOptions.ContentType.APPLICATION_JSON)) {
+      builder.bodyJson(GsonSingleton.getGson().toJsonTree(profileOptions.content()).getAsJsonObject());
+    } else {
+      builder.bodyContent(profileOptions.body(), profileOptions.contentType());
+    }
+
+    builder.header(HttpHeaders.ACCEPT, HttpMediaType.TEXT_CSV);
+    builder.query("headers", includeHeaders);
+
+    return createServiceCall(builder.build(), ResponseConverterUtils.getString());
+  }
 }

--- a/personality-insights/src/main/java/com/ibm/watson/developer_cloud/personality_insights/v3/model/ProfileOptions.java
+++ b/personality-insights/src/main/java/com/ibm/watson/developer_cloud/personality_insights/v3/model/ProfileOptions.java
@@ -92,7 +92,6 @@ public class ProfileOptions extends GenericModel {
   private String contentLanguage;
   private String acceptLanguage;
   private Boolean rawScores;
-  private Boolean csvHeaders;
   private Boolean consumptionPreferences;
 
   /**
@@ -105,7 +104,6 @@ public class ProfileOptions extends GenericModel {
     private String contentLanguage;
     private String acceptLanguage;
     private Boolean rawScores;
-    private Boolean csvHeaders;
     private Boolean consumptionPreferences;
 
     private Builder(ProfileOptions profileOptions) {
@@ -115,7 +113,6 @@ public class ProfileOptions extends GenericModel {
       contentLanguage = profileOptions.contentLanguage;
       acceptLanguage = profileOptions.acceptLanguage;
       rawScores = profileOptions.rawScores;
-      csvHeaders = profileOptions.csvHeaders;
       consumptionPreferences = profileOptions.consumptionPreferences;
     }
 
@@ -164,17 +161,6 @@ public class ProfileOptions extends GenericModel {
      */
     public Builder rawScores(Boolean rawScores) {
       this.rawScores = rawScores;
-      return this;
-    }
-
-    /**
-     * Set the csvHeaders.
-     *
-     * @param csvHeaders the csvHeaders
-     * @return the ProfileOptions builder
-     */
-    public Builder csvHeaders(Boolean csvHeaders) {
-      this.csvHeaders = csvHeaders;
       return this;
     }
 
@@ -234,7 +220,6 @@ public class ProfileOptions extends GenericModel {
     contentLanguage = builder.contentLanguage;
     acceptLanguage = builder.acceptLanguage;
     rawScores = builder.rawScores;
-    csvHeaders = builder.csvHeaders;
     consumptionPreferences = builder.consumptionPreferences;
   }
 
@@ -326,18 +311,6 @@ public class ProfileOptions extends GenericModel {
    */
   public Boolean rawScores() {
     return rawScores;
-  }
-
-  /**
-   * Gets the csvHeaders.
-   *
-   * If `true`, column labels are returned with a CSV response; if `false` (the default), they are not. Applies only
-   * when the `Accept` header is set to `text/csv`.
-   *
-   * @return the csvHeaders
-   */
-  public Boolean csvHeaders() {
-    return csvHeaders;
   }
 
   /**

--- a/personality-insights/src/test/java/com/ibm/watson/developer_cloud/personality_insights/v3/PersonalityInsightsTest.java
+++ b/personality-insights/src/test/java/com/ibm/watson/developer_cloud/personality_insights/v3/PersonalityInsightsTest.java
@@ -218,13 +218,11 @@ public class PersonalityInsightsTest extends WatsonServiceUnitTest {
         .html(text)
         .contentLanguage(ProfileOptions.ContentLanguage.ES)
         .acceptLanguage(ProfileOptions.AcceptLanguage.EN)
-        .csvHeaders(true)
         .build();
     final ProfileOptions newOptions = options.newBuilder().build();
     assertEquals(newOptions.body(), text);
     assertEquals(newOptions.contentLanguage(), ProfileOptions.ContentLanguage.ES);
     assertEquals(newOptions.acceptLanguage(), ProfileOptions.AcceptLanguage.EN);
-    assertEquals(newOptions.csvHeaders(), true);
   }
 
   /**


### PR DESCRIPTION
This PR updates Discovery to use the new NLU-based Enrichment models and fixes an issue with adding/updating configurations as described [here](https://github.com/watson-developer-cloud/java-sdk/issues/826).

It also adds back the old `getProfileAsCSV()` method to Personality Insights that had been missing since v4.0.0.