### PR TITLE
Handle username and password authentication with "apikey"

### DIFF
--- a/core/src/main/java/com/ibm/watson/developer_cloud/service/WatsonService.java
+++ b/core/src/main/java/com/ibm/watson/developer_cloud/service/WatsonService.java
@@ -349,9 +349,16 @@ public abstract class WatsonService {
    * @param password the password
    */
   public void setUsernameAndPassword(final String username, final String password) {
-    this.username = username;
-    this.password = password;
-    apiKey = Credentials.basic(username, password);
+    if (username.equals("apikey")) {
+      IamOptions iamOptions = new IamOptions.Builder()
+          .apiKey(password)
+          .build();
+      setIamCredentials(iamOptions);
+    } else {
+      this.username = username;
+      this.password = password;
+      apiKey = Credentials.basic(username, password);
+    }
   }
 
   /**

--- a/core/src/main/java/com/ibm/watson/developer_cloud/service/WatsonService.java
+++ b/core/src/main/java/com/ibm/watson/developer_cloud/service/WatsonService.java
@@ -69,6 +69,7 @@ public abstract class WatsonService {
   private static final String MESSAGE_ERROR_2 = "error_message";
   private static final String BASIC = "Basic ";
   private static final String BEARER = "Bearer ";
+  private static final String APIKEY_AS_USERNAME = "apikey";
   private static final Logger LOG = Logger.getLogger(WatsonService.class.getName());
   private static final String AUTH_HEADER_DEPRECATION_MESSAGE = "Authenticating with the X-Watson-Authorization-Token"
       + "header is deprecated. The token continues to work with Cloud Foundry services, but is not supported for "
@@ -349,7 +350,7 @@ public abstract class WatsonService {
    * @param password the password
    */
   public void setUsernameAndPassword(final String username, final String password) {
-    if (username.equals("apikey")) {
+    if (username.equals(APIKEY_AS_USERNAME)) {
       IamOptions iamOptions = new IamOptions.Builder()
           .apiKey(password)
           .build();

--- a/core/src/test/java/com/ibm/watson/developer_cloud/service/AuthenticationTest.java
+++ b/core/src/test/java/com/ibm/watson/developer_cloud/service/AuthenticationTest.java
@@ -1,0 +1,24 @@
+package com.ibm.watson.developer_cloud.service;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+public class AuthenticationTest {
+  private static final String APIKEY = "12345";
+
+  public class TestService extends WatsonService {
+    private static final String SERVICE_NAME = "test";
+
+    public TestService() {
+      super(SERVICE_NAME);
+    }
+  }
+
+  @Test
+  public void authenticateWithApiKeyAsUsername() {
+    TestService service = new TestService();
+    service.setUsernameAndPassword("apikey", APIKEY);
+    assertTrue(service.isTokenManagerSet());
+  }
+}


### PR DESCRIPTION
This PR handles the case where the user authenticates with a username and password in the following manner:
```
username: "apikey"
password: "<iam_apikey>"
```
The SDK now recognizes this and automatically creates an IAM token manager instance to handle it.