### PR TITLE
Add deprecation notice for Language Translator v2

### DIFF
--- a/language-translator/README.md
+++ b/language-translator/README.md
@@ -1,5 +1,8 @@
 # Language Translator
 
+## Deprecation notice
+Language Translator v3 is now available. The v2 Language Translator API will no longer be available after July 31, 2018. To take advantage of the latest service enhancements, migrate to the v3 API. View the [Migrating to Language Translator v3](https://console.bluemix.net/docs/services/language-translator/migrating.html) page for more information.
+
 ## Installation
 
 ##### Maven

--- a/language-translator/src/main/java/com/ibm/watson/developer_cloud/language_translator/v2/LanguageTranslator.java
+++ b/language-translator/src/main/java/com/ibm/watson/developer_cloud/language_translator/v2/LanguageTranslator.java
@@ -44,7 +44,11 @@ import okhttp3.RequestBody;
  *
  * @version v2
  * @see <a href="http://www.ibm.com/watson/developercloud/language-translator.html">Language Translator</a>
+ * @deprecated Language Translator v3 is now available. The v2 Language Translator API will no longer be available
+ * after July 31, 2018. To take advantage of the latest service enhancements, migrate to the v3 API. View the
+ * following page for more information: https://console.bluemix.net/docs/services/language-translator/migrating.html).
  */
+@Deprecated
 public class LanguageTranslator extends WatsonService {
 
   private static final String SERVICE_NAME = "language_translator";


### PR DESCRIPTION
This PR adds a deprecation notice both in the Language Translator v2 class and in the service README.