### PR TITLE
Fix broken parameter passing when calling recognizeUsingWebSocket

### DIFF
--- a/speech-to-text/src/main/java/com/ibm/watson/developer_cloud/speech_to_text/v1/websocket/SpeechToTextWebSocketListener.java
+++ b/speech-to-text/src/main/java/com/ibm/watson/developer_cloud/speech_to_text/v1/websocket/SpeechToTextWebSocketListener.java
@@ -12,7 +12,9 @@
  */
 package com.ibm.watson.developer_cloud.speech_to_text.v1.websocket;
 
+import com.google.gson.FieldNamingPolicy;
 import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.ibm.watson.developer_cloud.speech_to_text.v1.SpeechToText;
@@ -210,7 +212,10 @@ public final class SpeechToTextWebSocketListener extends WebSocketListener {
    * @return the request
    */
   private String buildStartMessage(RecognizeOptions options) {
-    JsonObject startMessage = new JsonParser().parse(new Gson().toJson(options)).getAsJsonObject();
+    Gson gson = new GsonBuilder()
+        .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
+        .create();
+    JsonObject startMessage = new JsonParser().parse(gson.toJson(options)).getAsJsonObject();
     startMessage.remove(MODEL);
     startMessage.remove(CUSTOMIZATION_ID);
     startMessage.remove(ACOUSTIC_CUSTOMIZATION_ID);

--- a/speech-to-text/src/test/java/com/ibm/watson/developer_cloud/speech_to_text/v1/SpeechToTextIT.java
+++ b/speech-to-text/src/test/java/com/ibm/watson/developer_cloud/speech_to_text/v1/SpeechToTextIT.java
@@ -274,7 +274,6 @@ public class SpeechToTextIT extends WatsonServiceTest {
         .wordAlternativesThreshold(0.5f)
         .model(EN_BROADBAND16K)
         .contentType(HttpMediaType.AUDIO_WAV)
-        .inactivityTimeout(120)
         .build();
 
     service.recognizeUsingWebSocket(options, new BaseRecognizeCallback() {

--- a/speech-to-text/src/test/java/com/ibm/watson/developer_cloud/speech_to_text/v1/SpeechToTextTest.java
+++ b/speech-to-text/src/test/java/com/ibm/watson/developer_cloud/speech_to_text/v1/SpeechToTextTest.java
@@ -1349,8 +1349,8 @@ public class SpeechToTextTest extends WatsonServiceUnitTest {
     outputStream.write(ByteString.encodeUtf8("test").toByteArray());
     outputStream.close();
 
-    webSocketRecorder.assertTextMessage("{\"customizationId\":\"id\","
-        + "\"customizationWeight\":0.1,\"content-type\":\"audio/l16; rate=44000\"," + "\"action\":\"start\"}");
+    webSocketRecorder.assertTextMessage("{\"content-type\":\"audio/l16; rate=44000\","
+        + "\"action\":\"start\"}");
     webSocketRecorder.assertBinaryMessage(ByteString.encodeUtf8("test"));
     webSocketRecorder.assertTextMessage("{\"action\":\"stop\"}");
     webSocketRecorder.assertExhausted();


### PR DESCRIPTION
Currently, when setting the JSON body for a `recognizeUsingWebSocket()` call, the JSON keys are left as camelCase, so some parameters are being unrecognized by the service (ex: `interimResults`).

This PR ensures that the JSON body is properly formatted.