### PR TITLE
Fix issues with API diff generation

### DIFF
--- a/.utility/generate-api-diff.sh
+++ b/.utility/generate-api-diff.sh
@@ -1,8 +1,8 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Author: Hanbin Cho (mraerok@gmail.com)
 # Description: This script 1) downloads the latest java-sdk jar published in Maven Repo 2) builds the jar of current java-sdk version, then 3) generate an API diff report of the two versions.
 # Assumptions
-# 1. This script is placed in the project root of java-sdk.
+# 1. This script is placed in .utility folder of the java-sdk.
 # 2. Version format is [0-9].[0-9].[0-9]
 
 # Step 1: Download the latest release of java-sdk published in Maven Repository.
@@ -34,7 +34,7 @@ popd
 ./gradlew shadowJar
 
 # Step 5: Construct the filepath to the current version of java-sdk.
-CURRENT_VERSION=`cat gradle.properties | grep "version=[0-9]\.[0-9]\.[0-9]" | cut -d '=' -f 2`
+CURRENT_VERSION=`cat ../gradle.properties | grep "version=[0-9]\.[0-9]\.[0-9]" | cut -d '=' -f 2`
 CURRENT_JAR_FILENAME="java-sdk-${CURRENT_VERSION}-jar-with-dependencies.jar"
 CURRENT_JAR_BASEPATH="java-sdk/build/libs"
 CURRENT_JAR_PATH="${CURRENT_JAR_BASEPATH}/${CURRENT_JAR_FILENAME}"
@@ -46,5 +46,4 @@ if [ ! -f $CURRENT_JAR_PATH ]; then
 fi
 
 # Step 7: Produce an API diff between the latest release and the current version using japicmp module.
-# TODO: Figure out how to set japicmp task's properties (oldClasspath and newClasspath) through command-line invocation.
 ./gradlew japicmp -PoldJarPath="${LATEST_RELEASE_JAR_PATH}" -PnewJarPath="${CURRENT_JAR_PATH}" -PoldJarVersion="${LATEST_RELEASE_VERSION}" -PnewJarVersion="${CURRENT_VERSION}"

--- a/.utility/generate_apidiff_index_html.sh
+++ b/.utility/generate_apidiff_index_html.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 # based on https://odoepner.wordpress.com/2012/02/17/shell-script-to-generate-simple-index-html/
 


### PR DESCRIPTION
Unfortunately, the addition of API diff generation is not working yet. On the latest release, these were the errors thrown in Travis:

![screen shot 2018-06-04 at 11 23 16 am](https://user-images.githubusercontent.com/8710772/40926346-fcd92e4c-67e9-11e8-88fb-44fb05a4bb69.png)

This PR looks to address those to hopefully get things running smoothly.