### PR TITLE
Set authorization in header for VR dedicated

### DIFF
--- a/core/src/main/java/com/ibm/watson/developer_cloud/service/WatsonService.java
+++ b/core/src/main/java/com/ibm/watson/developer_cloud/service/WatsonService.java
@@ -68,6 +68,8 @@ public abstract class WatsonService {
   private static final String BASIC = "Basic ";
   private static final Logger LOG = Logger.getLogger(WatsonService.class.getName());
   private String apiKey;
+  private String username;
+  private String password;
   private String endPoint;
   private final String name;
 
@@ -244,6 +246,26 @@ public abstract class WatsonService {
   }
 
   /**
+   * Gets the username.
+   *
+   *
+   * @return the username
+   */
+  protected String getUsername() {
+    return username;
+  }
+
+  /**
+   * Gets the password.
+   *
+   *
+   * @return the password
+   */
+  protected String getPassword() {
+    return password;
+  }
+
+  /**
    * Gets the API end point.
    *
    *
@@ -308,7 +330,6 @@ public abstract class WatsonService {
     return name;
   }
 
-
   /**
    * Sets the API key.
    *
@@ -351,6 +372,8 @@ public abstract class WatsonService {
    * @param password the password
    */
   public void setUsernameAndPassword(final String username, final String password) {
+    this.username = username;
+    this.password = password;
     apiKey = Credentials.basic(username, password);
   }
 

--- a/visual-recognition/src/main/java/com/ibm/watson/developer_cloud/visual_recognition/v3/VisualRecognition.java
+++ b/visual-recognition/src/main/java/com/ibm/watson/developer_cloud/visual_recognition/v3/VisualRecognition.java
@@ -59,6 +59,8 @@ public class VisualRecognition extends WatsonService {
   /** The Constant VERSION_DATE_2016_05_20. */
   public static final String VERSION_DATE_2016_05_20 = "2016-05-20";
 
+  private boolean endPointChanged;
+
   /**
    * Instantiates a new `VisualRecognition`.
    *
@@ -89,6 +91,17 @@ public class VisualRecognition extends WatsonService {
     setApiKey(apiKey);
   }
 
+  /**
+   * Sets the endpoint while making a note of the change to later authenticate properly.
+   *
+   * @param endPoint the new endpoint. Will be ignored if empty or null
+   */
+  @Override
+  public void setEndPoint(String endPoint) {
+    super.setEndPoint(endPoint);
+    endPointChanged = true;
+  }
+
   /*
    * (non-Javadoc)
    */
@@ -96,6 +109,9 @@ public class VisualRecognition extends WatsonService {
   protected void setAuthentication(okhttp3.Request.Builder builder) {
     if (getApiKey() == null) {
       throw new IllegalArgumentException("api_key needs to be specified. Use setApiKey()");
+    }
+    if (endPointChanged && !getEndPoint().equals(URL)) {
+      super.setAuthentication(builder);
     }
     final okhttp3.HttpUrl url = okhttp3.HttpUrl.parse(builder.build().url().toString());
     if ((url.query() == null) || url.query().isEmpty()) {

--- a/visual-recognition/src/main/java/com/ibm/watson/developer_cloud/visual_recognition/v3/VisualRecognition.java
+++ b/visual-recognition/src/main/java/com/ibm/watson/developer_cloud/visual_recognition/v3/VisualRecognition.java
@@ -91,33 +91,23 @@ public class VisualRecognition extends WatsonService {
     setApiKey(apiKey);
   }
 
-  /**
-   * Sets the endpoint while making a note of the change to later authenticate properly.
-   *
-   * @param endPoint the new endpoint. Will be ignored if empty or null
-   */
-  @Override
-  public void setEndPoint(String endPoint) {
-    super.setEndPoint(endPoint);
-    endPointChanged = true;
-  }
-
   /*
    * (non-Javadoc)
    */
   @Override
   protected void setAuthentication(okhttp3.Request.Builder builder) {
-    if (getApiKey() == null) {
-      throw new IllegalArgumentException("api_key needs to be specified. Use setApiKey()");
-    }
-    if (endPointChanged && !getEndPoint().equals(URL)) {
+    if (getUsername() != null && getPassword() != null) {
       super.setAuthentication(builder);
-    }
-    final okhttp3.HttpUrl url = okhttp3.HttpUrl.parse(builder.build().url().toString());
-    if ((url.query() == null) || url.query().isEmpty()) {
-      builder.url(builder.build().url() + "?api_key=" + getApiKey());
+    } else if (getApiKey() != null) {
+      final okhttp3.HttpUrl url = okhttp3.HttpUrl.parse(builder.build().url().toString());
+      
+      if ((url.query() == null) || url.query().isEmpty()) {
+        builder.url(builder.build().url() + "?api_key=" + getApiKey());
+      } else {
+        builder.url(builder.build().url() + "&api_key=" + getApiKey());
+      }
     } else {
-      builder.url(builder.build().url() + "&api_key=" + getApiKey());
+      throw new IllegalArgumentException("Credentials need to be specified. Use setApiKey() or setUsernameAndPassword()");
     }
   }
 

--- a/visual-recognition/src/main/java/com/ibm/watson/developer_cloud/visual_recognition/v3/VisualRecognition.java
+++ b/visual-recognition/src/main/java/com/ibm/watson/developer_cloud/visual_recognition/v3/VisualRecognition.java
@@ -100,14 +100,15 @@ public class VisualRecognition extends WatsonService {
       super.setAuthentication(builder);
     } else if (getApiKey() != null) {
       final okhttp3.HttpUrl url = okhttp3.HttpUrl.parse(builder.build().url().toString());
-      
+
       if ((url.query() == null) || url.query().isEmpty()) {
         builder.url(builder.build().url() + "?api_key=" + getApiKey());
       } else {
         builder.url(builder.build().url() + "&api_key=" + getApiKey());
       }
     } else {
-      throw new IllegalArgumentException("Credentials need to be specified. Use setApiKey() or setUsernameAndPassword()");
+      throw new IllegalArgumentException(
+        "Credentials need to be specified. Use setApiKey() or setUsernameAndPassword()");
     }
   }
 


### PR DESCRIPTION
Fixes #838 

~~This PR makes sure that if the user of a VR service changes the endpoint, the authorization is set in the header like in other services.~~

~~Unfortunately, the change is being made to the VR service file, meaning it will have to be tweaked post-codegen. This is just due to the nature of VR using an API key most of the time but a username and password for the dedicated option.~~

After new updates, `WatsonService` has been changed to store the username and password. The VR service will then check for those values to decide which authorization method to use. Presence of a username and password guarantees the use of a dedicated VR service.

The new changes to the VR service class can also be added to the generator code, eliminating the need for post-generation tweaks.
  