### PR TITLE
Deprecate doc conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ APIs and SDKs that use cognitive computing to solve complex problems.
   * [Conversation](conversation)
   * [Dialog](dialog)
   * [Discovery](discovery)
-  * [Document Conversion](document-conversion)
   * [Language Translation](language-translation)
   * [Language Translator](language-translator)
   * [Natural Language Classifier](natural-language-classifier)

--- a/document-conversion/README.md
+++ b/document-conversion/README.md
@@ -1,33 +1,3 @@
 # Document Conversion
 
-## Installation
-
-##### Maven
-```xml
-<dependency>
-	<groupId>com.ibm.watson.developer_cloud</groupId>
-	<artifactId>document-conversion</artifactId>
-	<version>4.2.1</version>
-</dependency>
-```
-
-##### Gradle
-```gradle
-'com.ibm.watson.developer_cloud:document-conversion:4.2.1'
-```
-
-## Usage
-The [Document Conversion][document_conversion] service allows to convert pdf, word, and html documents into formats useful to other Watson Cognitive services. Target formats include normalized html, plain text, and sets of potential answers for Watson question answering. You can convert documents synchronously one at a time, or asynchronously in batches
-
-Returns the document list using the [Document Conversion][document_conversion] service.
-
-```java
-DocumentConversion service = new DocumentConversion("2015-12-01");
-service.setUsernameAndPassword("<username>", "<password>");
-
-File doc = new File("src/test/resources/document_conversion/word-document-heading-input.doc");
-Answers htmlToAnswers = service.convertDocumentToAnswer(doc).execute();
-System.out.println(htmlToAnswers);
-```
-
-[document_conversion]: https://console.bluemix.net/docs/services/document-conversion/index.html
+Document Conversion was retired in October 2017. To continue using document conversion capabilities with Watson, please use the [Watson Discovery](../discovery) service instead.

--- a/document-conversion/src/main/java/com/ibm/watson/developer_cloud/document_conversion/v1/DocumentConversion.java
+++ b/document-conversion/src/main/java/com/ibm/watson/developer_cloud/document_conversion/v1/DocumentConversion.java
@@ -42,9 +42,13 @@ import okhttp3.RequestBody;
  * The IBM Watson Document Conversion service converts provided source documents (HTML, Word, PDF) into JSON Answer
  * Units, Normalized HTML, or Normalized Text.
  *
+ * @deprecated Document Conversion was retired in October 2017. The document conversion capabilities of Watson
+ *             Discovery have continued to improve along with its integrated data pipeline and information retrieval
+ *             capabilities. If you are a Document Conversion user, get started with Discovery today.
  * @version v1
  * @see <a href= "http://www.ibm.com/watson/developercloud/document-conversion.html"> Document Conversion</a>
  */
+@Deprecated
 public class DocumentConversion extends WatsonService {
 
   private static final String CONVERSION_TARGET = "conversion_target";


### PR DESCRIPTION
This PR adds documentation and Javadoc changes to reflect Document Conversion's retirement in October 2017.