### PR TITLE
Fix javadoc warnings about the @throws tag

### DIFF
--- a/discovery/src/main/java/com/ibm/watson/developer_cloud/discovery/v1/model/AddDocumentOptions.java
+++ b/discovery/src/main/java/com/ibm/watson/developer_cloud/discovery/v1/model/AddDocumentOptions.java
@@ -150,7 +150,7 @@ public class AddDocumentOptions extends GenericModel {
      * @param file the file
      * @return the AddDocumentOptions builder
      *
-     * @throws FileNotFoundException
+     * @throws FileNotFoundException if the file could not be found
      */
     public Builder file(File file) throws FileNotFoundException {
       this.file = new FileInputStream(file);

--- a/discovery/src/main/java/com/ibm/watson/developer_cloud/discovery/v1/model/TestConfigurationInEnvironmentOptions.java
+++ b/discovery/src/main/java/com/ibm/watson/developer_cloud/discovery/v1/model/TestConfigurationInEnvironmentOptions.java
@@ -195,7 +195,7 @@ public class TestConfigurationInEnvironmentOptions extends GenericModel {
      * @param file the file
      * @return the TestConfigurationInEnvironmentOptions builder
      *
-     * @throws FileNotFoundException
+     * @throws FileNotFoundException if the file could not be found
      */
     public Builder file(File file) throws FileNotFoundException {
       this.file = new FileInputStream(file);

--- a/discovery/src/main/java/com/ibm/watson/developer_cloud/discovery/v1/model/UpdateDocumentOptions.java
+++ b/discovery/src/main/java/com/ibm/watson/developer_cloud/discovery/v1/model/UpdateDocumentOptions.java
@@ -166,7 +166,7 @@ public class UpdateDocumentOptions extends GenericModel {
      * @param file the file
      * @return the UpdateDocumentOptions builder
      *
-     * @throws FileNotFoundException
+     * @throws FileNotFoundException if the file could not be found
      */
     public Builder file(File file) throws FileNotFoundException {
       this.file = new FileInputStream(file);

--- a/language-translator/src/main/java/com/ibm/watson/developer_cloud/language_translator/v2/model/CreateModelOptions.java
+++ b/language-translator/src/main/java/com/ibm/watson/developer_cloud/language_translator/v2/model/CreateModelOptions.java
@@ -176,7 +176,7 @@ public class CreateModelOptions extends GenericModel {
      * @param forcedGlossary the forcedGlossary
      * @return the CreateModelOptions builder
      *
-     * @throws FileNotFoundException
+     * @throws FileNotFoundException if the file could not be found
      */
     public Builder forcedGlossary(File forcedGlossary) throws FileNotFoundException {
       this.forcedGlossary = new FileInputStream(forcedGlossary);
@@ -190,7 +190,7 @@ public class CreateModelOptions extends GenericModel {
      * @param parallelCorpus the parallelCorpus
      * @return the CreateModelOptions builder
      *
-     * @throws FileNotFoundException
+     * @throws FileNotFoundException if the file could not be found
      */
     public Builder parallelCorpus(File parallelCorpus) throws FileNotFoundException {
       this.parallelCorpus = new FileInputStream(parallelCorpus);
@@ -204,7 +204,7 @@ public class CreateModelOptions extends GenericModel {
      * @param monolingualCorpus the monolingualCorpus
      * @return the CreateModelOptions builder
      *
-     * @throws FileNotFoundException
+     * @throws FileNotFoundException if the file could not be found
      */
     public Builder monolingualCorpus(File monolingualCorpus) throws FileNotFoundException {
       this.monolingualCorpus = new FileInputStream(monolingualCorpus);

--- a/visual-recognition/src/main/java/com/ibm/watson/developer_cloud/visual_recognition/v3/model/ClassifyOptions.java
+++ b/visual-recognition/src/main/java/com/ibm/watson/developer_cloud/visual_recognition/v3/model/ClassifyOptions.java
@@ -148,7 +148,7 @@ public class ClassifyOptions extends GenericModel {
      * @param imagesFile the imagesFile
      * @return the ClassifyOptions builder
      *
-     * @throws FileNotFoundException
+     * @throws FileNotFoundException if the file could not be found
      */
     public Builder imagesFile(File imagesFile) throws FileNotFoundException {
       this.imagesFile = new FileInputStream(imagesFile);

--- a/visual-recognition/src/main/java/com/ibm/watson/developer_cloud/visual_recognition/v3/model/CreateClassifierOptions.java
+++ b/visual-recognition/src/main/java/com/ibm/watson/developer_cloud/visual_recognition/v3/model/CreateClassifierOptions.java
@@ -129,7 +129,7 @@ public class CreateClassifierOptions extends GenericModel {
      * @param negativeExamples the negativeExamples
      * @return the CreateClassifierOptions builder
      *
-     * @throws FileNotFoundException
+     * @throws FileNotFoundException if the file could not be found
      */
     public Builder negativeExamples(File negativeExamples) throws FileNotFoundException {
       this.negativeExamples = new FileInputStream(negativeExamples);

--- a/visual-recognition/src/main/java/com/ibm/watson/developer_cloud/visual_recognition/v3/model/DetectFacesOptions.java
+++ b/visual-recognition/src/main/java/com/ibm/watson/developer_cloud/visual_recognition/v3/model/DetectFacesOptions.java
@@ -110,7 +110,7 @@ public class DetectFacesOptions extends GenericModel {
      * @param imagesFile the imagesFile
      * @return the DetectFacesOptions builder
      *
-     * @throws FileNotFoundException
+     * @throws FileNotFoundException if the file could not be found
      */
     public Builder imagesFile(File imagesFile) throws FileNotFoundException {
       this.imagesFile = new FileInputStream(imagesFile);

--- a/visual-recognition/src/main/java/com/ibm/watson/developer_cloud/visual_recognition/v3/model/UpdateClassifierOptions.java
+++ b/visual-recognition/src/main/java/com/ibm/watson/developer_cloud/visual_recognition/v3/model/UpdateClassifierOptions.java
@@ -129,7 +129,7 @@ public class UpdateClassifierOptions extends GenericModel {
      * @param negativeExamples the negativeExamples
      * @return the UpdateClassifierOptions builder
      *
-     * @throws FileNotFoundException
+     * @throws FileNotFoundException if the file could not be found
      */
     public Builder negativeExamples(File negativeExamples) throws FileNotFoundException {
       this.negativeExamples = new FileInputStream(negativeExamples);


### PR DESCRIPTION
Resolves #839 

Some warnings were being thrown with the previous Javadocs because of missing descriptions on `@throws` tags. These have been added and the change was also made in the generator code.