### PR TITLE
fix(assistant): Add missing dependency line for Assistant

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -3,6 +3,8 @@ current_version = 5.1.0
 
 [bumpversion:file:README.md]
 
+[bumpversion:file:assistant/README.md]
+
 [bumpversion:file:conversation/README.md]
 
 [bumpversion:file:discovery/README.md]

--- a/java-sdk/build.gradle
+++ b/java-sdk/build.gradle
@@ -80,6 +80,7 @@ artifacts {
 }
 
 dependencies {
+    compile project(':assistant')
     compile project(':conversation')
     compile project(':core')
     compile project(':discovery')


### PR DESCRIPTION
This PR adds the Assistant service as a Gradle dependency so that it's packaged in the JAR. This was accidentally left out in the last release.