### PR TITLE
Add CF token deprecation messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,8 @@ Watson services are migrating to token-based Identity and Access Management (IAM
 - In other instances, you authenticate by providing the **[username and password](#username-and-password)** for the service instance.
 - Visual Recognition uses a form of [API key](#api-key) only with instances created before May 23, 2018. Newer instances of Visual Recognition use [IAM](#iam).
 
+**Note:** Previously, it was possible to authenticate using a token in a header called `X-Watson-Authorization-Token`. This method is deprecated. The token continues to work with Cloud Foundry services, but is not supported for services that use Identity and Access Management (IAM) authentication. See [here](#iam) for details.
+
 ### Getting credentials
 To find out which authentication to use, view the service credentials. You find the service credentials for authentication the same way for all Watson services:
 

--- a/core/src/main/java/com/ibm/watson/developer_cloud/service/WatsonService.java
+++ b/core/src/main/java/com/ibm/watson/developer_cloud/service/WatsonService.java
@@ -70,6 +70,10 @@ public abstract class WatsonService {
   private static final String BASIC = "Basic ";
   private static final String BEARER = "Bearer ";
   private static final Logger LOG = Logger.getLogger(WatsonService.class.getName());
+  private static final String AUTH_HEADER_DEPRECATION_MESSAGE = "Authenticating with the X-Watson-Authorization-Token"
+      + "header is deprecated. The token continues to work with Cloud Foundry services, but is not supported for "
+      + "services that use Identity and Access Management (IAM) authentication. For details see the IAM "
+      + "authentication section in the README.";
   private String apiKey;
   private String username;
   private String password;
@@ -311,7 +315,11 @@ public abstract class WatsonService {
       builder.addHeader(HttpHeaders.AUTHORIZATION, BEARER + accessToken);
     } else if (getApiKey() == null) {
       if (skipAuthentication) {
-        return; // chosen to skip authentication with the service
+        Headers currentHeaders = builder.build().headers();
+        if (currentHeaders.get(HttpHeaders.X_WATSON_AUTHORIZATION_TOKEN) != null) {
+          LOG.warning(AUTH_HEADER_DEPRECATION_MESSAGE);
+        }
+        return;
       }
       throw new IllegalArgumentException("apiKey or username and password were not specified");
     } else {


### PR DESCRIPTION
This PR adds a deprecation message in the README as well as in the code where it would be encountered, which is only in the case that the user uses the `X-Watson-Authorization-Token` while also skipping authentication with the other methods.