### PR TITLE
Add newest generated code for Language Translator

### DIFF
--- a/language-translator/src/main/java/com/ibm/watson/developer_cloud/language_translator/v2/LanguageTranslator.java
+++ b/language-translator/src/main/java/com/ibm/watson/developer_cloud/language_translator/v2/LanguageTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 IBM Corp. All Rights Reserved.
+ * Copyright 2018 IBM Corp. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -12,9 +12,6 @@
  */
 package com.ibm.watson.developer_cloud.language_translator.v2;
 
-import okhttp3.MultipartBody;
-import okhttp3.RequestBody;
-import com.ibm.watson.developer_cloud.util.RequestUtils;
 import com.google.gson.JsonObject;
 import com.ibm.watson.developer_cloud.http.RequestBuilder;
 import com.ibm.watson.developer_cloud.http.ServiceCall;
@@ -32,8 +29,11 @@ import com.ibm.watson.developer_cloud.language_translator.v2.model.TranslationMo
 import com.ibm.watson.developer_cloud.language_translator.v2.model.TranslationResult;
 import com.ibm.watson.developer_cloud.service.WatsonService;
 import com.ibm.watson.developer_cloud.util.GsonSingleton;
+import com.ibm.watson.developer_cloud.util.RequestUtils;
 import com.ibm.watson.developer_cloud.util.ResponseConverterUtils;
 import com.ibm.watson.developer_cloud.util.Validator;
+import okhttp3.MultipartBody;
+import okhttp3.RequestBody;
 
 /**
  * Language Translator translates text from one language to another. The service offers multiple domain-specific models
@@ -139,6 +139,10 @@ public class LanguageTranslator extends WatsonService {
 
   /**
    * Uploads a TMX glossary file on top of a domain to customize a translation model.
+   *
+   * Depending on the size of the file, training can range from minutes for a glossary to several hours for a large
+   * parallel corpus. Glossary files must be less than 10 MB. The cumulative file size of all uploaded glossary and
+   * corpus files is limited to 250 MB.
    *
    * @param createModelOptions the {@link CreateModelOptions} containing the options for the call
    * @return a {@link ServiceCall} with a response type of {@link TranslationModel}

--- a/language-translator/src/main/java/com/ibm/watson/developer_cloud/language_translator/v2/model/CreateModelOptions.java
+++ b/language-translator/src/main/java/com/ibm/watson/developer_cloud/language_translator/v2/model/CreateModelOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 IBM Corp. All Rights Reserved.
+ * Copyright 2018 IBM Corp. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/language-translator/src/main/java/com/ibm/watson/developer_cloud/language_translator/v2/model/DeleteModelOptions.java
+++ b/language-translator/src/main/java/com/ibm/watson/developer_cloud/language_translator/v2/model/DeleteModelOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 IBM Corp. All Rights Reserved.
+ * Copyright 2018 IBM Corp. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/language-translator/src/main/java/com/ibm/watson/developer_cloud/language_translator/v2/model/GetModelOptions.java
+++ b/language-translator/src/main/java/com/ibm/watson/developer_cloud/language_translator/v2/model/GetModelOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 IBM Corp. All Rights Reserved.
+ * Copyright 2018 IBM Corp. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -85,7 +85,7 @@ public class GetModelOptions extends GenericModel {
   /**
    * Gets the modelId.
    *
-   * Model ID to use
+   * Model ID to use.
    *
    * @return the modelId
    */

