### PR TITLE
Update references to old static version strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Override the `configureHttpClient()` method and add the proxy using the `OkHttpC
 For example:
 
 ```java
-Conversation service = new Conversation(Conversation.VERSION_DATE_2017_05_26) {
+Conversation service = new Conversation("2018-02-16") {
   @Override
   protected OkHttpClient configureHttpClient() {
     Proxy proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress("proxyHost", 8080));
@@ -165,7 +165,7 @@ When running in IBM Cloud (or other platforms based on Cloud Foundry), the libra
 If you have more than one plan, you can use `CredentialUtils` to get the service credentials for an specific plan.
 
 ```java
-PersonalityInsights service = new PersonalityInsights();
+PersonalityInsights service = new PersonalityInsights("2016-10-19");
 String apiKey = CredentialUtils.getAPIKey(service.getName(), CredentialUtils.PLAN_STANDARD);
 service.setApiKey(apiKey);
 ```
@@ -177,7 +177,7 @@ Default headers can be specified at any time by using the `setDefaultHeaders(Map
 The example below sends the `X-Watson-Learning-Opt-Out` header in every request preventing Watson from using the payload to improve the service.
 
 ```java
-PersonalityInsights service = new PersonalityInsights();
+PersonalityInsights service = new PersonalityInsights("2016-10-19");
 
 Map<String, String> headers = new HashMap<String, String>();
 headers.put(HttpHeaders.X_WATSON_LEARNING_OPT_OUT, 1);
@@ -196,7 +196,7 @@ For example, if you have the conversation service in Germany, the Endpoint may b
 You will need to call
 
 ```java
-Conversation service = new Conversation("<version-date>");
+Conversation service = new Conversation("2018-02-16");
 service.sentEndPoint("https://gateway-fra.watsonplatform.net/conversation/api")
 ```
 

--- a/conversation/README.md
+++ b/conversation/README.md
@@ -21,7 +21,7 @@
 Use the [Conversation][conversation] service to identify intents, entities, and conduct conversations.
 
 ```java
-Conversation service = new Conversation(Conversation.VERSION_DATE_2017_05_26);
+Conversation service = new Conversation("2018-02-16");
 service.setUsernameAndPassword("<username>", "<password>");
 
 InputData input = new InputData.Builder("Hi").build();

--- a/discovery/README.md
+++ b/discovery/README.md
@@ -20,7 +20,7 @@
 The [Discovery][discovery] wraps the environment, collection, configuration, document, and query operations of the Discovery service.
 
 ```java
-Discovery discovery = new Discovery("2017-09-01");
+Discovery discovery = new Discovery("2017-11-07");
 discovery.setEndPoint("https://gateway.watsonplatform.net/discovery/api/");
 discovery.setUsernameAndPassword("<username>", "<password>");
 

--- a/natural-language-understanding/README.md
+++ b/natural-language-understanding/README.md
@@ -24,7 +24,7 @@ analysis by default, so the results can ignore most advertisements and other unw
 
 ```java
 NaturalLanguageUnderstanding service = new NaturalLanguageUnderstanding(
-  NaturalLanguageUnderstanding.VERSION_DATE_2017_02_27,
+  "2017-02-27",
   "username",
   "password"
 );

--- a/tone-analyzer/README.md
+++ b/tone-analyzer/README.md
@@ -20,7 +20,7 @@
 Use the [Tone Analyzer][tone_analyzer] service to get the tone of your email.
 
 ```java
-final String VERSION_DATE = "2016-05-19";
+final String VERSION_DATE = "2017-09-21";
 ToneAnalyzer service = new ToneAnalyzer(VERSION_DATE);
 service.setUsernameAndPassword("<username>", "<password>");
 

--- a/visual-recognition/README.md
+++ b/visual-recognition/README.md
@@ -23,7 +23,7 @@ following picture.
 ![Car](https://visual-recognition-demo.ng.bluemix.net/images/samples/5.jpg)
 
 ```java
-VisualRecognition service = new VisualRecognition(VisualRecognition.VERSION_DATE_2016_05_20);
+VisualRecognition service = new VisualRecognition("2016-05-20");
 service.setApiKey("<api-key>");
 
 System.out.println("Classify an image");


### PR DESCRIPTION
This PR removes references to the old static version date strings in documentation, since these have been removed in favor of explicitly specifying the desired version date in the latest release.