### PR TITLE
Semantic release

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,6 @@
 [bumpversion]
 current_version = 6.1.0
+commit = True
 
 [bumpversion:file:README.md]
 

--- a/.releaserc
+++ b/.releaserc
@@ -1,7 +1,13 @@
 {
   "branch": "master",
+  "tagFormat": "java-sdk-${version}",
   "verifyConditions": [],
-  "prepare": [],
+  "prepare": [
+    {
+      "path": "@semantic-release/exec",
+      "cmd": "bumpversion --current-version ${lastRelease.version} --new-version ${nextRelease.version} patch"
+    }
+  ],
   "publish": [
     {
       "path": "@semantic-release/github",

--- a/.releaserc
+++ b/.releaserc
@@ -1,0 +1,13 @@
+{
+  "branch": "master",
+  "verifyConditions": [],
+  "prepare": [],
+  "publish": [
+    {
+      "path": "@semantic-release/github",
+      "assets": [
+        {"path": "java-sdk/build/libs/java-sdk-*-jar-with-dependencies.txt", "label": "Release JAR"}
+      ]
+    }
+  ]
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ before_install:
   - sed -i.bak -e 's|https://nexus.codehaus.org/snapshots/|https://oss.sonatype.org/content/repositories/codehaus-snapshots/|g' ~/.m2/settings.xml
   - sudo apt-get update
   - sudo apt-get install python
+  - nvm use node
 
 install:
   - pip install --user bumpversion

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,7 @@ script:
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)
+  - npx semantic-release
 
 deploy:
   - provider: script
@@ -56,13 +57,5 @@ deploy:
       repo: watson-developer-cloud/java-sdk
       jdk: oraclejdk7
 
-  - provider: releases
-    api_key: ${GITHUB_TOKEN_RELEASES}
-    file: java-sdk/build/libs/${TRAVIS_BRANCH}-jar-with-dependencies.jar
-    skip_cleanup: true
-    on:
-      repo: watson-developer-cloud/java-sdk
-      jdk: oraclejdk7
-      tags: true
 notifications:
   email: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,8 @@ before_install:
   - sed -i.bak -e 's|https://nexus.codehaus.org/snapshots/|https://oss.sonatype.org/content/repositories/codehaus-snapshots/|g' ~/.m2/settings.xml
   - sudo apt-get update
   - sudo apt-get install python
+  - npm install npm@latest -g
+  - nvm install node
   - nvm use node
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,10 +24,14 @@ env:
   - secure: eLv41LVZoRCqQehOM29RLodZ6NZhrIdLWklAkMdLGlFDEiVY5f0shaPLffpUiuv/3pg+CuQk9ffBc72m8lwTsimex9unC/WVsqQJhqQEWJEaPGL0UamV/HqHMeBQEpKiCcKHaBRHFGk7QQJVtiXvVvlbwk7Jks5giUR7+s/Q6iI=
   - secure: l0dde5NSGedD6fny5aMr1ll90FYVd7IKDsZ0Kd1GWnB+iDd3rjDBwz5q6NUwN2LTqw3jWFqmqdEnGUGO3Er0rdfdtPh3K194sTK3XuCZz8GEjFvYAEDRQ59oyK8fhw60c86cWppBQ4gluLKLstm12DLkARTUvJiIsTQTnuc2YGg=
 
-install: true
-
 before_install:
   - sed -i.bak -e 's|https://nexus.codehaus.org/snapshots/|https://oss.sonatype.org/content/repositories/codehaus-snapshots/|g' ~/.m2/settings.xml
+  - sudo apt-get update
+  - sudo apt-get install python
+
+install:
+  - pip install --user bumpversion
+  - npm install @semantic-release/exec
 
 script:
   - '[ "${TRAVIS_PULL_REQUEST}" = "false" ] && openssl aes-256-cbc -K $encrypted_b248e84a4806_key -iv $encrypted_b248e84a4806_iv -in config.properties.enc -out core/src/test/resources/config.properties -d || true'
@@ -39,7 +43,6 @@ script:
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)
-  - npx semantic-release
 
 deploy:
   - provider: script
@@ -53,6 +56,13 @@ deploy:
   - provider: script
     script: .utility/deploy.sh
     skip_cleanup: true
+    on:
+      repo: watson-developer-cloud/java-sdk
+      jdk: oraclejdk7
+
+  - provider: script
+    skip_cleanup: true
+    script: npx travis-deploy-once "npx semantic-release"
     on:
       repo: watson-developer-cloud/java-sdk
       jdk: oraclejdk7

--- a/.utility/deploy.sh
+++ b/.utility/deploy.sh
@@ -2,6 +2,6 @@
 
 if [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_BRANCH" == "master" ]; then
   openssl aes-256-cbc -K $encrypted_2a8b0f951653_key -iv $encrypted_2a8b0f951653_iv -in .utility/cd/secring.gpg.enc -out .utility/cd/secring.gpg -d
-  ./gradlew uploadArchives -Psigning.keyId=$SIGNING_KEY -Psigning.password=$SIGNING_PASSWORD -Psigning.secretKeyRingFile=$KEYRING_PATH
-  ./gradlew closeAndReleaseRepository -PossrhUsername=$OSSRH_JIRA_USERNAME -PossrhPassword=$OSSRH_JIRA_PASSWORD
+  ./gradlew uploadArchives -Psigning.keyId=$SIGNING_KEY -Psigning.password=$SIGNING_PASSWORD -Psigning.secretKeyRingFile=$KEYRING_PATH -PossrhUsername=$OSSRH_JIRA_USERNAME -PossrhPassword=$OSSRH_JIRA_PASSWORD
+  ./gradlew release
 fi

--- a/.utility/deploy.sh
+++ b/.utility/deploy.sh
@@ -2,5 +2,6 @@
 
 if [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_BRANCH" == "master" ]; then
   openssl aes-256-cbc -K $encrypted_2a8b0f951653_key -iv $encrypted_2a8b0f951653_iv -in .utility/cd/secring.gpg.enc -out .utility/cd/secring.gpg -d
-  ./gradlew uploadArchives -Psigning.keyId=$SIGNING_KEY -Psigning.password=$SIGNING_PASSWORD -Psigning.secretKeyRingFile=$KEYRING_PATH -PossrhUsername=$OSSRH_JIRA_USERNAME -PossrhPassword=$OSSRH_JIRA_PASSWORD
+  ./gradlew uploadArchives -Psigning.keyId=$SIGNING_KEY -Psigning.password=$SIGNING_PASSWORD -Psigning.secretKeyRingFile=$KEYRING_PATH
+  ./gradlew closeAndReleaseRepository -PossrhUsername=$OSSRH_JIRA_USERNAME -PossrhPassword=$OSSRH_JIRA_PASSWORD
 fi

--- a/build.gradle
+++ b/build.gradle
@@ -62,6 +62,7 @@ allprojects {
 subprojects {
 
   dependencies {
+    compile 'org.codehaus.groovy.modules.http-builder:http-builder:0.7.1'
     testCompile group: 'com.squareup.okhttp3', name: 'mockwebserver', version: '3.8.0'
     testCompile group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.3'
     testCompile group: 'com.google.guava', name: 'guava', version: '20.0'

--- a/build.gradle
+++ b/build.gradle
@@ -62,7 +62,7 @@ allprojects {
 subprojects {
 
   dependencies {
-    compile 'org.codehaus.groovy.modules.http-builder:http-builder:0.7.1'
+    compile group: 'org.codehaus.groovy.modules.http-builder', name: 'http-builder', version: '0.7.1'
     testCompile group: 'com.squareup.okhttp3', name: 'mockwebserver', version: '3.8.0'
     testCompile group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.3'
     testCompile group: 'com.google.guava', name: 'guava', version: '20.0'

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id 'io.codearte.nexus-staging' version '0.11.0'
+  id 'net.researchgate.release' version '2.4.0'
   id 'me.champeau.gradle.japicmp' version '0.2.6'
 }
 
@@ -12,10 +12,6 @@ apply plugin: 'idea'
 archivesBaseName = 'parent'
 
 description = 'Client library to use the IBM Watson and Alchemy Services'
-
-nexusStaging {
-  stagingProfileId = "127ae59093cb28"
-}
 
 javadoc {
   source = 'src/main/java'
@@ -62,7 +58,6 @@ allprojects {
 subprojects {
 
   dependencies {
-    compile group: 'org.codehaus.groovy.modules.http-builder', name: 'http-builder', version: '0.7.1'
     testCompile group: 'com.squareup.okhttp3', name: 'mockwebserver', version: '3.8.0'
     testCompile group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.3'
     testCompile group: 'com.google.guava', name: 'guava', version: '20.0'
@@ -132,12 +127,6 @@ task startmessage {
   }
 }
 
-task printversion {
-  doLast {
-    println project.version
-  }
-}
-
 task japicmp(type: me.champeau.gradle.japicmp.JapicmpTask) {
     ext.oldJarVersion = project.hasProperty('oldJarVersion') ? project.getProperty('oldJarVersion') : "pass-in-older-jar-version"
     ext.newJarVersion = project.hasProperty('newJarVersion') ? project.getProperty('newJarVersion') : "pass-in-newer-jar-version"
@@ -152,3 +141,5 @@ task japicmp(type: me.champeau.gradle.japicmp.JapicmpTask) {
 
     htmlOutputFile = file("$buildDir/reports/java-sdk-api-diff-" + oldJarVersion + "-to-" + newJarVersion + ".html")
 }
+
+beforeReleaseBuild.dependsOn startmessage

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id 'net.researchgate.release' version '2.4.0'
+  id 'io.codearte.nexus-staging' version '0.11.0'
   id 'me.champeau.gradle.japicmp' version '0.2.6'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -121,6 +121,10 @@ task testReport(type: TestReport) {
   reportOn subprojects*.test
 }
 
+release {
+    tagTemplate = 'java-sdk-$version'
+}
+
 task startmessage {
   doLast {
     println 'starting build'

--- a/build.gradle
+++ b/build.gradle
@@ -9,11 +9,13 @@ apply plugin: 'checkstyle'
 apply plugin: 'eclipse'
 apply plugin: 'idea'
 
-import org.apache.tools.ant.filters.*
-
 archivesBaseName = 'parent'
 
 description = 'Client library to use the IBM Watson and Alchemy Services'
+
+nexusStaging {
+  stagingProfileId = "127ae59093cb28"
+}
 
 javadoc {
   source = 'src/main/java'
@@ -123,10 +125,6 @@ task testReport(type: TestReport) {
   reportOn subprojects*.test
 }
 
-release {
-  tagTemplate = 'java-sdk-$version'
-}
-
 task startmessage {
   doLast {
     println 'starting build'
@@ -153,6 +151,3 @@ task japicmp(type: me.champeau.gradle.japicmp.JapicmpTask) {
 
     htmlOutputFile = file("$buildDir/reports/java-sdk-api-diff-" + oldJarVersion + "-to-" + newJarVersion + ".html")
 }
-
-beforeReleaseBuild.dependsOn startmessage
-afterReleaseBuild.dependsOn printversion


### PR DESCRIPTION
This PR adds `semantic-release` to the build process to update version numbers, release to GitHub, and create a changelog after successful to `master`.

The `./gradlew release` command has also been moved to the deployment script in Travis. The goal of these changes is that releasing the SDK will only require:
1. Merging a PR into `master`
2. Going to the Sonatype website and releasing the repository