### PR TITLE
Fix broken link to download jar

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,4 +309,4 @@ or [Stack Overflow](http://stackoverflow.com/questions/ask?tags=ibm-watson).
 [apache_maven]: http://maven.apache.org/
 [sonatype_snapshots]: https://oss.sonatype.org/content/repositories/snapshots/com/ibm/watson/developer_cloud/
 
-[jar]: https://github.com/watson-developer-cloud/java-sdk/releases/download/java-sdk-4.2.1/java-sdk-4.2.1-jar-with-dependencies.jar
+[jar]: https://github.com/watson-developer-cloud/java-sdk/releases/download/java-sdk-4.2.0/java-sdk-4.2.1-jar-with-dependencies.jar


### PR DESCRIPTION
With the last release, there was an issue getting the version number right and it caused the link to download the jar in the README to be incorrect. This PR makes that small fix to target the correct location.