### PR TITLE
Add dummy API key when using IAM in Visual Recognition

### DIFF
--- a/core/src/main/java/com/ibm/watson/developer_cloud/service/WatsonService.java
+++ b/core/src/main/java/com/ibm/watson/developer_cloud/service/WatsonService.java
@@ -238,6 +238,15 @@ public abstract class WatsonService {
   }
 
   /**
+   * Checks the status of the tokenManager.
+   *
+   * @return true if the tokenManager has been set
+   */
+  protected boolean isTokenManagerSet() {
+    return tokenManager != null;
+  }
+
+  /**
    * Gets the error message from a JSON response.
    *
    * <pre>

--- a/visual-recognition/src/main/java/com/ibm/watson/developer_cloud/visual_recognition/v3/VisualRecognition.java
+++ b/visual-recognition/src/main/java/com/ibm/watson/developer_cloud/visual_recognition/v3/VisualRecognition.java
@@ -49,6 +49,7 @@ public class VisualRecognition extends WatsonService {
 
   private static final String SERVICE_NAME = "visual_recognition";
   private static final String URL = "https://gateway-a.watsonplatform.net/visual-recognition/api";
+  private static final String DUMMY_API_KEY = "00000";
 
   private String versionDate;
 
@@ -88,17 +89,31 @@ public class VisualRecognition extends WatsonService {
   protected void setAuthentication(okhttp3.Request.Builder builder) {
     if (getUsername() != null && getPassword() != null) {
       super.setAuthentication(builder);
+    } else if (isTokenManagerSet()) {
+      // add dummy API key as a query parameter for backwards-compatibility until it's not required by the service
+      addApiKeyQueryParameter(builder, DUMMY_API_KEY);
+      super.setAuthentication(builder);
     } else if (getApiKey() != null) {
-      final okhttp3.HttpUrl url = okhttp3.HttpUrl.parse(builder.build().url().toString());
-
-      if ((url.query() == null) || url.query().isEmpty()) {
-        builder.url(builder.build().url() + "?api_key=" + getApiKey());
-      } else {
-        builder.url(builder.build().url() + "&api_key=" + getApiKey());
-      }
+      addApiKeyQueryParameter(builder, getApiKey());
     } else {
       throw new IllegalArgumentException(
-          "Credentials need to be specified. Use setApiKey() or setUsernameAndPassword()");
+          "Credentials need to be specified. Use setApiKey(), setIamCredentials(), or setUsernameAndPassword().");
+    }
+  }
+
+  /**
+   * Adds the API key as a query parameter to the request URL.
+   *
+   * @param builder builder for the current request
+   * @param apiKey API key to be added
+   */
+  private void addApiKeyQueryParameter(okhttp3.Request.Builder builder, String apiKey) {
+    final okhttp3.HttpUrl url = okhttp3.HttpUrl.parse(builder.build().url().toString());
+
+    if ((url.query() == null) || url.query().isEmpty()) {
+      builder.url(builder.build().url() + "?api_key=" + apiKey);
+    } else {
+      builder.url(builder.build().url() + "&api_key=" + apiKey);
     }
   }
 


### PR DESCRIPTION
Before the addition of IAM, the only form of authentication in the public Visual Recognition API was through an API key. This API key was then passed as a required query parameter in all of the API endpoints.

With the addition of IAM, authentication is done through a header. However, until the service changes, it will still expect an API key query parameter.

This PR changes the `setAuthentication()` method used specifically for Visual Recognition to add a dummy API key when authenticating through IAM, the idea being that this will prevent the service from complaining while actual authentication is done in the header.

Once the service changes this requirement, this dummy value can be removed.