--- a/language-translator/src/main/java/com/ibm/watson/developer_cloud/language_translator/v2/model/IdentifiableLanguage.java
+++ b/language-translator/src/main/java/com/ibm/watson/developer_cloud/language_translator/v2/model/IdentifiableLanguage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 IBM Corp. All Rights Reserved.
+ * Copyright 2018 IBM Corp. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/language-translator/src/main/java/com/ibm/watson/developer_cloud/language_translator/v2/model/IdentifiableLanguages.java
+++ b/language-translator/src/main/java/com/ibm/watson/developer_cloud/language_translator/v2/model/IdentifiableLanguages.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 IBM Corp. All Rights Reserved.
+ * Copyright 2018 IBM Corp. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/language-translator/src/main/java/com/ibm/watson/developer_cloud/language_translator/v2/model/IdentifiedLanguage.java
+++ b/language-translator/src/main/java/com/ibm/watson/developer_cloud/language_translator/v2/model/IdentifiedLanguage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 IBM Corp. All Rights Reserved.
+ * Copyright 2018 IBM Corp. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/language-translator/src/main/java/com/ibm/watson/developer_cloud/language_translator/v2/model/IdentifiedLanguages.java
+++ b/language-translator/src/main/java/com/ibm/watson/developer_cloud/language_translator/v2/model/IdentifiedLanguages.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 IBM Corp. All Rights Reserved.
+ * Copyright 2018 IBM Corp. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/language-translator/src/main/java/com/ibm/watson/developer_cloud/language_translator/v2/model/IdentifyOptions.java
+++ b/language-translator/src/main/java/com/ibm/watson/developer_cloud/language_translator/v2/model/IdentifyOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 IBM Corp. All Rights Reserved.
+ * Copyright 2018 IBM Corp. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/language-translator/src/main/java/com/ibm/watson/developer_cloud/language_translator/v2/model/ListIdentifiableLanguagesOptions.java
+++ b/language-translator/src/main/java/com/ibm/watson/developer_cloud/language_translator/v2/model/ListIdentifiableLanguagesOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 IBM Corp. All Rights Reserved.
+ * Copyright 2018 IBM Corp. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/language-translator/src/main/java/com/ibm/watson/developer_cloud/language_translator/v2/model/ListModelsOptions.java
+++ b/language-translator/src/main/java/com/ibm/watson/developer_cloud/language_translator/v2/model/ListModelsOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 IBM Corp. All Rights Reserved.
+ * Copyright 2018 IBM Corp. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/language-translator/src/main/java/com/ibm/watson/developer_cloud/language_translator/v2/model/TranslateOptions.java
+++ b/language-translator/src/main/java/com/ibm/watson/developer_cloud/language_translator/v2/model/TranslateOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 IBM Corp. All Rights Reserved.
+ * Copyright 2018 IBM Corp. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/language-translator/src/main/java/com/ibm/watson/developer_cloud/language_translator/v2/model/Translation.java
+++ b/language-translator/src/main/java/com/ibm/watson/developer_cloud/language_translator/v2/model/Translation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 IBM Corp. All Rights Reserved.
+ * Copyright 2018 IBM Corp. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/language-translator/src/main/java/com/ibm/watson/developer_cloud/language_translator/v2/model/TranslationModel.java
+++ b/language-translator/src/main/java/com/ibm/watson/developer_cloud/language_translator/v2/model/TranslationModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 IBM Corp. All Rights Reserved.
+ * Copyright 2018 IBM Corp. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/language-translator/src/main/java/com/ibm/watson/developer_cloud/language_translator/v2/model/TranslationModels.java
+++ b/language-translator/src/main/java/com/ibm/watson/developer_cloud/language_translator/v2/model/TranslationModels.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 IBM Corp. All Rights Reserved.
+ * Copyright 2018 IBM Corp. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/language-translator/src/main/java/com/ibm/watson/developer_cloud/language_translator/v2/model/TranslationResult.java
+++ b/language-translator/src/main/java/com/ibm/watson/developer_cloud/language_translator/v2/model/TranslationResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 IBM Corp. All Rights Reserved.
+ * Copyright 2018 IBM Corp. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/language-translator/src/main/java/com/ibm/watson/developer_cloud/language_translator/v2/package-info.java
+++ b/language-translator/src/main/java/com/ibm/watson/developer_cloud/language_translator/v2/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 IBM Corp. All Rights Reserved.
+ * Copyright 2018 IBM Corp. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/language-translator/src/test/java/com/ibm/watson/developer_cloud/language_translator/v2/LanguageTranslatorIT.java
+++ b/language-translator/src/test/java/com/ibm/watson/developer_cloud/language_translator/v2/LanguageTranslatorIT.java
@@ -61,7 +61,6 @@ public class LanguageTranslatorIT extends WatsonServiceTest {
 
   /*
    * (non-Javadoc)
-   *
    * @see com.ibm.watson.developercloud.WatsonServiceTest#setUp()
    */
   @Override
@@ -85,8 +84,8 @@ public class LanguageTranslatorIT extends WatsonServiceTest {
    */
   @Test
   public void testReadme() throws InterruptedException, IOException {
-//    LanguageTranslator service = new LanguageTranslator();
-//    service.setUsernameAndPassword("<username>", "<password>");
+    //    LanguageTranslator service = new LanguageTranslator();
+    //    service.setUsernameAndPassword("<username>", "<password>");
 
     TranslateOptions translateOptions = new TranslateOptions.Builder()
         .addText("hello").source(Language.ENGLISH).target(Language.SPANISH).build();

--- a/language-translator/src/test/java/com/ibm/watson/developer_cloud/language_translator/v2/LanguageTranslatorTest.java
+++ b/language-translator/src/test/java/com/ibm/watson/developer_cloud/language_translator/v2/LanguageTranslatorTest.java
@@ -63,8 +63,8 @@ public class LanguageTranslatorTest extends WatsonServiceUnitTest {
   private static final String IDENTITY_PATH = "/v2/identify";
   private static final String LANGUAGE_TRANSLATION_PATH = "/v2/translate";
   private static final String RESOURCE = "src/test/resources/language_translation/";
-  private static final Type TYPE_IDENTIFIED_LANGUAGES =
-      new TypeToken<Map<String, List<IdentifiableLanguage>>>() { }.getType();
+  private static final Type TYPE_IDENTIFIED_LANGUAGES = new TypeToken<Map<String, List<IdentifiableLanguage>>>() {
+  }.getType();
   private static final Gson GSON = GsonSingleton.getGsonWithoutPrettyPrinting();
   private final String modelId = "foo-bar";
   private LanguageTranslator service;
@@ -79,7 +79,6 @@ public class LanguageTranslatorTest extends WatsonServiceUnitTest {
 
   /*
    * (non-Javadoc)
-   *
    * @see com.ibm.watson.developercloud.WatsonServiceTest#setUp()
    */
   @Override
@@ -237,8 +236,8 @@ public class LanguageTranslatorTest extends WatsonServiceUnitTest {
     final Translation t = new Translation();
     t.setTranslation(text);
 
-    final Map<String, ?> response =
-        ImmutableMap.of("word_count", 6, "character_count", 20, "translations", Collections.singletonList(t));
+    final Map<String, ?> response = ImmutableMap.of("word_count", 6, "character_count", 20, "translations", Collections
+        .singletonList(t));
 
     final Map<String, ?> requestBody = ImmutableMap.of("text", Collections.singleton(text), "model_id", modelId);
 
@@ -265,8 +264,8 @@ public class LanguageTranslatorTest extends WatsonServiceUnitTest {
     final Translation t2 = new Translation();
     t2.setTranslation(translations.get(texts.get(1)));
 
-    final Map<String, ?> response =
-        ImmutableMap.of("word_count", 6, "character_count", 20, "translations", Arrays.asList(t1, t2));
+    final Map<String, ?> response = ImmutableMap.of("word_count", 6, "character_count", 20, "translations", Arrays
+        .asList(t1, t2));
 
     final Map<String, ?> requestBody = ImmutableMap.of("text", texts, "model_id", modelId);
 
@@ -299,7 +298,6 @@ public class LanguageTranslatorTest extends WatsonServiceUnitTest {
         .build();
     service.translate(translateOptions).execute();
   }
-
 
   /**
    * Test translate with null.


### PR DESCRIPTION
This PR adds new newest generated code for Language Translator as of 2/8/18 for the purpose of the Java SDK 5.0.0 release.