### PR TITLE
Add IAM support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,10 @@ Java client library to use the [Watson APIs][wdc].
     * [Gradle](#gradle)
   * [Usage](#usage)
   * [Running in IBM Cloud](#running-in-ibm-cloud)
-  * [Getting the Service Credentials](#getting-the-service-credentials)
+  * [Authentication](#authentication)
+    * [Username and Password](#username-and-password)
+    * [API Key](#api-key)
+    * [Using IAM](#using-iam)
   * IBM Watson Services
     * [Assistant](assistant)
     * [Discovery](discovery)
@@ -123,17 +126,91 @@ credentials; the library will get them for you by looking at the [`VCAP_SERVICES
 When running in IBM Cloud (or other platforms based on Cloud Foundry), the library will automatically get the credentials from [`VCAP_SERVICES`][vcap_services].
 If you have more than one plan, you can use `CredentialUtils` to get the service credentials for an specific plan.
 
-## Getting the Service Credentials
+## Authentication
 
-You will need the `username` and `password` (`api_key` for Visual Recognition) credentials, and the API endpoint for each service. Service credentials are different from your IBM Cloud account username and password.
+There are three ways to authenticate with IBM Cloud through the SDK: using a `username` and `password`, using an `api_key`, and with IAM.
 
-To get your service credentials, follow these steps:
+Getting the credentials necessary for authentication is the same process for all methods. To get them, follow these steps:
 
 1. Log in to [IBM Cloud](https://console.bluemix.net/catalog?category=watson)
 1. In the IBM Cloud **Catalog**, select the service you want to use.
 1. Click **Create**.
 1. On the left side of the page, click **Service Credentials**, and then **View credentials** to view your service credentials.
-1. Copy `url`, `username` and `password`(`api_key` for AlchemyAPI or Visual Recognition).
+1. Copy the necessary credentials (`url`, `username`, `password`, `api_key`, `apikey`, etc.).
+
+In your code, you can use these values in the service constructor or with a method call after instantiating your service. Here are some examples:
+
+### Username and Password
+
+```java
+// in the constructor
+Discovery service = new Discovery("2017-11-07", "<username>", "<password>");
+```
+
+```java
+// after instantiation
+Discovery service = new Discovery("2017-11-07");
+service.setUsernameAndPassword("<username>", "<password>");
+```
+
+### API Key
+
+_Note: This version of instantiation only works with Visual Recognition, as it's the only service that uses an API key rather than a username and password._
+
+```java
+// in the constructor
+VisualRecognition service = new VisualRecognition("2016-05-20", "<api_key>");
+```
+
+```java
+// after instantiation
+VisualRecognition service = new VisualRecognition("2016-05-20");
+service.setApiKey("<api_key>");
+```
+
+### Using IAM
+
+When authenticating with IAM, you have the option of passing in the IAM API key, the IAM URL, and an IAM access token. **Be aware that passing in an access token means that you're assuming responsibility for maintaining that token's lifecycle.** If you instead pass in an IAM API key, the SDK will manage it for you.
+
+```java
+// in the constructor, letting the SDK manage the IAM token
+IamOptions options = new IamOptions.Builder()
+  .apiKey("<iam_api_key>")
+  .url("<iam_url>")
+  .build();
+Discovery service = new Discovery("2017-11-07", options);
+```
+
+```java
+// after instantiation, letting the SDK manage the IAM token
+Discovery service = new Discovery("2017-11-07");
+IamOptions options = new IamOptions.Builder()
+  .apiKey("<iam_api_key>")
+  .url("<iam_url>")
+  .build();
+service.setIamCredentials(options);
+```
+
+```java
+// in the constructor, taking control of managing IAM token
+IamOptions options = new IamOptions.Builder()
+  .accessToken("<access_token>")
+  .url("<iam_url>")
+  .build();
+Discovery service = new Discovery("2017-11-07", options);
+```
+
+```java
+// after instantiation, taking control of managing IAM token
+Discovery service = new Discovery("2017-11-07");
+IamOptions options = new IamOptions.Builder()
+  .accessToken("<access_token>")
+  .url("<iam_url>")
+  .build();
+service.setIamCredentials(options);
+```
+
+If at any time you would like to let the SDK take over managing your IAM token, simply override your stored IAM credentials with an IAM API key by calling the `setIamCredentials()` method again.
 
 ## Android
 

--- a/README.md
+++ b/README.md
@@ -170,13 +170,17 @@ service.setApiKey("<api_key>");
 
 ### Using IAM
 
-When authenticating with IAM, you have the option of passing in the IAM API key, the IAM URL, and an IAM access token. **Be aware that passing in an access token means that you're assuming responsibility for maintaining that token's lifecycle.** If you instead pass in an IAM API key, the SDK will manage it for you.
+When authenticating with IAM, you have the option of passing in:
+- the IAM API key and, optionally, the IAM service URL
+- an IAM access token
+
+**Be aware that passing in an access token means that you're assuming responsibility for maintaining that token's lifecycle.** If you instead pass in an IAM API key, the SDK will manage it for you.
 
 ```java
 // in the constructor, letting the SDK manage the IAM token
 IamOptions options = new IamOptions.Builder()
   .apiKey("<iam_api_key>")
-  .url("<iam_url>")
+  .url("<iam_url>") // optional - the default value is https://iam.ng.bluemix.net/identity/token
   .build();
 Discovery service = new Discovery("2017-11-07", options);
 ```
@@ -186,26 +190,23 @@ Discovery service = new Discovery("2017-11-07", options);
 Discovery service = new Discovery("2017-11-07");
 IamOptions options = new IamOptions.Builder()
   .apiKey("<iam_api_key>")
-  .url("<iam_url>")
   .build();
 service.setIamCredentials(options);
 ```
 
 ```java
-// in the constructor, taking control of managing IAM token
+// in the constructor, assuming control of managing IAM token
 IamOptions options = new IamOptions.Builder()
   .accessToken("<access_token>")
-  .url("<iam_url>")
   .build();
 Discovery service = new Discovery("2017-11-07", options);
 ```
 
 ```java
-// after instantiation, taking control of managing IAM token
+// after instantiation, assuming control of managing IAM token
 Discovery service = new Discovery("2017-11-07");
 IamOptions options = new IamOptions.Builder()
   .accessToken("<access_token>")
-  .url("<iam_url>")
   .build();
 service.setIamCredentials(options);
 ```

--- a/assistant/src/main/java/com/ibm/watson/developer_cloud/assistant/v1/Assistant.java
+++ b/assistant/src/main/java/com/ibm/watson/developer_cloud/assistant/v1/Assistant.java
@@ -81,7 +81,7 @@ import com.ibm.watson.developer_cloud.assistant.v1.model.WorkspaceExport;
 import com.ibm.watson.developer_cloud.http.RequestBuilder;
 import com.ibm.watson.developer_cloud.http.ServiceCall;
 import com.ibm.watson.developer_cloud.service.WatsonService;
-import com.ibm.watson.developer_cloud.service.security.CredentialOptions;
+import com.ibm.watson.developer_cloud.service.security.IamOptions;
 import com.ibm.watson.developer_cloud.util.GsonSingleton;
 import com.ibm.watson.developer_cloud.util.ResponseConverterUtils;
 import com.ibm.watson.developer_cloud.util.Validator;
@@ -130,9 +130,9 @@ public class Assistant extends WatsonService {
     setUsernameAndPassword(username, password);
   }
 
-  public Assistant(String versionDate, CredentialOptions credentialOptions) {
+  public Assistant(String versionDate, IamOptions iamOptions) {
     this(versionDate);
-    setCredentials(credentialOptions);
+    setIamCredentials(iamOptions);
   }
 
   /**

--- a/assistant/src/main/java/com/ibm/watson/developer_cloud/assistant/v1/Assistant.java
+++ b/assistant/src/main/java/com/ibm/watson/developer_cloud/assistant/v1/Assistant.java
@@ -81,6 +81,7 @@ import com.ibm.watson.developer_cloud.assistant.v1.model.WorkspaceExport;
 import com.ibm.watson.developer_cloud.http.RequestBuilder;
 import com.ibm.watson.developer_cloud.http.ServiceCall;
 import com.ibm.watson.developer_cloud.service.WatsonService;
+import com.ibm.watson.developer_cloud.service.security.IamOptions;
 import com.ibm.watson.developer_cloud.util.GsonSingleton;
 import com.ibm.watson.developer_cloud.util.ResponseConverterUtils;
 import com.ibm.watson.developer_cloud.util.Validator;
@@ -127,6 +128,20 @@ public class Assistant extends WatsonService {
   public Assistant(String versionDate, String username, String password) {
     this(versionDate);
     setUsernameAndPassword(username, password);
+  }
+
+  /**
+   * Instantiates a new `Assistant` with IAM. Note that if the access token is specified in the iamOptions,
+   * you accept responsibility for managing the access token yourself. You must set a new access token before this one
+   * expires. Failing to do so will result in authentication errors after this token expires.
+   *
+   * @param versionDate The version date (yyyy-MM-dd) of the REST API to use. Specifying this value will keep your API
+   *          calls from failing when the service introduces breaking changes.
+   * @param iamOptions the options for authenticating through IAM
+   */
+  public Assistant(String versionDate, IamOptions iamOptions) {
+    this(versionDate);
+    setIamCredentials(iamOptions);
   }
 
   /**

--- a/assistant/src/main/java/com/ibm/watson/developer_cloud/assistant/v1/Assistant.java
+++ b/assistant/src/main/java/com/ibm/watson/developer_cloud/assistant/v1/Assistant.java
@@ -130,6 +130,15 @@ public class Assistant extends WatsonService {
     setUsernameAndPassword(username, password);
   }
 
+  /**
+   * Instantiates a new `Assistant` with IAM. Note that if the access token is specified in the iamOptions, you accept
+   * responsibility for managing the access token yourself. You must set a new access token before this one expires.
+   * Failing to do so will result in authentication errors after this token expires.
+   *
+   * @param versionDate The version date (yyyy-MM-dd) of the REST API to use. Specifying this value will keep your API
+   *          calls from failing when the service introduces breaking changes.
+   * @param iamOptions the options for authenticating through IAM
+   */
   public Assistant(String versionDate, IamOptions iamOptions) {
     this(versionDate);
     setIamCredentials(iamOptions);

--- a/assistant/src/main/java/com/ibm/watson/developer_cloud/assistant/v1/Assistant.java
+++ b/assistant/src/main/java/com/ibm/watson/developer_cloud/assistant/v1/Assistant.java
@@ -81,6 +81,7 @@ import com.ibm.watson.developer_cloud.assistant.v1.model.WorkspaceExport;
 import com.ibm.watson.developer_cloud.http.RequestBuilder;
 import com.ibm.watson.developer_cloud.http.ServiceCall;
 import com.ibm.watson.developer_cloud.service.WatsonService;
+import com.ibm.watson.developer_cloud.service.security.CredentialOptions;
 import com.ibm.watson.developer_cloud.util.GsonSingleton;
 import com.ibm.watson.developer_cloud.util.ResponseConverterUtils;
 import com.ibm.watson.developer_cloud.util.Validator;
@@ -127,6 +128,11 @@ public class Assistant extends WatsonService {
   public Assistant(String versionDate, String username, String password) {
     this(versionDate);
     setUsernameAndPassword(username, password);
+  }
+
+  public Assistant(String versionDate, CredentialOptions credentialOptions) {
+    this(versionDate);
+    setCredentials(credentialOptions);
   }
 
   /**

--- a/assistant/src/main/java/com/ibm/watson/developer_cloud/assistant/v1/Assistant.java
+++ b/assistant/src/main/java/com/ibm/watson/developer_cloud/assistant/v1/Assistant.java
@@ -81,7 +81,6 @@ import com.ibm.watson.developer_cloud.assistant.v1.model.WorkspaceExport;
 import com.ibm.watson.developer_cloud.http.RequestBuilder;
 import com.ibm.watson.developer_cloud.http.ServiceCall;
 import com.ibm.watson.developer_cloud.service.WatsonService;
-import com.ibm.watson.developer_cloud.service.security.IamOptions;
 import com.ibm.watson.developer_cloud.util.GsonSingleton;
 import com.ibm.watson.developer_cloud.util.ResponseConverterUtils;
 import com.ibm.watson.developer_cloud.util.Validator;
@@ -128,20 +127,6 @@ public class Assistant extends WatsonService {
   public Assistant(String versionDate, String username, String password) {
     this(versionDate);
     setUsernameAndPassword(username, password);
-  }
-
-  /**
-   * Instantiates a new `Assistant` with IAM. Note that if the access token is specified in the iamOptions, you accept
-   * responsibility for managing the access token yourself. You must set a new access token before this one expires.
-   * Failing to do so will result in authentication errors after this token expires.
-   *
-   * @param versionDate The version date (yyyy-MM-dd) of the REST API to use. Specifying this value will keep your API
-   *          calls from failing when the service introduces breaking changes.
-   * @param iamOptions the options for authenticating through IAM
-   */
-  public Assistant(String versionDate, IamOptions iamOptions) {
-    this(versionDate);
-    setIamCredentials(iamOptions);
   }
 
   /**

--- a/assistant/src/test/java/com/ibm/watson/developer_cloud/assistant/v1/AssistantServiceTest.java
+++ b/assistant/src/test/java/com/ibm/watson/developer_cloud/assistant/v1/AssistantServiceTest.java
@@ -13,7 +13,7 @@
 package com.ibm.watson.developer_cloud.assistant.v1;
 
 import com.ibm.watson.developer_cloud.WatsonServiceTest;
-import com.ibm.watson.developer_cloud.service.security.CredentialOptions;
+import com.ibm.watson.developer_cloud.service.security.IamOptions;
 import org.junit.Assume;
 import org.junit.Before;
 
@@ -39,7 +39,7 @@ public class AssistantServiceTest extends WatsonServiceTest {
     Assume.assumeFalse("config.properties doesn't have valid credentials.",
         (username == null) || username.equals(PLACEHOLDER));
 
-    CredentialOptions options = new CredentialOptions.Builder()
+    IamOptions options = new IamOptions.Builder()
         .iamApiKey("cY2HWLnw-BFIyaw65ZgTtqciDE9oijwt4FL8vyz0zWgP")
         .build();
     service = new Assistant("2018-02-16", options);

--- a/assistant/src/test/java/com/ibm/watson/developer_cloud/assistant/v1/AssistantServiceTest.java
+++ b/assistant/src/test/java/com/ibm/watson/developer_cloud/assistant/v1/AssistantServiceTest.java
@@ -40,7 +40,7 @@ public class AssistantServiceTest extends WatsonServiceTest {
         (username == null) || username.equals(PLACEHOLDER));
 
     IamOptions options = new IamOptions.Builder()
-        .iamApiKey("cY2HWLnw-BFIyaw65ZgTtqciDE9oijwt4FL8vyz0zWgP")
+        .apiKey("cY2HWLnw-BFIyaw65ZgTtqciDE9oijwt4FL8vyz0zWgP")
         .build();
     service = new Assistant("2018-02-16", options);
     service.setEndPoint(getProperty("conversation.v1.url"));

--- a/assistant/src/test/java/com/ibm/watson/developer_cloud/assistant/v1/AssistantServiceTest.java
+++ b/assistant/src/test/java/com/ibm/watson/developer_cloud/assistant/v1/AssistantServiceTest.java
@@ -13,6 +13,7 @@
 package com.ibm.watson.developer_cloud.assistant.v1;
 
 import com.ibm.watson.developer_cloud.WatsonServiceTest;
+import com.ibm.watson.developer_cloud.service.security.CredentialOptions;
 import org.junit.Assume;
 import org.junit.Before;
 
@@ -38,9 +39,12 @@ public class AssistantServiceTest extends WatsonServiceTest {
     Assume.assumeFalse("config.properties doesn't have valid credentials.",
         (username == null) || username.equals(PLACEHOLDER));
 
-    service = new Assistant("2018-02-16");
+    CredentialOptions options = new CredentialOptions.Builder()
+        .iamApiKey("cY2HWLnw-BFIyaw65ZgTtqciDE9oijwt4FL8vyz0zWgP")
+        .build();
+    service = new Assistant("2018-02-16", options);
     service.setEndPoint(getProperty("conversation.v1.url"));
-    service.setUsernameAndPassword(username, password);
+    //service.setUsernameAndPassword(username, password);
     service.setDefaultHeaders(getDefaultHeaders());
   }
 

--- a/assistant/src/test/java/com/ibm/watson/developer_cloud/assistant/v1/AssistantServiceTest.java
+++ b/assistant/src/test/java/com/ibm/watson/developer_cloud/assistant/v1/AssistantServiceTest.java
@@ -13,7 +13,6 @@
 package com.ibm.watson.developer_cloud.assistant.v1;
 
 import com.ibm.watson.developer_cloud.WatsonServiceTest;
-import com.ibm.watson.developer_cloud.service.security.IamOptions;
 import org.junit.Assume;
 import org.junit.Before;
 
@@ -39,12 +38,9 @@ public class AssistantServiceTest extends WatsonServiceTest {
     Assume.assumeFalse("config.properties doesn't have valid credentials.",
         (username == null) || username.equals(PLACEHOLDER));
 
-    IamOptions options = new IamOptions.Builder()
-        .apiKey("cY2HWLnw-BFIyaw65ZgTtqciDE9oijwt4FL8vyz0zWgP")
-        .build();
-    service = new Assistant("2018-02-16", options);
+    service = new Assistant("2018-02-16");
     service.setEndPoint(getProperty("conversation.v1.url"));
-    //service.setUsernameAndPassword(username, password);
+    service.setUsernameAndPassword(username, password);
     service.setDefaultHeaders(getDefaultHeaders());
   }
 

--- a/conversation/src/main/java/com/ibm/watson/developer_cloud/conversation/v1/Conversation.java
+++ b/conversation/src/main/java/com/ibm/watson/developer_cloud/conversation/v1/Conversation.java
@@ -81,6 +81,7 @@ import com.ibm.watson.developer_cloud.conversation.v1.model.WorkspaceExport;
 import com.ibm.watson.developer_cloud.http.RequestBuilder;
 import com.ibm.watson.developer_cloud.http.ServiceCall;
 import com.ibm.watson.developer_cloud.service.WatsonService;
+import com.ibm.watson.developer_cloud.service.security.IamOptions;
 import com.ibm.watson.developer_cloud.util.GsonSingleton;
 import com.ibm.watson.developer_cloud.util.ResponseConverterUtils;
 import com.ibm.watson.developer_cloud.util.Validator;
@@ -127,6 +128,20 @@ public class Conversation extends WatsonService {
   public Conversation(String versionDate, String username, String password) {
     this(versionDate);
     setUsernameAndPassword(username, password);
+  }
+
+  /**
+   * Instantiates a new `Conversation` with IAM. Note that if the access token is specified in the iamOptions,
+   * you accept responsibility for managing the access token yourself. You must set a new access token before this one
+   * expires. Failing to do so will result in authentication errors after this token expires.
+   *
+   * @param versionDate The version date (yyyy-MM-dd) of the REST API to use. Specifying this value will keep your API
+   *          calls from failing when the service introduces breaking changes.
+   * @param iamOptions the options for authenticating through IAM
+   */
+  public Conversation(String versionDate, IamOptions iamOptions) {
+    this(versionDate);
+    setIamCredentials(iamOptions);
   }
 
   /**

--- a/conversation/src/main/java/com/ibm/watson/developer_cloud/conversation/v1/Conversation.java
+++ b/conversation/src/main/java/com/ibm/watson/developer_cloud/conversation/v1/Conversation.java
@@ -145,6 +145,45 @@ public class Conversation extends WatsonService {
   }
 
   /**
+   * Get a response to a user's input. There is no rate limit for this operation.
+   *
+   * @param messageOptions the {@link MessageOptions} containing the options for the call
+   * @return a {@link ServiceCall} with a response type of {@link MessageResponse}
+   */
+  public ServiceCall<MessageResponse> message(MessageOptions messageOptions) {
+    Validator.notNull(messageOptions, "messageOptions cannot be null");
+    String[] pathSegments = { "v1/workspaces", "message" };
+    String[] pathParameters = { messageOptions.workspaceId() };
+    RequestBuilder builder = RequestBuilder.post(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
+        pathParameters));
+    builder.query(VERSION, versionDate);
+    if (messageOptions.nodesVisitedDetails() != null) {
+      builder.query("nodes_visited_details", String.valueOf(messageOptions.nodesVisitedDetails()));
+    }
+    final JsonObject contentJson = new JsonObject();
+    if (messageOptions.input() != null) {
+      contentJson.add("input", GsonSingleton.getGson().toJsonTree(messageOptions.input()));
+    }
+    if (messageOptions.alternateIntents() != null) {
+      contentJson.addProperty("alternate_intents", messageOptions.alternateIntents());
+    }
+    if (messageOptions.context() != null) {
+      contentJson.add("context", GsonSingleton.getGson().toJsonTree(messageOptions.context()));
+    }
+    if (messageOptions.entities() != null) {
+      contentJson.add("entities", GsonSingleton.getGson().toJsonTree(messageOptions.entities()));
+    }
+    if (messageOptions.intents() != null) {
+      contentJson.add("intents", GsonSingleton.getGson().toJsonTree(messageOptions.intents()));
+    }
+    if (messageOptions.output() != null) {
+      contentJson.add("output", GsonSingleton.getGson().toJsonTree(messageOptions.output()));
+    }
+    builder.bodyJson(contentJson);
+    return createServiceCall(builder.build(), ResponseConverterUtils.getObject(MessageResponse.class));
+  }
+
+  /**
    * Create workspace.
    *
    * Create a workspace based on component objects. You must provide workspace components defining the content of the

--- a/core/src/main/java/com/ibm/watson/developer_cloud/service/WatsonService.java
+++ b/core/src/main/java/com/ibm/watson/developer_cloud/service/WatsonService.java
@@ -68,6 +68,7 @@ public abstract class WatsonService {
   private static final String MESSAGE_ERROR_3 = "message";
   private static final String MESSAGE_ERROR_2 = "error_message";
   private static final String BASIC = "Basic ";
+  private static final String BEARER = "Bearer ";
   private static final Logger LOG = Logger.getLogger(WatsonService.class.getName());
   private String apiKey;
   private String username;
@@ -294,7 +295,7 @@ public abstract class WatsonService {
   protected void setAuthentication(final Builder builder) {
     if (tokenManager != null) {
       String accessToken = tokenManager.getToken();
-      builder.addHeader(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken);
+      builder.addHeader(HttpHeaders.AUTHORIZATION, BEARER + accessToken);
     } else if (getApiKey() == null) {
       if (skipAuthentication) {
         return; // chosen to skip authentication with the service

--- a/core/src/main/java/com/ibm/watson/developer_cloud/service/WatsonService.java
+++ b/core/src/main/java/com/ibm/watson/developer_cloud/service/WatsonService.java
@@ -100,6 +100,10 @@ public abstract class WatsonService {
    */
   public WatsonService(final String name) {
     this.name = name;
+    String iamApiKey = CredentialUtils.getIamAPIKey(name);
+    if (iamApiKey != null) {
+      tokenManager = new IamTokenManager(new IamOptions.Builder().apiKey(iamApiKey).build());
+    }
     apiKey = CredentialUtils.getAPIKey(name);
     String url = CredentialUtils.getAPIUrl(name);
     if ((url != null) && !url.isEmpty()) {

--- a/core/src/main/java/com/ibm/watson/developer_cloud/service/WatsonService.java
+++ b/core/src/main/java/com/ibm/watson/developer_cloud/service/WatsonService.java
@@ -335,9 +335,13 @@ public abstract class WatsonService {
   /**
    * Sets IAM information.
    *
+   * Be aware that if you pass in an access token using this method, you accept responsibility for managing the access
+   * token yourself. You must set a new access token before this one expires. Failing to do so will result in
+   * authentication errors after this token expires.
+   *
    * @param iamOptions object containing values to be used for authenticating with IAM
    */
-  protected void setIamCredentials(IamOptions iamOptions) {
+  public void setIamCredentials(IamOptions iamOptions) {
     this.tokenManager = new IamTokenManager(iamOptions);
   }
 

--- a/core/src/main/java/com/ibm/watson/developer_cloud/service/WatsonService.java
+++ b/core/src/main/java/com/ibm/watson/developer_cloud/service/WatsonService.java
@@ -33,7 +33,7 @@ import com.ibm.watson.developer_cloud.service.exception.ServiceUnavailableExcept
 import com.ibm.watson.developer_cloud.service.exception.TooManyRequestsException;
 import com.ibm.watson.developer_cloud.service.exception.UnauthorizedException;
 import com.ibm.watson.developer_cloud.service.exception.UnsupportedException;
-import com.ibm.watson.developer_cloud.service.security.CredentialOptions;
+import com.ibm.watson.developer_cloud.service.security.IamOptions;
 import com.ibm.watson.developer_cloud.service.security.IamTokenManager;
 import com.ibm.watson.developer_cloud.util.CredentialUtils;
 import com.ibm.watson.developer_cloud.util.RequestUtils;
@@ -332,25 +332,8 @@ public abstract class WatsonService {
     }
   }
 
-  protected void setCredentials(CredentialOptions credentialOptions) {
-
-    // setting username and password
-    if (credentialOptions.getUsername() != null && credentialOptions.getPassword() != null) {
-      setUsernameAndPassword(credentialOptions.getUsername(), credentialOptions.getPassword());
-
-    // setting API key
-    } else if (credentialOptions.getApiKey() != null) {
-      setApiKey(credentialOptions.getApiKey());
-
-    // setting IAM token
-    } else if (credentialOptions.getAccessToken() != null || credentialOptions.getIamApiKey() != null) {
-      this.tokenManager = new IamTokenManager(
-          credentialOptions.getAccessToken(),
-          credentialOptions.getIamApiKey(),
-          credentialOptions.getRefreshToken(),
-          credentialOptions.getIamUrl()
-      );
-    }
+  protected void setIamCredentials(IamOptions iamOptions) {
+    this.tokenManager = new IamTokenManager(iamOptions);
   }
 
   /*

--- a/core/src/main/java/com/ibm/watson/developer_cloud/service/WatsonService.java
+++ b/core/src/main/java/com/ibm/watson/developer_cloud/service/WatsonService.java
@@ -332,6 +332,11 @@ public abstract class WatsonService {
     }
   }
 
+  /**
+   * Sets IAM information.
+   *
+   * @param iamOptions object containing values to be used for authenticating with IAM
+   */
   protected void setIamCredentials(IamOptions iamOptions) {
     this.tokenManager = new IamTokenManager(iamOptions);
   }

--- a/core/src/main/java/com/ibm/watson/developer_cloud/service/WatsonService.java
+++ b/core/src/main/java/com/ibm/watson/developer_cloud/service/WatsonService.java
@@ -100,7 +100,7 @@ public abstract class WatsonService {
    */
   public WatsonService(final String name) {
     this.name = name;
-    String iamApiKey = CredentialUtils.getIamAPIKey(name);
+    String iamApiKey = CredentialUtils.getIAMKey(name);
     if (iamApiKey != null) {
       tokenManager = new IamTokenManager(new IamOptions.Builder().apiKey(iamApiKey).build());
     }

--- a/core/src/main/java/com/ibm/watson/developer_cloud/service/WatsonService.java
+++ b/core/src/main/java/com/ibm/watson/developer_cloud/service/WatsonService.java
@@ -101,8 +101,13 @@ public abstract class WatsonService {
   public WatsonService(final String name) {
     this.name = name;
     String iamApiKey = CredentialUtils.getIAMKey(name);
-    if (iamApiKey != null) {
-      tokenManager = new IamTokenManager(new IamOptions.Builder().apiKey(iamApiKey).build());
+    String iamUrl = CredentialUtils.getIAMUrl(name);
+    if (iamApiKey != null && iamUrl != null) {
+      IamOptions iamOptions = new IamOptions.Builder()
+          .apiKey(iamApiKey)
+          .url(iamUrl)
+          .build();
+      tokenManager = new IamTokenManager(iamOptions);
     }
     apiKey = CredentialUtils.getAPIKey(name);
     String url = CredentialUtils.getAPIUrl(name);

--- a/core/src/main/java/com/ibm/watson/developer_cloud/service/WatsonService.java
+++ b/core/src/main/java/com/ibm/watson/developer_cloud/service/WatsonService.java
@@ -103,7 +103,7 @@ public abstract class WatsonService {
     this.name = name;
     String iamApiKey = CredentialUtils.getIAMKey(name);
     String iamUrl = CredentialUtils.getIAMUrl(name);
-    if (iamApiKey != null && iamUrl != null) {
+    if (iamApiKey != null) {
       IamOptions iamOptions = new IamOptions.Builder()
           .apiKey(iamApiKey)
           .url(iamUrl)

--- a/core/src/main/java/com/ibm/watson/developer_cloud/service/security/CredentialOptions.java
+++ b/core/src/main/java/com/ibm/watson/developer_cloud/service/security/CredentialOptions.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright 2018 IBM Corp. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
 package com.ibm.watson.developer_cloud.service.security;
 
 public class CredentialOptions {

--- a/core/src/main/java/com/ibm/watson/developer_cloud/service/security/CredentialOptions.java
+++ b/core/src/main/java/com/ibm/watson/developer_cloud/service/security/CredentialOptions.java
@@ -1,0 +1,98 @@
+package com.ibm.watson.developer_cloud.service.security;
+
+public class CredentialOptions {
+  private String username;
+  private String password;
+  private String apiKey;
+  private String iamApiKey;
+  private String accessToken;
+  private String refreshToken;
+  private String iamUrl;
+
+  public String getUsername() {
+    return username;
+  }
+
+  public String getPassword() {
+    return password;
+  }
+
+  public String getApiKey() {
+    return apiKey;
+  }
+
+  public String getIamApiKey() {
+    return iamApiKey;
+  }
+
+  public String getAccessToken() {
+    return accessToken;
+  }
+
+  public String getRefreshToken() {
+    return refreshToken;
+  }
+
+  public String getIamUrl() {
+    return iamUrl;
+  }
+
+  public static class Builder {
+    private String username;
+    private String password;
+    private String apiKey;
+    private String iamApiKey;
+    private String accessToken;
+    private String refreshToken;
+    private String iamUrl;
+
+    public CredentialOptions build() {
+      return new CredentialOptions(this);
+    }
+
+    public Builder username(String username) {
+      this.username = username;
+      return this;
+    }
+
+    public Builder password(String password) {
+      this.password = password;
+      return this;
+    }
+
+    public Builder apiKey(String apiKey) {
+      this.apiKey = apiKey;
+      return this;
+    }
+
+    public Builder iamApiKey(String iamApiKey) {
+      this.iamApiKey = iamApiKey;
+      return this;
+    }
+
+    public Builder accessToken(String accessToken) {
+      this.accessToken = accessToken;
+      return this;
+    }
+
+    public Builder refreshToken(String refreshToken) {
+      this.refreshToken = refreshToken;
+      return this;
+    }
+
+    public Builder iamUrl(String iamUrl) {
+      this.iamUrl = iamUrl;
+      return this;
+    }
+  }
+
+  private CredentialOptions(Builder builder) {
+    this.username = builder.username;
+    this.password = builder.password;
+    this.apiKey = builder.apiKey;
+    this.iamApiKey = builder.iamApiKey;
+    this.accessToken = builder.accessToken;
+    this.refreshToken = builder.refreshToken;
+    this.iamUrl = builder.iamUrl;
+  }
+}

--- a/core/src/main/java/com/ibm/watson/developer_cloud/service/security/IamOptions.java
+++ b/core/src/main/java/com/ibm/watson/developer_cloud/service/security/IamOptions.java
@@ -18,7 +18,6 @@ package com.ibm.watson.developer_cloud.service.security;
 public class IamOptions {
   private String apiKey;
   private String accessToken;
-  private String refreshToken;
   private String url;
 
   public String getApiKey() {
@@ -29,10 +28,6 @@ public class IamOptions {
     return accessToken;
   }
 
-  public String getRefreshToken() {
-    return refreshToken;
-  }
-
   public String getUrl() {
     return url;
   }
@@ -40,7 +35,6 @@ public class IamOptions {
   public static class Builder {
     private String apiKey;
     private String accessToken;
-    private String refreshToken;
     private String url;
 
     public IamOptions build() {
@@ -57,11 +51,6 @@ public class IamOptions {
       return this;
     }
 
-    public Builder refreshToken(String refreshToken) {
-      this.refreshToken = refreshToken;
-      return this;
-    }
-
     public Builder url(String url) {
       this.url = url;
       return this;
@@ -71,7 +60,6 @@ public class IamOptions {
   private IamOptions(Builder builder) {
     this.apiKey = builder.apiKey;
     this.accessToken = builder.accessToken;
-    this.refreshToken = builder.refreshToken;
     this.url = builder.url;
   }
 }

--- a/core/src/main/java/com/ibm/watson/developer_cloud/service/security/IamOptions.java
+++ b/core/src/main/java/com/ibm/watson/developer_cloud/service/security/IamOptions.java
@@ -14,10 +14,6 @@ package com.ibm.watson.developer_cloud.service.security;
 
 /**
  * Options for authenticating using IAM.
- *
- * Be aware that if you decide to pass in an access token, you accept responsibility for managing the access token
- * yourself. You must set a new access token before this one expires. Failing to do so will result in authentication
- * errors after this token expires.
  */
 public class IamOptions {
   private String apiKey;

--- a/core/src/main/java/com/ibm/watson/developer_cloud/service/security/IamOptions.java
+++ b/core/src/main/java/com/ibm/watson/developer_cloud/service/security/IamOptions.java
@@ -14,6 +14,10 @@ package com.ibm.watson.developer_cloud.service.security;
 
 /**
  * Options for authenticating using IAM.
+ *
+ * Be aware that if you decide to pass in an access token, you accept responsibility for managing the access token
+ * yourself. You must set a new access token before this one expires. Failing to do so will result in authentication
+ * errors after this token expires.
  */
 public class IamOptions {
   private String apiKey;

--- a/core/src/main/java/com/ibm/watson/developer_cloud/service/security/IamOptions.java
+++ b/core/src/main/java/com/ibm/watson/developer_cloud/service/security/IamOptions.java
@@ -12,29 +12,17 @@
  */
 package com.ibm.watson.developer_cloud.service.security;
 
-public class CredentialOptions {
-  private String username;
-  private String password;
+/**
+ * Options for authenticating using IAM.
+ */
+public class IamOptions {
   private String apiKey;
-  private String iamApiKey;
   private String accessToken;
   private String refreshToken;
-  private String iamUrl;
-
-  public String getUsername() {
-    return username;
-  }
-
-  public String getPassword() {
-    return password;
-  }
+  private String url;
 
   public String getApiKey() {
     return apiKey;
-  }
-
-  public String getIamApiKey() {
-    return iamApiKey;
   }
 
   public String getAccessToken() {
@@ -45,40 +33,22 @@ public class CredentialOptions {
     return refreshToken;
   }
 
-  public String getIamUrl() {
-    return iamUrl;
+  public String getUrl() {
+    return url;
   }
 
   public static class Builder {
-    private String username;
-    private String password;
     private String apiKey;
-    private String iamApiKey;
     private String accessToken;
     private String refreshToken;
-    private String iamUrl;
+    private String url;
 
-    public CredentialOptions build() {
-      return new CredentialOptions(this);
-    }
-
-    public Builder username(String username) {
-      this.username = username;
-      return this;
-    }
-
-    public Builder password(String password) {
-      this.password = password;
-      return this;
+    public IamOptions build() {
+      return new IamOptions(this);
     }
 
     public Builder apiKey(String apiKey) {
       this.apiKey = apiKey;
-      return this;
-    }
-
-    public Builder iamApiKey(String iamApiKey) {
-      this.iamApiKey = iamApiKey;
       return this;
     }
 
@@ -92,19 +62,16 @@ public class CredentialOptions {
       return this;
     }
 
-    public Builder iamUrl(String iamUrl) {
-      this.iamUrl = iamUrl;
+    public Builder url(String url) {
+      this.url = url;
       return this;
     }
   }
 
-  private CredentialOptions(Builder builder) {
-    this.username = builder.username;
-    this.password = builder.password;
+  private IamOptions(Builder builder) {
     this.apiKey = builder.apiKey;
-    this.iamApiKey = builder.iamApiKey;
     this.accessToken = builder.accessToken;
     this.refreshToken = builder.refreshToken;
-    this.iamUrl = builder.iamUrl;
+    this.url = builder.url;
   }
 }

--- a/core/src/main/java/com/ibm/watson/developer_cloud/service/security/IamToken.java
+++ b/core/src/main/java/com/ibm/watson/developer_cloud/service/security/IamToken.java
@@ -18,7 +18,7 @@ import com.ibm.watson.developer_cloud.service.model.ObjectModel;
 /**
  * Represents response from IAM API.
  */
-class IamToken implements ObjectModel {
+public class IamToken implements ObjectModel {
   @SerializedName("access_token")
   private String accessToken;
   @SerializedName("refresh_token")
@@ -29,23 +29,23 @@ class IamToken implements ObjectModel {
   private Long expiresIn;
   private Long expiration;
 
-  String getAccessToken() {
+  public String getAccessToken() {
     return accessToken;
   }
 
-  String getRefreshToken() {
+  public String getRefreshToken() {
     return refreshToken;
   }
 
-  String getTokenType() {
+  public String getTokenType() {
     return tokenType;
   }
 
-  Long getExpiresIn() {
+  public Long getExpiresIn() {
     return expiresIn;
   }
 
-  Long getExpiration() {
+  public Long getExpiration() {
     return expiration;
   }
 }

--- a/core/src/main/java/com/ibm/watson/developer_cloud/service/security/IamToken.java
+++ b/core/src/main/java/com/ibm/watson/developer_cloud/service/security/IamToken.java
@@ -29,47 +29,28 @@ class IamToken implements ObjectModel {
   private Long expiresIn;
   private Long expiration;
 
-  public static class Builder {
-    private String accessToken;
-    private String refreshToken;
-
-    public IamToken build() {
-      return new IamToken(this);
-    }
-
-    public Builder accessToken(String accessToken) {
-      this.accessToken = accessToken;
-      return this;
-    }
-
-    public Builder refreshToken(String refreshToken) {
-      this.refreshToken = refreshToken;
-      return this;
-    }
+  IamToken(String accessToken, String refreshToken) {
+    this.accessToken = accessToken;
+    this.refreshToken = refreshToken;
   }
 
-  private IamToken(Builder builder) {
-    this.accessToken = builder.accessToken;
-    this.refreshToken = builder.refreshToken;
-  }
-
-  public String getAccessToken() {
+  String getAccessToken() {
     return accessToken;
   }
 
-  public String getRefreshToken() {
+  String getRefreshToken() {
     return refreshToken;
   }
 
-  public String getTokenType() {
+  String getTokenType() {
     return tokenType;
   }
 
-  public Long getExpiresIn() {
+  Long getExpiresIn() {
     return expiresIn;
   }
 
-  public Long getExpiration() {
+  Long getExpiration() {
     return expiration;
   }
 }

--- a/core/src/main/java/com/ibm/watson/developer_cloud/service/security/IamToken.java
+++ b/core/src/main/java/com/ibm/watson/developer_cloud/service/security/IamToken.java
@@ -1,11 +1,16 @@
 package com.ibm.watson.developer_cloud.service.security;
 
+import com.google.gson.annotations.SerializedName;
 import com.ibm.watson.developer_cloud.service.model.ObjectModel;
 
 class IamToken implements ObjectModel {
+  @SerializedName("access_token")
   private String accessToken;
+  @SerializedName("refresh_token")
   private String refreshToken;
+  @SerializedName("token_type")
   private String tokenType;
+  @SerializedName("expires_in")
   private Long expiresIn;
   private Long expiration;
 

--- a/core/src/main/java/com/ibm/watson/developer_cloud/service/security/IamToken.java
+++ b/core/src/main/java/com/ibm/watson/developer_cloud/service/security/IamToken.java
@@ -29,10 +29,6 @@ class IamToken implements ObjectModel {
   private Long expiresIn;
   private Long expiration;
 
-  IamToken(String refreshToken) {
-    this.refreshToken = refreshToken;
-  }
-
   String getAccessToken() {
     return accessToken;
   }

--- a/core/src/main/java/com/ibm/watson/developer_cloud/service/security/IamToken.java
+++ b/core/src/main/java/com/ibm/watson/developer_cloud/service/security/IamToken.java
@@ -1,8 +1,23 @@
+/*
+ * Copyright 2018 IBM Corp. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
 package com.ibm.watson.developer_cloud.service.security;
 
 import com.google.gson.annotations.SerializedName;
 import com.ibm.watson.developer_cloud.service.model.ObjectModel;
 
+/**
+ * Represents response from IAM API.
+ */
 class IamToken implements ObjectModel {
   @SerializedName("access_token")
   private String accessToken;

--- a/core/src/main/java/com/ibm/watson/developer_cloud/service/security/IamToken.java
+++ b/core/src/main/java/com/ibm/watson/developer_cloud/service/security/IamToken.java
@@ -1,0 +1,55 @@
+package com.ibm.watson.developer_cloud.service.security;
+
+import com.ibm.watson.developer_cloud.service.model.ObjectModel;
+
+class IamToken implements ObjectModel {
+  private String accessToken;
+  private String refreshToken;
+  private String tokenType;
+  private Long expiresIn;
+  private Long expiration;
+
+  public static class Builder {
+    private String accessToken;
+    private String refreshToken;
+
+    public IamToken build() {
+      return new IamToken(this);
+    }
+
+    public Builder accessToken(String accessToken) {
+      this.accessToken = accessToken;
+      return this;
+    }
+
+    public Builder refreshToken(String refreshToken) {
+      this.refreshToken = refreshToken;
+      return this;
+    }
+  }
+
+  private IamToken(Builder builder) {
+    this.accessToken = builder.accessToken;
+    this.refreshToken = builder.refreshToken;
+  }
+
+  public String getAccessToken() {
+    return accessToken;
+  }
+
+  public String getRefreshToken() {
+    return refreshToken;
+  }
+
+  public String getTokenType() {
+    return tokenType;
+  }
+
+  public Long getExpiresIn() {
+    return expiresIn;
+  }
+
+  public Long getExpiration() {
+    return expiration;
+  }
+}

--- a/core/src/main/java/com/ibm/watson/developer_cloud/service/security/IamToken.java
+++ b/core/src/main/java/com/ibm/watson/developer_cloud/service/security/IamToken.java
@@ -29,8 +29,7 @@ class IamToken implements ObjectModel {
   private Long expiresIn;
   private Long expiration;
 
-  IamToken(String accessToken, String refreshToken) {
-    this.accessToken = accessToken;
+  IamToken(String refreshToken) {
     this.refreshToken = refreshToken;
   }
 

--- a/core/src/main/java/com/ibm/watson/developer_cloud/service/security/IamTokenManager.java
+++ b/core/src/main/java/com/ibm/watson/developer_cloud/service/security/IamTokenManager.java
@@ -66,12 +66,10 @@ public class IamTokenManager {
       token = tokenData.getAccessToken();
     } else if (tokenData.getAccessToken() == null) {
       // request first-time token
-      tokenData = requestToken();
-      token = tokenData.getAccessToken();
+      token = requestToken();
     } else if (isTokenExpired()) {
       // refresh current token
-      tokenData = refreshToken();
-      token = tokenData.getAccessToken();
+      token = refreshToken();
     } else {
       // use valid managed token
       token = tokenData.getAccessToken();
@@ -81,11 +79,11 @@ public class IamTokenManager {
   }
 
   /**
-   * Request an IAM token using an API key.
+   * Request an IAM token using an API key. Also updates internal managed IAM token information.
    *
    * @return the new access token
    */
-  public IamToken requestToken() {
+  public String requestToken() {
     RequestBuilder builder = RequestBuilder.post(RequestBuilder.constructHttpUrl(url, new String[0]));
 
     builder.header(HttpHeaders.CONTENT_TYPE, HttpMediaType.APPLICATION_FORM_URLENCODED);
@@ -99,15 +97,16 @@ public class IamTokenManager {
     builder.body(formBody);
 
     Call call = HttpClientSingleton.getInstance().createHttpClient().newCall(builder.build());
-    return new IamServiceCall<>(call, ResponseConverterUtils.getObject(IamToken.class)).execute();
+    tokenData = new IamServiceCall<>(call, ResponseConverterUtils.getObject(IamToken.class)).execute();
+    return tokenData.getAccessToken();
   }
 
   /**
-   * Refresh an IAM token using a refresh token.
+   * Refresh an IAM token using a refresh token. Also updates internal managed IAM token information.
    *
    * @return the new access token
    */
-  public IamToken refreshToken() {
+  public String refreshToken() {
     RequestBuilder builder = RequestBuilder.post(RequestBuilder.constructHttpUrl(url, new String[0]));
 
     builder.header(HttpHeaders.CONTENT_TYPE, HttpMediaType.APPLICATION_FORM_URLENCODED);
@@ -120,7 +119,8 @@ public class IamTokenManager {
     builder.body(formBody);
 
     Call call = HttpClientSingleton.getInstance().createHttpClient().newCall(builder.build());
-    return new IamServiceCall<>(call, ResponseConverterUtils.getObject(IamToken.class)).execute();
+    tokenData = new IamServiceCall<>(call, ResponseConverterUtils.getObject(IamToken.class)).execute();
+    return tokenData.getAccessToken();
   }
 
 

--- a/core/src/main/java/com/ibm/watson/developer_cloud/service/security/IamTokenManager.java
+++ b/core/src/main/java/com/ibm/watson/developer_cloud/service/security/IamTokenManager.java
@@ -114,20 +114,6 @@ public class IamTokenManager {
   }
 
   /**
-   * Set a self-managed IAM access token.
-   * The access token should be valid and not yet expired.
-   *
-   * By using this method, you accept responsibility for managing the access token yourself. You must set a new
-   * access token before this one expires. Failing to do so will result in authentication errors after this token
-   * expires.
-   *
-   * @param userManagedAccessToken a valid, non-expired IAM access token
-   */
-  public void setAccessToken(String userManagedAccessToken) {
-    this.userManagedAccessToken = userManagedAccessToken;
-  }
-
-  /**
    * Check if currently stored token is expired.
    *
    * Using a buffer to prevent the edge case of the

--- a/core/src/main/java/com/ibm/watson/developer_cloud/service/security/IamTokenManager.java
+++ b/core/src/main/java/com/ibm/watson/developer_cloud/service/security/IamTokenManager.java
@@ -34,10 +34,18 @@ public class IamTokenManager {
   private IamToken tokenData;
 
   private static final String DEFAULT_AUTHORIZATION = "Basic Yng6Yng=";
+  private static final String DEFAULT_IAM_URL = "https://iam.ng.bluemix.net/identity/token";
+  private static final String GRANT_TYPE = "grant_type";
+  private static final String REQUEST_GRANT_TYPE = "urn:ibm:params:oauth:grant-type:apikey";
+  private static final String REFRESH_GRANT_TYPE = "refresh_token";
+  private static final String API_KEY = "apikey";
+  private static final String RESPONSE_TYPE = "response_type";
+  private static final String CLOUD_IAM = "cloud_iam";
+  private static final String REFRESH_TOKEN = "refresh_token";
 
   public IamTokenManager(IamOptions options) {
     this.apiKey = options.getApiKey();
-    this.url = (options.getUrl() != null) ? options.getUrl() : "https://iam.ng.bluemix.net/identity/token";
+    this.url = (options.getUrl() != null) ? options.getUrl() : DEFAULT_IAM_URL;
     this.userManagedAccessToken = options.getAccessToken();
     tokenData = new IamToken();
   }
@@ -84,9 +92,9 @@ public class IamTokenManager {
     builder.header(HttpHeaders.AUTHORIZATION, DEFAULT_AUTHORIZATION);
 
     FormBody formBody = new FormBody.Builder()
-        .add("grant_type", "urn:ibm:params:oauth:grant-type:apikey")
-        .add("apikey", apiKey)
-        .add("response_type", "cloud_iam")
+        .add(GRANT_TYPE, REQUEST_GRANT_TYPE)
+        .add(API_KEY, apiKey)
+        .add(RESPONSE_TYPE, CLOUD_IAM)
         .build();
     builder.body(formBody);
 
@@ -106,8 +114,8 @@ public class IamTokenManager {
     builder.header(HttpHeaders.AUTHORIZATION, DEFAULT_AUTHORIZATION);
 
     FormBody formBody = new FormBody.Builder()
-        .add("grant_type", "refresh_token")
-        .add("refresh_token", tokenData.getRefreshToken())
+        .add(GRANT_TYPE, REFRESH_GRANT_TYPE)
+        .add(REFRESH_TOKEN, tokenData.getRefreshToken())
         .build();
     builder.body(formBody);
 

--- a/core/src/main/java/com/ibm/watson/developer_cloud/service/security/IamTokenManager.java
+++ b/core/src/main/java/com/ibm/watson/developer_cloud/service/security/IamTokenManager.java
@@ -1,6 +1,19 @@
+/*
+ * Copyright 2018 IBM Corp. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
 package com.ibm.watson.developer_cloud.service.security;
 
 import com.ibm.watson.developer_cloud.http.HttpClientSingleton;
+import com.ibm.watson.developer_cloud.http.HttpHeaders;
 import com.ibm.watson.developer_cloud.http.HttpMediaType;
 import com.ibm.watson.developer_cloud.http.RequestBuilder;
 import com.ibm.watson.developer_cloud.http.Response;
@@ -12,13 +25,17 @@ import com.ibm.watson.developer_cloud.util.ResponseConverterUtils;
 import jersey.repackaged.jsr166e.CompletableFuture;
 import okhttp3.Call;
 import okhttp3.FormBody;
-
 import java.io.IOException;
 
+/**
+ * Retrieves, stores, and refreshes IAM tokens.
+ */
 public class IamTokenManager {
   private String apiKey;
   private String url;
   private IamToken tokenData;
+
+  private static final String DEFAULT_AUTHORIZATION = "Basic Yng6Yng=";
 
   public IamTokenManager(String accessToken, String apiKey, String refreshToken, String url) {
     if (apiKey != null) {
@@ -32,29 +49,47 @@ public class IamTokenManager {
         .build();
   }
 
+  /**
+   * This function returns an access token. The source of the token is determined by the following logic:
+   * 1. If user provides their own managed access token, assume it is valid and send it
+   * 2. If this class is managing tokens and does not yet have one, make a request for one
+   * 3. If this class is managing tokens and the token has expired, refresh it
+   * 4. If this class is managing tokens and has a valid token stored, send it
+   *
+   * @return the valid access token
+   */
   public String getToken() {
     String token;
 
     if (tokenData.getAccessToken() != null) {
+      // use user-managed access token
       token = tokenData.getAccessToken();
     } else if (tokenData.getAccessToken() == null) {
+      // request first-time token
       tokenData = requestToken();
       token = tokenData.getAccessToken();
     } else if (isTokenExpired()) {
+      // refresh current token
       tokenData = refreshToken();
       token = tokenData.getAccessToken();
     } else {
+      // use valid managed token
       token = tokenData.getAccessToken();
     }
 
     return token;
   }
 
+  /**
+   * Request an IAM token using an API key.
+   *
+   * @return the new access token
+   */
   public IamToken requestToken() {
     RequestBuilder builder = RequestBuilder.post(RequestBuilder.constructHttpUrl(url, new String[0]));
 
-    builder.header("Content-Type", HttpMediaType.APPLICATION_FORM_URLENCODED);
-    builder.header("Authorization", "Basic Yng6Yng=");
+    builder.header(HttpHeaders.CONTENT_TYPE, HttpMediaType.APPLICATION_FORM_URLENCODED);
+    builder.header(HttpHeaders.AUTHORIZATION, DEFAULT_AUTHORIZATION);
 
     FormBody formBody = new FormBody.Builder()
         .add("grant_type", "urn:ibm:params:oauth:grant-type:apikey")
@@ -67,11 +102,16 @@ public class IamTokenManager {
     return new IamServiceCall<>(call, ResponseConverterUtils.getObject(IamToken.class)).execute();
   }
 
+  /**
+   * Refresh an IAM token using a refresh token.
+   *
+   * @return the new access token
+   */
   public IamToken refreshToken() {
     RequestBuilder builder = RequestBuilder.post(RequestBuilder.constructHttpUrl(url, new String[0]));
 
-    builder.header("Content-Type", HttpMediaType.APPLICATION_FORM_URLENCODED);
-    builder.header("Authorization", "Basic Yng6Yng=");
+    builder.header(HttpHeaders.CONTENT_TYPE, HttpMediaType.APPLICATION_FORM_URLENCODED);
+    builder.header(HttpHeaders.AUTHORIZATION, DEFAULT_AUTHORIZATION);
 
     FormBody formBody = new FormBody.Builder()
         .add("grant_type", "refresh_token")
@@ -83,13 +123,29 @@ public class IamTokenManager {
     return new IamServiceCall<>(call, ResponseConverterUtils.getObject(IamToken.class)).execute();
   }
 
+
+  /**
+   * Check if currently stored token is expired.
+   *
+   * Using a buffer to prevent the edge case of the
+   * token expiring before the request could be made.
+   *
+   * The buffer will be a fraction of the total TTL. Using 80%.
+   *
+   * @return whether the current managed token is expired or not
+   */
   private boolean isTokenExpired() {
+    if (tokenData.getExpiresIn() == null || tokenData.getExpiration() == null) {
+      return true;
+    }
+
     Double fractionOfTimeToLive = 0.8;
     Long timeToLive = tokenData.getExpiresIn();
     Long expirationTime = tokenData.getExpiration();
+    Double refreshTime = expirationTime - (timeToLive * (1.0 - fractionOfTimeToLive));
+    Double currentTime = Math.floor(System.currentTimeMillis() / 1000);
 
-    return (expirationTime - (timeToLive * (1.0 - fractionOfTimeToLive)))
-        < Math.floor(System.currentTimeMillis() / 1000);
+    return refreshTime < currentTime;
   }
 
   private class IamServiceCall<IamToken> implements ServiceCall<IamToken> {

--- a/core/src/main/java/com/ibm/watson/developer_cloud/service/security/IamTokenManager.java
+++ b/core/src/main/java/com/ibm/watson/developer_cloud/service/security/IamTokenManager.java
@@ -1,0 +1,161 @@
+package com.ibm.watson.developer_cloud.service.security;
+
+import com.google.gson.JsonObject;
+import com.ibm.watson.developer_cloud.http.HttpClientSingleton;
+import com.ibm.watson.developer_cloud.http.HttpMediaType;
+import com.ibm.watson.developer_cloud.http.NameValue;
+import com.ibm.watson.developer_cloud.http.RequestBuilder;
+import com.ibm.watson.developer_cloud.http.Response;
+import com.ibm.watson.developer_cloud.http.ResponseConverter;
+import com.ibm.watson.developer_cloud.http.ServiceCall;
+import com.ibm.watson.developer_cloud.http.ServiceCallback;
+import com.ibm.watson.developer_cloud.http.ServiceCallbackWithDetails;
+import com.ibm.watson.developer_cloud.util.ResponseConverterUtils;
+import jersey.repackaged.jsr166e.CompletableFuture;
+import okhttp3.Call;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class IamTokenManager {
+  private String apiKey;
+  private String url;
+  private IamToken tokenData;
+
+  public IamTokenManager(String accessToken, String apiKey, String refreshToken, String url) {
+    if (apiKey != null) {
+      this.apiKey = apiKey;
+    }
+    this.url = (url != null) ? url : "https://iam.ng.bluemix.net/identity/token";
+
+    tokenData = new IamToken.Builder()
+        .accessToken(accessToken)
+        .refreshToken(refreshToken)
+        .build();
+  }
+
+  public String getToken() {
+    String token;
+
+    if (tokenData.getAccessToken() != null) {
+      token = tokenData.getAccessToken();
+    } else if (tokenData.getAccessToken() == null) {
+      tokenData = requestToken(null);
+      token = tokenData.getAccessToken();
+    } else if (isTokenExpired()) {
+      tokenData = refreshToken(null);
+      token = tokenData.getAccessToken();
+    } else {
+      token = tokenData.getAccessToken();
+    }
+
+    return token;
+  }
+
+  public IamToken requestToken(String authorizationHeader) {
+    RequestBuilder builder = RequestBuilder.post(RequestBuilder.constructHttpUrl(url, new String[0]));
+
+    builder.header("Content-Type", HttpMediaType.APPLICATION_FORM_URLENCODED);
+    builder.header("Authorization", (authorizationHeader != null) ? authorizationHeader : "Basic Yng6Yng=");
+
+    //Map<String, String> formObject = new HashMap<>();
+    //final JsonObject jsonContent = new JsonObject();
+    //jsonContent.addProperty("grant_type", "urn:ibm:params:oauth:grant-type:apikey");
+    List<NameValue> formObject = new ArrayList<>();
+    formObject.add(new NameValue("grant_type", "urn:ibm:params:oauth:grant-type:apikey"));
+    //formObject.put("grant_type", "urn:ibm:params:oauth:grant-type:apikey");
+    //jsonContent.addProperty("apikey", apiKey);
+    //formObject.put("apikey", apiKey);
+    formObject.add(new NameValue("apikey", apiKey));
+    //jsonContent.addProperty("response_type", "cloud_iam");
+    //formObject.put("response_type", "cloud_iam");
+    formObject.add(new NameValue("response_type", "cloud_iam"));
+    //builder.bodyJson(jsonContent);
+    builder.form(formObject);
+
+    Call call = HttpClientSingleton.getInstance().createHttpClient().newCall(builder.build());
+    IamToken tokenTest = new IamServiceCall<>(call, ResponseConverterUtils.getObject(IamToken.class)).execute();
+    return tokenTest;
+    //return new IamServiceCall<>(call, ResponseConverterUtils.getObject(IamToken.class)).execute();
+  }
+
+  public IamToken refreshToken(String authorizationHeader) {
+    RequestBuilder builder = RequestBuilder.post(RequestBuilder.constructHttpUrl(url, new String[0]));
+
+    builder.header("Content-Type", HttpMediaType.APPLICATION_FORM_URLENCODED);
+    builder.header("Authorization", (authorizationHeader != null) ? authorizationHeader : "Basic Yng6Yng=");
+
+    final JsonObject jsonContent = new JsonObject();
+    jsonContent.addProperty("grant_type", "refresh_token");
+    jsonContent.addProperty("refresh_token", tokenData.getRefreshToken());
+    //builder.bodyJson(jsonContent);
+    builder.form(jsonContent);
+
+    Call call = HttpClientSingleton.getInstance().createHttpClient().newCall(builder.build());
+    return new IamServiceCall<>(call, ResponseConverterUtils.getObject(IamToken.class)).execute();
+  }
+
+  private boolean isTokenExpired() {
+    Double fractionOfTimeToLive = 0.8;
+    Long timeToLive = tokenData.getExpiresIn();
+    Long expirationTime = tokenData.getExpiration();
+
+    return (expirationTime - (timeToLive * (1.0 - fractionOfTimeToLive)))
+        < Math.floor(System.currentTimeMillis() / 1000);
+  }
+
+  private class IamServiceCall<IamToken> implements ServiceCall<IamToken> {
+
+    private Call call;
+    private ResponseConverter<IamToken> converter;
+
+    IamServiceCall(Call call, ResponseConverter<IamToken> converter) {
+      this.call = call;
+      this.converter = converter;
+    }
+
+    @Override
+    public ServiceCall<IamToken> addHeader(String name, String value) {
+      return null;
+    }
+
+    @Override
+    public IamToken execute() throws RuntimeException {
+      try {
+        okhttp3.Response response = call.execute();
+        return converter.convert(response);
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+    @Override
+    public Response<IamToken> executeWithDetails() throws RuntimeException {
+      return null;
+    }
+
+    @Override
+    public void enqueue(ServiceCallback<? super IamToken> callback) {
+
+    }
+
+    @Override
+    public void enqueueWithDetails(ServiceCallbackWithDetails<IamToken> callback) {
+
+    }
+
+    @Override
+    public CompletableFuture<IamToken> rx() {
+      return null;
+    }
+
+    @Override
+    public CompletableFuture<Response<IamToken>> rxWithDetails() {
+      return null;
+    }
+  }
+
+}

--- a/core/src/main/java/com/ibm/watson/developer_cloud/service/security/IamTokenManager.java
+++ b/core/src/main/java/com/ibm/watson/developer_cloud/service/security/IamTokenManager.java
@@ -43,10 +43,7 @@ public class IamTokenManager {
     }
     this.url = (url != null) ? url : "https://iam.ng.bluemix.net/identity/token";
 
-    tokenData = new IamToken.Builder()
-        .accessToken(accessToken)
-        .refreshToken(refreshToken)
-        .build();
+    tokenData = new IamToken(accessToken, refreshToken);
   }
 
   /**

--- a/core/src/main/java/com/ibm/watson/developer_cloud/service/security/IamTokenManager.java
+++ b/core/src/main/java/com/ibm/watson/developer_cloud/service/security/IamTokenManager.java
@@ -162,7 +162,7 @@ public class IamTokenManager {
    * @returns whether the current managed refresh token is expired or not
    */
   private boolean isRefreshTokenExpired() {
-    if (tokenData.getExpiration() != null) {
+    if (tokenData.getExpiration() == null) {
       return true;
     }
 

--- a/core/src/main/java/com/ibm/watson/developer_cloud/service/security/IamTokenManager.java
+++ b/core/src/main/java/com/ibm/watson/developer_cloud/service/security/IamTokenManager.java
@@ -39,6 +39,7 @@ public class IamTokenManager {
     this.apiKey = options.getApiKey();
     this.url = (options.getUrl() != null) ? options.getUrl() : "https://iam.ng.bluemix.net/identity/token";
     this.userManagedAccessToken = options.getAccessToken();
+    tokenData = new IamToken();
   }
 
   /**
@@ -111,6 +112,20 @@ public class IamTokenManager {
 
     tokenData = callIamApi(builder.build());
     return tokenData.getAccessToken();
+  }
+
+  /**
+   * Set a self-managed IAM access token.
+   * The access token should be valid and not yet expired.
+   *
+   * By using this method, you accept responsibility for managing the access token yourself. You must set a new
+   * access token before this one expires. Failing to do so will result in authentication errors after this token
+   * expires.
+   *
+   * @param userManagedAccessToken a valid, non-expired IAM access token
+   */
+  public void setAccessToken(String userManagedAccessToken) {
+    this.userManagedAccessToken = userManagedAccessToken;
   }
 
   /**

--- a/core/src/main/java/com/ibm/watson/developer_cloud/service/security/IamTokenManager.java
+++ b/core/src/main/java/com/ibm/watson/developer_cloud/service/security/IamTokenManager.java
@@ -31,19 +31,18 @@ import java.io.IOException;
  * Retrieves, stores, and refreshes IAM tokens.
  */
 public class IamTokenManager {
+  private String userManagedAccessToken;
   private String apiKey;
   private String url;
   private IamToken tokenData;
 
   private static final String DEFAULT_AUTHORIZATION = "Basic Yng6Yng=";
 
-  public IamTokenManager(String accessToken, String apiKey, String refreshToken, String url) {
-    if (apiKey != null) {
-      this.apiKey = apiKey;
-    }
-    this.url = (url != null) ? url : "https://iam.ng.bluemix.net/identity/token";
-
-    tokenData = new IamToken(accessToken, refreshToken);
+  public IamTokenManager(IamOptions options) {
+    this.apiKey = options.getApiKey();
+    this.url = (options.getUrl() != null) ? options.getUrl() : "https://iam.ng.bluemix.net/identity/token";
+    this.userManagedAccessToken = options.getAccessToken();
+    tokenData = new IamToken(options.getRefreshToken());
   }
 
   /**
@@ -58,9 +57,9 @@ public class IamTokenManager {
   public String getToken() {
     String token;
 
-    if (tokenData.getAccessToken() != null) {
+    if (userManagedAccessToken != null) {
       // use user-managed access token
-      token = tokenData.getAccessToken();
+      token = userManagedAccessToken;
     } else if (tokenData.getAccessToken() == null) {
       // request first-time token
       token = requestToken();

--- a/core/src/main/java/com/ibm/watson/developer_cloud/service/security/IamTokenManager.java
+++ b/core/src/main/java/com/ibm/watson/developer_cloud/service/security/IamTokenManager.java
@@ -42,7 +42,6 @@ public class IamTokenManager {
     this.apiKey = options.getApiKey();
     this.url = (options.getUrl() != null) ? options.getUrl() : "https://iam.ng.bluemix.net/identity/token";
     this.userManagedAccessToken = options.getAccessToken();
-    tokenData = new IamToken(options.getRefreshToken());
   }
 
   /**

--- a/core/src/main/java/com/ibm/watson/developer_cloud/service/security/IamTokenManager.java
+++ b/core/src/main/java/com/ibm/watson/developer_cloud/service/security/IamTokenManager.java
@@ -85,7 +85,7 @@ public class IamTokenManager {
    *
    * @return the new access token
    */
-  public String requestToken() {
+  private String requestToken() {
     RequestBuilder builder = RequestBuilder.post(RequestBuilder.constructHttpUrl(url, new String[0]));
 
     builder.header(HttpHeaders.CONTENT_TYPE, HttpMediaType.APPLICATION_FORM_URLENCODED);
@@ -107,7 +107,7 @@ public class IamTokenManager {
    *
    * @return the new access token
    */
-  public String refreshToken() {
+  private String refreshToken() {
     RequestBuilder builder = RequestBuilder.post(RequestBuilder.constructHttpUrl(url, new String[0]));
 
     builder.header(HttpHeaders.CONTENT_TYPE, HttpMediaType.APPLICATION_FORM_URLENCODED);
@@ -121,20 +121,6 @@ public class IamTokenManager {
 
     tokenData = callIamApi(builder.build());
     return tokenData.getAccessToken();
-  }
-
-  /**
-   * Set a self-managed IAM access token.
-   * The access token should be valid and not yet expired.
-   *
-   * By using this method, you accept responsibility for managing the access token yourself. You must set a new
-   * access token before this one expires. Failing to do so will result in authentication errors after this token
-   * expires.
-   *
-   * @param userManagedAccessToken a valid, non-expired IAM access token
-   */
-  public void setAccessToken(String userManagedAccessToken) {
-    this.userManagedAccessToken = userManagedAccessToken;
   }
 
   /**

--- a/core/src/main/java/com/ibm/watson/developer_cloud/service/security/IamTokenManager.java
+++ b/core/src/main/java/com/ibm/watson/developer_cloud/service/security/IamTokenManager.java
@@ -114,6 +114,20 @@ public class IamTokenManager {
   }
 
   /**
+   * Set a self-managed IAM access token.
+   * The access token should be valid and not yet expired.
+   *
+   * By using this method, you accept responsibility for managing the access token yourself. You must set a new
+   * access token before this one expires. Failing to do so will result in authentication errors after this token
+   * expires.
+   *
+   * @param userManagedAccessToken a valid, non-expired IAM access token
+   */
+  public void setAccessToken(String userManagedAccessToken) {
+    this.userManagedAccessToken = userManagedAccessToken;
+  }
+
+  /**
    * Check if currently stored token is expired.
    *
    * Using a buffer to prevent the edge case of the

--- a/core/src/main/java/com/ibm/watson/developer_cloud/util/CredentialUtils.java
+++ b/core/src/main/java/com/ibm/watson/developer_cloud/util/CredentialUtils.java
@@ -77,6 +77,9 @@ public final class CredentialUtils {
   /** The Constant APIKEY. */
   private static final String APIKEY = "apikey";
 
+  /** The Constant IAM_API_KEY_NAME. */
+  private static final String IAM_API_KEY_NAME = "iam_apikey_name";
+
   /** The Constant CREDENTIALS. */
   private static final String CREDENTIALS = "credentials";
 
@@ -100,6 +103,9 @@ public final class CredentialUtils {
 
   /** The Constant URL. */
   private static final String URL = "url";
+
+  /** The Constant IAM_URL. */
+  private static final String IAM_URL = "iam_url";
 
   /** The Constant PLAN_EXPERIMENTAL. */
   public static final String PLAN_EXPERIMENTAL = "experimental";
@@ -205,7 +211,7 @@ public final class CredentialUtils {
     }
 
     final JsonObject credentials = getCredentialsObject(services, serviceName, null);
-    if (credentials != null && credentials.get(APIKEY) != null && credentials.get("iam_apikey_name") != null) {
+    if (credentials != null && credentials.get(APIKEY) != null && credentials.get(IAM_API_KEY_NAME) != null) {
       return credentials.get(APIKEY).getAsString();
     }
 
@@ -364,6 +370,21 @@ public final class CredentialUtils {
     final JsonObject credentials = getCredentialsObject(services, serviceName, plan);
     if ((credentials != null) && credentials.has(URL)) {
       return credentials.get(URL).getAsString();
+    }
+
+    return null;
+  }
+
+  public static String getIAMUrl(String serviceName) {
+    final JsonObject services = getVCAPServices();
+
+    if (serviceName == null || services == null) {
+      return null;
+    }
+
+    final JsonObject credentials = getCredentialsObject(services, serviceName, null);
+    if (credentials != null && credentials.get(IAM_URL) != null) {
+      return credentials.get(IAM_URL).getAsString();
     }
 
     return null;

--- a/core/src/main/java/com/ibm/watson/developer_cloud/util/CredentialUtils.java
+++ b/core/src/main/java/com/ibm/watson/developer_cloud/util/CredentialUtils.java
@@ -197,7 +197,7 @@ public final class CredentialUtils {
    * @param serviceName the service name
    * @return the IAM API key or null if the service cannot be found
    */
-  public static String getIamAPIKey(String serviceName) {
+  public static String getIAMKey(String serviceName) {
     final JsonObject services = getVCAPServices();
 
     if (serviceName == null || services == null) {

--- a/core/src/main/java/com/ibm/watson/developer_cloud/util/CredentialUtils.java
+++ b/core/src/main/java/com/ibm/watson/developer_cloud/util/CredentialUtils.java
@@ -192,6 +192,27 @@ public final class CredentialUtils {
   }
 
   /**
+   * Returns the IAM API key from the VCAP_SERVICES, or null if it doesn't exist.
+   *
+   * @param serviceName the service name
+   * @return the IAM API key or null if the service cannot be found
+   */
+  public static String getIamAPIKey(String serviceName) {
+    final JsonObject services = getVCAPServices();
+
+    if (serviceName == null || services == null) {
+      return null;
+    }
+
+    final JsonObject credentials = getCredentialsObject(services, serviceName, null);
+    if (credentials != null && credentials.get(APIKEY) != null && credentials.get("iam_apikey_name") != null) {
+      return credentials.get(APIKEY).getAsString();
+    }
+
+    return null;
+  }
+
+  /**
    * Returns the apiKey from the VCAP_SERVICES or null if doesn't exists.
    *
    * @param serviceName the service name

--- a/core/src/test/java/com/ibm/watson/developer_cloud/service/IamManagerTest.java
+++ b/core/src/test/java/com/ibm/watson/developer_cloud/service/IamManagerTest.java
@@ -18,6 +18,7 @@ import com.ibm.watson.developer_cloud.service.security.IamToken;
 import com.ibm.watson.developer_cloud.service.security.IamTokenManager;
 import org.junit.Before;
 import org.junit.Test;
+
 import static org.junit.Assert.assertEquals;
 
 public class IamManagerTest extends WatsonServiceUnitTest {
@@ -49,23 +50,6 @@ public class IamManagerTest extends WatsonServiceUnitTest {
         .url(url)
         .build();
     IamTokenManager manager = new IamTokenManager(options);
-
-    String token = manager.getToken();
-    assertEquals(ACCESS_TOKEN, token);
-  }
-
-  /**
-   * Tests that if a user sets their own access token at some point, that access token gets passed back during later
-   * retrieval.
-   */
-  @Test
-  public void getUserManagedTokenFromMethodCall() {
-    IamOptions options = new IamOptions.Builder()
-        .apiKey(API_KEY)
-        .url(url)
-        .build();
-    IamTokenManager manager = new IamTokenManager(options);
-    manager.setAccessToken(ACCESS_TOKEN);
 
     String token = manager.getToken();
     assertEquals(ACCESS_TOKEN, token);

--- a/core/src/test/java/com/ibm/watson/developer_cloud/service/IamManagerTest.java
+++ b/core/src/test/java/com/ibm/watson/developer_cloud/service/IamManagerTest.java
@@ -1,0 +1,113 @@
+/**
+ * Copyright 2018 IBM Corp. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.ibm.watson.developer_cloud.service;
+
+import com.ibm.watson.developer_cloud.WatsonServiceUnitTest;
+import com.ibm.watson.developer_cloud.service.security.IamOptions;
+import com.ibm.watson.developer_cloud.service.security.IamToken;
+import com.ibm.watson.developer_cloud.service.security.IamTokenManager;
+import org.junit.Before;
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+
+public class IamManagerTest extends WatsonServiceUnitTest {
+
+  private IamToken expiredTokenData;
+  private IamToken validTokenData;
+  private String url;
+
+  private static final String ACCESS_TOKEN = "abcd-1234";
+  private static final String API_KEY = "123456789";
+
+  @Override
+  @Before
+  public void setUp() throws Exception {
+    super.setUp();
+    url = getMockWebServerUrl();
+    expiredTokenData = loadFixture("src/test/resources/expired_iam_token.json", IamToken.class);
+    validTokenData = loadFixture("src/test/resources/valid_iam_token.json", IamToken.class);
+  }
+
+  /**
+   * Tests that if a user passes in an access token during initial IAM setup, that access token is passed back
+   * during later retrieval.
+   */
+  @Test
+  public void getUserManagedTokenFromConstructor() {
+    IamOptions options = new IamOptions.Builder()
+        .accessToken(ACCESS_TOKEN)
+        .url(url)
+        .build();
+    IamTokenManager manager = new IamTokenManager(options);
+
+    String token = manager.getToken();
+    assertEquals(ACCESS_TOKEN, token);
+  }
+
+  /**
+   * Tests that if a user sets their own access token at some point, that access token gets passed back during later
+   * retrieval.
+   */
+  @Test
+  public void getUserManagedTokenFromMethodCall() {
+    IamOptions options = new IamOptions.Builder()
+        .apiKey(API_KEY)
+        .url(url)
+        .build();
+    IamTokenManager manager = new IamTokenManager(options);
+    manager.setAccessToken(ACCESS_TOKEN);
+
+    String token = manager.getToken();
+    assertEquals(ACCESS_TOKEN, token);
+  }
+
+  /**
+   * Tests that if only an API key is stored, the user can get back a valid access token.
+   */
+  @Test
+  public void getTokenFromApiKey() throws InterruptedException {
+    server.enqueue(jsonResponse(validTokenData));
+
+    IamOptions options = new IamOptions.Builder()
+        .apiKey(API_KEY)
+        .url(url)
+        .build();
+    IamTokenManager manager = new IamTokenManager(options);
+
+    String token = manager.getToken();
+    assertEquals(validTokenData.getAccessToken(), token);
+  }
+
+  /**
+   * Tests that if the stored access token is expired, it can be refreshed properly.
+   */
+  @Test
+  public void getTokenAfterRefresh() {
+    server.enqueue(jsonResponse(expiredTokenData));
+
+    IamOptions options = new IamOptions.Builder()
+        .apiKey(API_KEY)
+        .url(url)
+        .build();
+    IamTokenManager manager = new IamTokenManager(options);
+
+    // setting expired token
+    manager.getToken();
+
+    // getting valid token
+    server.enqueue(jsonResponse(validTokenData));
+    String newToken = manager.getToken();
+
+    assertEquals(validTokenData.getAccessToken(), newToken);
+  }
+}

--- a/core/src/test/java/com/ibm/watson/developer_cloud/util/CredentialUtilsTest.java
+++ b/core/src/test/java/com/ibm/watson/developer_cloud/util/CredentialUtilsTest.java
@@ -13,6 +13,7 @@
 package com.ibm.watson.developer_cloud.util;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
@@ -53,6 +54,9 @@ public class CredentialUtilsTest extends WatsonServiceTest {
   private static final String VISUAL_RECOGNITION = "watson_vision_combined";
 
   private static final String PERSONALITY_INSIGHTS_URL = "https://gateway.watsonplatform.net/personality-insights/api";
+
+  private static final String IAM_SERVICE_NAME = "language_translator";
+  private static final String IAM_KEY_TEST_VALUE = "123456789";
 
   /**
    * Setup.
@@ -123,6 +127,15 @@ public class CredentialUtilsTest extends WatsonServiceTest {
     assertTrue(credentials != null);
     assertEquals(credentials.getUsername(), NOT_A_USERNAME);
     assertEquals(credentials.getPassword(), NOT_A_PASSWORD);
+  }
+
+  /**
+   * Test getting IAM API key from VCAP_SERVICES.
+   */
+  @Test
+  public void testGetIAMKey() {
+    String key = CredentialUtils.getIAMKey(IAM_SERVICE_NAME);
+    assertEquals(IAM_KEY_TEST_VALUE, key);
   }
 
   /**

--- a/core/src/test/java/com/ibm/watson/developer_cloud/util/CredentialUtilsTest.java
+++ b/core/src/test/java/com/ibm/watson/developer_cloud/util/CredentialUtilsTest.java
@@ -12,21 +12,19 @@
  */
 package com.ibm.watson.developer_cloud.util;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-
-import java.io.InputStream;
-import java.util.Hashtable;
-
+import com.ibm.watson.developer_cloud.WatsonServiceTest;
+import com.ibm.watson.developer_cloud.util.CredentialUtils.ServiceCredentials;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 
-import com.ibm.watson.developer_cloud.WatsonServiceTest;
-import com.ibm.watson.developer_cloud.util.CredentialUtils.ServiceCredentials;
+import java.io.InputStream;
+import java.util.Hashtable;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * The Class CredentialUtilsTest.

--- a/core/src/test/resources/expired_iam_token.json
+++ b/core/src/test/resources/expired_iam_token.json
@@ -1,0 +1,7 @@
+{
+  "access_token": "wxyz-9876",
+  "refresh_token": "00000000",
+  "token_type": "Bearer",
+  "expires_in": 3600,
+  "expiration": 1522788645
+}

--- a/core/src/test/resources/valid_iam_token.json
+++ b/core/src/test/resources/valid_iam_token.json
@@ -1,0 +1,7 @@
+{
+  "access_token": "aaaa-1111",
+  "refresh_token": "99999999",
+  "token_type": "Bearer",
+  "expires_in": 3600,
+  "expiration": 999999999999999999
+}

--- a/core/src/test/resources/vcap_services.json
+++ b/core/src/test/resources/vcap_services.json
@@ -59,15 +59,18 @@
          }
       }
    ],
-   "language_translation": [
+   "language_translator": [
       {
-         "name": "language_translation_docs",
-         "label": "language_translation",
+         "name": "language_translator_docs",
+         "label": "language_translator",
          "plan": "standard",
          "credentials": {
-            "url": "https://gateway.watsonplatform.net/language-translation/api",
-            "username": "not-a-username",
-            "password": "not-a-password"
+            "apikey": "123456789",
+            "iam_apikey_description": "Auto generated apikey...",
+            "iam_apikey_name": "auto-generated-apikey-111-222-333",
+            "iam_role_crn": "crn:v1:bluemix:public:iam::::serviceRole:Manager",
+            "iam_serviceid_crn": "crn:v1:staging:public:iam-identity::a/::serviceid:ServiceID-1234",
+            "url": "https://gateway.watsonplatform.net/language-translator/api"
          }
       }
    ],

--- a/core/src/test/resources/vcap_services.json
+++ b/core/src/test/resources/vcap_services.json
@@ -70,7 +70,8 @@
             "iam_apikey_name": "auto-generated-apikey-111-222-333",
             "iam_role_crn": "crn:v1:bluemix:public:iam::::serviceRole:Manager",
             "iam_serviceid_crn": "crn:v1:staging:public:iam-identity::a/::serviceid:ServiceID-1234",
-            "url": "https://gateway.watsonplatform.net/language-translator/api"
+            "url": "https://gateway.watsonplatform.net/language-translator/api",
+            "iam_url": "https://iam.ng.bluemix.net/identity/token"
          }
       }
    ],

--- a/discovery/src/main/java/com/ibm/watson/developer_cloud/discovery/v1/Discovery.java
+++ b/discovery/src/main/java/com/ibm/watson/developer_cloud/discovery/v1/Discovery.java
@@ -76,6 +76,7 @@ import com.ibm.watson.developer_cloud.discovery.v1.model.UpdateTrainingExampleOp
 import com.ibm.watson.developer_cloud.http.RequestBuilder;
 import com.ibm.watson.developer_cloud.http.ServiceCall;
 import com.ibm.watson.developer_cloud.service.WatsonService;
+import com.ibm.watson.developer_cloud.service.security.IamOptions;
 import com.ibm.watson.developer_cloud.util.GsonSingleton;
 import com.ibm.watson.developer_cloud.util.RequestUtils;
 import com.ibm.watson.developer_cloud.util.ResponseConverterUtils;
@@ -127,6 +128,20 @@ public class Discovery extends WatsonService {
   public Discovery(String versionDate, String username, String password) {
     this(versionDate);
     setUsernameAndPassword(username, password);
+  }
+
+  /**
+   * Instantiates a new `Discovery` with IAM. Note that if the access token is specified in the iamOptions,
+   * you accept responsibility for managing the access token yourself. You must set a new access token before this one
+   * expires. Failing to do so will result in authentication errors after this token expires.
+   *
+   * @param versionDate The version date (yyyy-MM-dd) of the REST API to use. Specifying this value will keep your API
+   *          calls from failing when the service introduces breaking changes.
+   * @param iamOptions the options for authenticating through IAM
+   */
+  public Discovery(String versionDate, IamOptions iamOptions) {
+    this(versionDate);
+    setIamCredentials(iamOptions);
   }
 
   /**

--- a/language-translator/src/main/java/com/ibm/watson/developer_cloud/language_translator/v2/LanguageTranslator.java
+++ b/language-translator/src/main/java/com/ibm/watson/developer_cloud/language_translator/v2/LanguageTranslator.java
@@ -28,6 +28,7 @@ import com.ibm.watson.developer_cloud.language_translator.v2.model.TranslationMo
 import com.ibm.watson.developer_cloud.language_translator.v2.model.TranslationModels;
 import com.ibm.watson.developer_cloud.language_translator.v2.model.TranslationResult;
 import com.ibm.watson.developer_cloud.service.WatsonService;
+import com.ibm.watson.developer_cloud.service.security.IamOptions;
 import com.ibm.watson.developer_cloud.util.GsonSingleton;
 import com.ibm.watson.developer_cloud.util.RequestUtils;
 import com.ibm.watson.developer_cloud.util.ResponseConverterUtils;
@@ -68,6 +69,18 @@ public class LanguageTranslator extends WatsonService {
   public LanguageTranslator(String username, String password) {
     this();
     setUsernameAndPassword(username, password);
+  }
+
+  /**
+   * Instantiates a new `LanguageTranslator` with IAM. Note that if the access token is specified in the iamOptions,
+   * you accept responsibility for managing the access token yourself. You must set a new access token before this one
+   * expires. Failing to do so will result in authentication errors after this token expires.
+   *
+   * @param iamOptions the options for authenticating through IAM
+   */
+  public LanguageTranslator(IamOptions iamOptions) {
+    this();
+    setIamCredentials(iamOptions);
   }
 
   /**

--- a/natural-language-classifier/src/main/java/com/ibm/watson/developer_cloud/natural_language_classifier/v1/NaturalLanguageClassifier.java
+++ b/natural-language-classifier/src/main/java/com/ibm/watson/developer_cloud/natural_language_classifier/v1/NaturalLanguageClassifier.java
@@ -26,6 +26,7 @@ import com.ibm.watson.developer_cloud.natural_language_classifier.v1.model.Delet
 import com.ibm.watson.developer_cloud.natural_language_classifier.v1.model.GetClassifierOptions;
 import com.ibm.watson.developer_cloud.natural_language_classifier.v1.model.ListClassifiersOptions;
 import com.ibm.watson.developer_cloud.service.WatsonService;
+import com.ibm.watson.developer_cloud.service.security.IamOptions;
 import com.ibm.watson.developer_cloud.util.GsonSingleton;
 import com.ibm.watson.developer_cloud.util.RequestUtils;
 import com.ibm.watson.developer_cloud.util.ResponseConverterUtils;
@@ -73,6 +74,18 @@ public class NaturalLanguageClassifier extends WatsonService {
   public NaturalLanguageClassifier(String username, String password) {
     this();
     setUsernameAndPassword(username, password);
+  }
+
+  /**
+   * Instantiates a new `NaturalLanguageClassifier` with IAM. Note that if the access token is specified in the iamOptions,
+   * you accept responsibility for managing the access token yourself. You must set a new access token before this one
+   * expires. Failing to do so will result in authentication errors after this token expires.
+   *
+   * @param iamOptions the options for authenticating through IAM
+   */
+  public NaturalLanguageClassifier(IamOptions iamOptions) {
+    this();
+    setIamCredentials(iamOptions);
   }
 
   /**

--- a/natural-language-classifier/src/main/java/com/ibm/watson/developer_cloud/natural_language_classifier/v1/NaturalLanguageClassifier.java
+++ b/natural-language-classifier/src/main/java/com/ibm/watson/developer_cloud/natural_language_classifier/v1/NaturalLanguageClassifier.java
@@ -77,9 +77,9 @@ public class NaturalLanguageClassifier extends WatsonService {
   }
 
   /**
-   * Instantiates a new `NaturalLanguageClassifier` with IAM. Note that if the access token is specified in the iamOptions,
-   * you accept responsibility for managing the access token yourself. You must set a new access token before this one
-   * expires. Failing to do so will result in authentication errors after this token expires.
+   * Instantiates a new `NaturalLanguageClassifier` with IAM. Note that if the access token is specified in the
+   * iamOptions, you accept responsibility for managing the access token yourself. You must set a new access token
+   * before this one expires. Failing to do so will result in authentication errors after this token expires.
    *
    * @param iamOptions the options for authenticating through IAM
    */

--- a/natural-language-understanding/src/main/java/com/ibm/watson/developer_cloud/natural_language_understanding/v1/NaturalLanguageUnderstanding.java
+++ b/natural-language-understanding/src/main/java/com/ibm/watson/developer_cloud/natural_language_understanding/v1/NaturalLanguageUnderstanding.java
@@ -21,6 +21,7 @@ import com.ibm.watson.developer_cloud.natural_language_understanding.v1.model.De
 import com.ibm.watson.developer_cloud.natural_language_understanding.v1.model.ListModelsOptions;
 import com.ibm.watson.developer_cloud.natural_language_understanding.v1.model.ListModelsResults;
 import com.ibm.watson.developer_cloud.service.WatsonService;
+import com.ibm.watson.developer_cloud.service.security.IamOptions;
 import com.ibm.watson.developer_cloud.util.GsonSingleton;
 import com.ibm.watson.developer_cloud.util.ResponseConverterUtils;
 import com.ibm.watson.developer_cloud.util.Validator;
@@ -106,6 +107,20 @@ public class NaturalLanguageUnderstanding extends WatsonService {
   public NaturalLanguageUnderstanding(String versionDate, String username, String password) {
     this(versionDate);
     setUsernameAndPassword(username, password);
+  }
+
+  /**
+   * Instantiates a new `NaturalLanguageUnderstanding` with IAM. Note that if the access token is specified in the iamOptions,
+   * you accept responsibility for managing the access token yourself. You must set a new access token before this one
+   * expires. Failing to do so will result in authentication errors after this token expires.
+   *
+   * @param versionDate The version date (yyyy-MM-dd) of the REST API to use. Specifying this value will keep your API
+   *          calls from failing when the service introduces breaking changes.
+   * @param iamOptions the options for authenticating through IAM
+   */
+  public NaturalLanguageUnderstanding(String versionDate, IamOptions iamOptions) {
+    this(versionDate);
+    setIamCredentials(iamOptions);
   }
 
   /**

--- a/natural-language-understanding/src/main/java/com/ibm/watson/developer_cloud/natural_language_understanding/v1/NaturalLanguageUnderstanding.java
+++ b/natural-language-understanding/src/main/java/com/ibm/watson/developer_cloud/natural_language_understanding/v1/NaturalLanguageUnderstanding.java
@@ -78,9 +78,9 @@ public class NaturalLanguageUnderstanding extends WatsonService {
   }
 
   /**
-   * Instantiates a new `NaturalLanguageUnderstanding` with IAM. Note that if the access token is specified in the iamOptions,
-   * you accept responsibility for managing the access token yourself. You must set a new access token before this one
-   * expires. Failing to do so will result in authentication errors after this token expires.
+   * Instantiates a new `NaturalLanguageUnderstanding` with IAM. Note that if the access token is specified in the
+   * iamOptions, you accept responsibility for managing the access token yourself. You must set a new access token
+   * before this one expires. Failing to do so will result in authentication errors after this token expires.
    *
    * @param versionDate The version date (yyyy-MM-dd) of the REST API to use. Specifying this value will keep your API
    *          calls from failing when the service introduces breaking changes.

--- a/personality-insights/src/main/java/com/ibm/watson/developer_cloud/personality_insights/v3/PersonalityInsights.java
+++ b/personality-insights/src/main/java/com/ibm/watson/developer_cloud/personality_insights/v3/PersonalityInsights.java
@@ -19,6 +19,7 @@ import com.ibm.watson.developer_cloud.http.ServiceCall;
 import com.ibm.watson.developer_cloud.personality_insights.v3.model.Profile;
 import com.ibm.watson.developer_cloud.personality_insights.v3.model.ProfileOptions;
 import com.ibm.watson.developer_cloud.service.WatsonService;
+import com.ibm.watson.developer_cloud.service.security.IamOptions;
 import com.ibm.watson.developer_cloud.util.GsonSingleton;
 import com.ibm.watson.developer_cloud.util.ResponseConverterUtils;
 import com.ibm.watson.developer_cloud.util.Validator;
@@ -93,6 +94,20 @@ public class PersonalityInsights extends WatsonService {
   public PersonalityInsights(String versionDate, String username, String password) {
     this(versionDate);
     setUsernameAndPassword(username, password);
+  }
+
+  /**
+   * Instantiates a new `PersonalityInsights` with IAM. Note that if the access token is specified in the iamOptions,
+   * you accept responsibility for managing the access token yourself. You must set a new access token before this one
+   * expires. Failing to do so will result in authentication errors after this token expires.
+   *
+   * @param versionDate The version date (yyyy-MM-dd) of the REST API to use. Specifying this value will keep your API
+   *          calls from failing when the service introduces breaking changes.
+   * @param iamOptions the options for authenticating through IAM
+   */
+  public PersonalityInsights(String versionDate, IamOptions iamOptions) {
+    this(versionDate);
+    setIamCredentials(iamOptions);
   }
 
   /**

--- a/speech-to-text/src/main/java/com/ibm/watson/developer_cloud/speech_to_text/v1/SpeechToText.java
+++ b/speech-to-text/src/main/java/com/ibm/watson/developer_cloud/speech_to_text/v1/SpeechToText.java
@@ -17,6 +17,7 @@ import com.ibm.watson.developer_cloud.http.InputStreamRequestBody;
 import com.ibm.watson.developer_cloud.http.RequestBuilder;
 import com.ibm.watson.developer_cloud.http.ServiceCall;
 import com.ibm.watson.developer_cloud.service.WatsonService;
+import com.ibm.watson.developer_cloud.service.security.IamOptions;
 import com.ibm.watson.developer_cloud.speech_to_text.v1.model.AcousticModel;
 import com.ibm.watson.developer_cloud.speech_to_text.v1.model.AcousticModels;
 import com.ibm.watson.developer_cloud.speech_to_text.v1.model.AddAudioOptions;
@@ -116,6 +117,18 @@ public class SpeechToText extends WatsonService {
   public SpeechToText(String username, String password) {
     this();
     setUsernameAndPassword(username, password);
+  }
+
+  /**
+   * Instantiates a new `SpeechToText` with IAM. Note that if the access token is specified in the iamOptions,
+   * you accept responsibility for managing the access token yourself. You must set a new access token before this one
+   * expires. Failing to do so will result in authentication errors after this token expires.
+   *
+   * @param iamOptions the options for authenticating through IAM
+   */
+  public SpeechToText(IamOptions iamOptions) {
+    this();
+    setIamCredentials(iamOptions);
   }
 
   /**

--- a/text-to-speech/src/main/java/com/ibm/watson/developer_cloud/text_to_speech/v1/TextToSpeech.java
+++ b/text-to-speech/src/main/java/com/ibm/watson/developer_cloud/text_to_speech/v1/TextToSpeech.java
@@ -16,6 +16,7 @@ import com.google.gson.JsonObject;
 import com.ibm.watson.developer_cloud.http.RequestBuilder;
 import com.ibm.watson.developer_cloud.http.ServiceCall;
 import com.ibm.watson.developer_cloud.service.WatsonService;
+import com.ibm.watson.developer_cloud.service.security.IamOptions;
 import com.ibm.watson.developer_cloud.text_to_speech.v1.model.AddWordOptions;
 import com.ibm.watson.developer_cloud.text_to_speech.v1.model.AddWordsOptions;
 import com.ibm.watson.developer_cloud.text_to_speech.v1.model.CreateVoiceModelOptions;
@@ -85,6 +86,18 @@ public class TextToSpeech extends WatsonService {
   public TextToSpeech(String username, String password) {
     this();
     setUsernameAndPassword(username, password);
+  }
+
+  /**
+   * Instantiates a new `TextToSpeech` with IAM. Note that if the access token is specified in the iamOptions,
+   * you accept responsibility for managing the access token yourself. You must set a new access token before this one
+   * expires. Failing to do so will result in authentication errors after this token expires.
+   *
+   * @param iamOptions the options for authenticating through IAM
+   */
+  public TextToSpeech(IamOptions iamOptions) {
+    this();
+    setIamCredentials(iamOptions);
   }
 
   /**

--- a/tone-analyzer/src/main/java/com/ibm/watson/developer_cloud/tone_analyzer/v3/ToneAnalyzer.java
+++ b/tone-analyzer/src/main/java/com/ibm/watson/developer_cloud/tone_analyzer/v3/ToneAnalyzer.java
@@ -16,6 +16,7 @@ import com.google.gson.JsonObject;
 import com.ibm.watson.developer_cloud.http.RequestBuilder;
 import com.ibm.watson.developer_cloud.http.ServiceCall;
 import com.ibm.watson.developer_cloud.service.WatsonService;
+import com.ibm.watson.developer_cloud.service.security.IamOptions;
 import com.ibm.watson.developer_cloud.tone_analyzer.v3.model.ToneAnalysis;
 import com.ibm.watson.developer_cloud.tone_analyzer.v3.model.ToneChatOptions;
 import com.ibm.watson.developer_cloud.tone_analyzer.v3.model.ToneOptions;
@@ -70,6 +71,20 @@ public class ToneAnalyzer extends WatsonService {
   public ToneAnalyzer(String versionDate, String username, String password) {
     this(versionDate);
     setUsernameAndPassword(username, password);
+  }
+
+  /**
+   * Instantiates a new `ToneAnalyzer` with IAM. Note that if the access token is specified in the iamOptions,
+   * you accept responsibility for managing the access token yourself. You must set a new access token before this one
+   * expires. Failing to do so will result in authentication errors after this token expires.
+   *
+   * @param versionDate The version date (yyyy-MM-dd) of the REST API to use. Specifying this value will keep your API
+   *          calls from failing when the service introduces breaking changes.
+   * @param iamOptions the options for authenticating through IAM
+   */
+  public ToneAnalyzer(String versionDate, IamOptions iamOptions) {
+    this(versionDate);
+    setIamCredentials(iamOptions);
   }
 
   /**

--- a/visual-recognition/src/main/java/com/ibm/watson/developer_cloud/visual_recognition/v3/VisualRecognition.java
+++ b/visual-recognition/src/main/java/com/ibm/watson/developer_cloud/visual_recognition/v3/VisualRecognition.java
@@ -15,6 +15,7 @@ package com.ibm.watson.developer_cloud.visual_recognition.v3;
 import com.ibm.watson.developer_cloud.http.RequestBuilder;
 import com.ibm.watson.developer_cloud.http.ServiceCall;
 import com.ibm.watson.developer_cloud.service.WatsonService;
+import com.ibm.watson.developer_cloud.service.security.IamOptions;
 import com.ibm.watson.developer_cloud.util.RequestUtils;
 import com.ibm.watson.developer_cloud.util.ResponseConverterUtils;
 import com.ibm.watson.developer_cloud.util.Validator;
@@ -99,6 +100,20 @@ public class VisualRecognition extends WatsonService {
       throw new IllegalArgumentException(
           "Credentials need to be specified. Use setApiKey() or setUsernameAndPassword()");
     }
+  }
+
+  /**
+   * Instantiates a new `VisualRecognition` with IAM. Note that if the access token is specified in the iamOptions,
+   * you accept responsibility for managing the access token yourself. You must set a new access token before this one
+   * expires. Failing to do so will result in authentication errors after this token expires.
+   *
+   * @param versionDate The version date (yyyy-MM-dd) of the REST API to use. Specifying this value will keep your API
+   *          calls from failing when the service introduces breaking changes.
+   * @param iamOptions the options for authenticating through IAM
+   */
+  public VisualRecognition(String versionDate, IamOptions iamOptions) {
+    this(versionDate);
+    setIamCredentials(iamOptions);
   }
 
   /**


### PR DESCRIPTION
This PR adds in support for IAM in the core of the SDK. With these changes, users have the option of authenticating with Watson services using IAM tokens, which they can manage themselves or let the new `IamTokenManager` class handle.

Shout out to @dpopp07 for leading the way for this in the Node SDK. Definitely leaned on your changes for my implementation 😉 