### PR TITLE
Add support for more concurrent WebSocket connections

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 6.4.0
+current_version = 6.5.0
 commit = True
 message = docs: Update version numbers from {current_version} -> {new_version}
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ All the services:
 <dependency>
 	<groupId>com.ibm.watson.developer_cloud</groupId>
 	<artifactId>java-sdk</artifactId>
-	<version>6.4.0</version>
+	<version>6.5.0</version>
 </dependency>
 ```
 
@@ -70,7 +70,7 @@ Only Discovery:
 <dependency>
 	<groupId>com.ibm.watson.developer_cloud</groupId>
 	<artifactId>discovery</artifactId>
-	<version>6.4.0</version>
+	<version>6.5.0</version>
 </dependency>
 ```
 
@@ -79,13 +79,13 @@ Only Discovery:
 All the services:
 
 ```gradle
-'com.ibm.watson.developer_cloud:java-sdk:6.4.0'
+'com.ibm.watson.developer_cloud:java-sdk:6.5.0'
 ```
 
 Only Assistant:
 
 ```gradle
-'com.ibm.watson.developer_cloud:assistant:6.4.0'
+'com.ibm.watson.developer_cloud:assistant:6.5.0'
 ```
 
 ##### Development snapshots
@@ -108,7 +108,7 @@ And then reference the snapshot version on your app module gradle
 Only Speech to Text:
 
 ```gradle
-'com.ibm.watson.developer_cloud:speech-to-text:6.4.1-SNAPSHOT'
+'com.ibm.watson.developer_cloud:speech-to-text:6.5.1-SNAPSHOT'
 ```
 
 ##### JAR
@@ -375,7 +375,7 @@ Gradle:
 
 ```sh
 cd java-sdk
-gradle jar  # build jar file (build/libs/watson-developer-cloud-6.4.0.jar)
+gradle jar  # build jar file (build/libs/watson-developer-cloud-6.5.0.jar)
 gradle test # run tests
 gradle check # performs quality checks on source files and generates reports
 gradle testReport # run tests and generate the aggregated test report (build/reports/allTests)
@@ -428,4 +428,4 @@ or [Stack Overflow](http://stackoverflow.com/questions/ask?tags=ibm-watson).
 [ibm-cloud-onboarding]: http://console.bluemix.net/registration?target=/developer/watson&cm_sp=WatsonPlatform-WatsonServices-_-OnPageNavLink-IBMWatson_SDKs-_-Java
 
 
-[jar]: https://github.com/watson-developer-cloud/java-sdk/releases/download/java-sdk-6.4.0/java-sdk-6.4.0-jar-with-dependencies.jar
+[jar]: https://github.com/watson-developer-cloud/java-sdk/releases/download/java-sdk-6.5.0/java-sdk-6.5.0-jar-with-dependencies.jar

--- a/assistant/README.md
+++ b/assistant/README.md
@@ -7,13 +7,13 @@
 <dependency>
   <groupId>com.ibm.watson.developer_cloud</groupId>
   <artifactId>assistant</artifactId>
-  <version>6.4.0</version>
+  <version>6.5.0</version>
 </dependency>
 ```
 
 ##### Gradle
 ```gradle
-'com.ibm.watson.developer_cloud:assistant:6.4.0'
+'com.ibm.watson.developer_cloud:assistant:6.5.0'
 ```
 
 ## Usage

--- a/assistant/build.gradle
+++ b/assistant/build.gradle
@@ -25,7 +25,7 @@ task sourcesJar(type: Jar) {
 }
 
 repositories {
-    mavenCentral()
+    maven { url = "http://repo.maven.apache.org/maven2" }
 }
 
 artifacts {

--- a/build.gradle
+++ b/build.gradle
@@ -58,7 +58,7 @@ allprojects {
 subprojects {
 
   dependencies {
-    testCompile group: 'com.squareup.okhttp3', name: 'mockwebserver', version: '3.8.0'
+    testCompile group: 'com.squareup.okhttp3', name: 'mockwebserver', version: '3.11.0'
     testCompile group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.3'
     testCompile group: 'com.google.guava', name: 'guava', version: '20.0'
     testCompile group: 'junit', name: 'junit', version: '4.12'

--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,7 @@ allprojects {
   targetCompatibility = JavaVersion.VERSION_1_7
 
   repositories {
-    mavenCentral()
+      maven { url = "http://repo.maven.apache.org/maven2" }
   }
 }
 

--- a/conversation/README.md
+++ b/conversation/README.md
@@ -7,13 +7,13 @@
 <dependency>
   <groupId>com.ibm.watson.developer_cloud</groupId>
   <artifactId>conversation</artifactId>
-  <version>6.4.0</version>
+  <version>6.5.0</version>
 </dependency>
 ```
 
 ##### Gradle
 ```gradle
-'com.ibm.watson.developer_cloud:conversation:6.4.0'
+'com.ibm.watson.developer_cloud:conversation:6.5.0'
 ```
 
 ## Usage

--- a/conversation/build.gradle
+++ b/conversation/build.gradle
@@ -25,7 +25,7 @@ task sourcesJar(type: Jar) {
 }
 
 repositories {
-    mavenCentral()
+    maven { url = "http://repo.maven.apache.org/maven2" }
 }
 
 artifacts {

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -69,9 +69,9 @@ checkstyle {
   }
 
 dependencies {
-    compile group: 'com.squareup.okhttp3', name: 'okhttp', version: '3.8.0'
-    compile group: 'com.squareup.okhttp3', name: 'logging-interceptor', version: '3.8.0'
-    compile group: 'com.squareup.okhttp3', name: 'okhttp-urlconnection', version: '3.8.0'
+    compile group: 'com.squareup.okhttp3', name: 'okhttp', version: '3.11.0'
+    compile group: 'com.squareup.okhttp3', name: 'logging-interceptor', version: '3.11.0'
+    compile group: 'com.squareup.okhttp3', name: 'okhttp-urlconnection', version: '3.11.0'
     compile group: 'com.google.code.gson', name: 'gson', version: '2.8.0'
     compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.5'
     compile group: 'org.glassfish.jersey.bundles.repackaged', name: 'jersey-jsr166e', version: '2.25.1'

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -25,7 +25,7 @@ task javadocJar(type: Jar, dependsOn: javadoc) {
 }
 
 repositories {
-    mavenCentral()
+    maven { url = "http://repo.maven.apache.org/maven2" }
 }
 
 artifacts {

--- a/discovery/README.md
+++ b/discovery/README.md
@@ -7,13 +7,13 @@
 <dependency>
   <groupId>com.ibm.watson.developer_cloud</groupId>
   <artifactId>discovery</artifactId>
-  <version>6.4.0</version>
+  <version>6.5.0</version>
 </dependency>
 ```
 
 ##### Gradle
 ```gradle
-'com.ibm.watson.developer_cloud:discovery:6.4.0'
+'com.ibm.watson.developer_cloud:discovery:6.5.0'
 ```
 
 ## Usage

--- a/discovery/build.gradle
+++ b/discovery/build.gradle
@@ -25,7 +25,7 @@ task javadocJar(type: Jar, dependsOn: javadoc) {
 }
 
 repositories {
-    mavenCentral()
+    maven { url = "http://repo.maven.apache.org/maven2" }
 }
 
 artifacts {

--- a/discovery/src/test/java/com/ibm/watson/developer_cloud/discovery/v1/DiscoveryServiceTest.java
+++ b/discovery/src/test/java/com/ibm/watson/developer_cloud/discovery/v1/DiscoveryServiceTest.java
@@ -142,11 +142,11 @@ public class DiscoveryServiceTest extends WatsonServiceUnitTest {
       + VERSION;
   private static final String Q1_PATH = "/v1/environments/mock_envid/collections/mock_collid/query?version="
       + VERSION
-      + "&filter=field:1"
-      + "&query=field:1&count=5&return=field&offset=5";
+      + "&filter=field%3A1&query=field%3A1&count=5&return=field&offset=5"
+      + "&similar=true&similar.document_ids=doc1%2Cdoc2&similar.fields=field1%2Cfield2";
   private static final String Q2_PATH = "/v1/environments/mock_envid/collections/mock_collid/query?version="
       + VERSION
-      + "&aggregation=term(field)";
+      + "&aggregation=term%28field%29";
   private static final String Q3_PATH = "/v1/environments/mock_envid/query?version="
       + VERSION + "&collection_ids=mock_collid";
   private static final String Q4_PATH = "/v1/environments/mock_envid/notices?version="
@@ -720,8 +720,7 @@ public class DiscoveryServiceTest extends WatsonServiceUnitTest {
     QueryResponse response = discoveryService.query(queryBuilder.build()).execute();
     RecordedRequest request = server.takeRequest();
 
-    assertEquals(Q1_PATH + "&similar=true&similar.document_ids=doc1,doc2&similar.fields=field1,field2",
-        request.getPath());
+    assertEquals(Q1_PATH, request.getPath());
     assertEquals(GET, request.getMethod());
     assertEquals(GsonSingleton.getGson().toJsonTree(queryResp), GsonSingleton.getGson().toJsonTree(response));
   }

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -20,7 +20,7 @@ task javadocJar(type: Jar, dependsOn: javadoc) {
 }
 
 repositories {
-    mavenCentral()
+    maven { url = "http://repo.maven.apache.org/maven2" }
 }
 
 artifacts {

--- a/java-sdk/build.gradle
+++ b/java-sdk/build.gradle
@@ -32,7 +32,7 @@ task javadocJar(type: Jar, dependsOn: javadoc) {
 }
 
 repositories {
-    mavenCentral()
+    maven { url = "http://repo.maven.apache.org/maven2" }
 }
 
 artifacts {

--- a/language-translator/README.md
+++ b/language-translator/README.md
@@ -10,13 +10,13 @@ Language Translator v3 is now available. The v2 Language Translator API will no 
 <dependency>
   <groupId>com.ibm.watson.developer_cloud</groupId>
   <artifactId>language-translator</artifactId>
-  <version>6.4.0</version>
+  <version>6.5.0</version>
 </dependency>
 ```
 
 ##### Gradle
 ```gradle
-'com.ibm.watson.developer_cloud:language-translator:6.4.0'
+'com.ibm.watson.developer_cloud:language-translator:6.5.0'
 ```
 
 ## Usage

--- a/language-translator/build.gradle
+++ b/language-translator/build.gradle
@@ -25,7 +25,7 @@ task javadocJar(type: Jar, dependsOn: javadoc) {
 }
 
 repositories {
-    mavenCentral()
+    maven { url = "http://repo.maven.apache.org/maven2" }
 }
 
 artifacts {

--- a/natural-language-classifier/README.md
+++ b/natural-language-classifier/README.md
@@ -7,13 +7,13 @@
 <dependency>
   <groupId>com.ibm.watson.developer_cloud</groupId>
   <artifactId>natural-language-classifier</artifactId>
-  <version>6.4.0</version>
+  <version>6.5.0</version>
 </dependency>
 ```
 
 ##### Gradle
 ```gradle
-'com.ibm.watson.developer_cloud:natural-language-classifier:6.4.0'
+'com.ibm.watson.developer_cloud:natural-language-classifier:6.5.0'
 ```
 
 ## Usage

--- a/natural-language-classifier/build.gradle
+++ b/natural-language-classifier/build.gradle
@@ -25,7 +25,7 @@ task javadocJar(type: Jar, dependsOn: javadoc) {
 }
 
 repositories {
-    mavenCentral()
+    maven { url = "http://repo.maven.apache.org/maven2" }
 }
 
 artifacts {

--- a/natural-language-understanding/README.md
+++ b/natural-language-understanding/README.md
@@ -7,13 +7,13 @@
 <dependency>
   <groupId>com.ibm.watson.developer_cloud</groupId>
   <artifactId>natural-language-understanding</artifactId>
-  <version>6.4.0</version>
+  <version>6.5.0</version>
 </dependency>
 ```
 
 ##### Gradle
 ```gradle
-'com.ibm.watson.developer_cloud:natural-language-understanding:6.4.0'
+'com.ibm.watson.developer_cloud:natural-language-understanding:6.5.0'
 ```
 
 ## Usage

--- a/natural-language-understanding/build.gradle
+++ b/natural-language-understanding/build.gradle
@@ -25,7 +25,7 @@ task javadocJar(type: Jar, dependsOn: javadoc) {
 }
 
 repositories {
-    mavenCentral()
+    maven { url = "http://repo.maven.apache.org/maven2" }
 }
 
 artifacts {

--- a/personality-insights/README.md
+++ b/personality-insights/README.md
@@ -7,13 +7,13 @@
 <dependency>
   <groupId>com.ibm.watson.developer_cloud</groupId>
   <artifactId>personality-insights</artifactId>
-  <version>6.4.0</version>
+  <version>6.5.0</version>
 </dependency>
 ```
 
 ##### Gradle
 ```gradle
-'com.ibm.watson.developer_cloud:personality-insights:6.4.0'
+'com.ibm.watson.developer_cloud:personality-insights:6.5.0'
 ```
 
 ## Usage

--- a/personality-insights/build.gradle
+++ b/personality-insights/build.gradle
@@ -25,7 +25,7 @@ task javadocJar(type: Jar, dependsOn: javadoc) {
 }
 
 repositories {
-    mavenCentral()
+    maven { url = "http://repo.maven.apache.org/maven2" }
 }
 
 artifacts {

--- a/speech-to-text/README.md
+++ b/speech-to-text/README.md
@@ -7,13 +7,13 @@
 <dependency>
   <groupId>com.ibm.watson.developer_cloud</groupId>
   <artifactId>speech-to-text</artifactId>
-  <version>6.4.0</version>
+  <version>6.5.0</version>
 </dependency>
 ```
 
 ##### Gradle
 ```gradle
-'com.ibm.watson.developer_cloud:speech-to-text:6.4.0'
+'com.ibm.watson.developer_cloud:speech-to-text:6.5.0'
 ```
 
 ## Usage

--- a/speech-to-text/build.gradle
+++ b/speech-to-text/build.gradle
@@ -25,7 +25,7 @@ task javadocJar(type: Jar, dependsOn: javadoc) {
 }
 
 repositories {
-    mavenCentral()
+    maven { url = "http://repo.maven.apache.org/maven2" }
 }
 
 artifacts {

--- a/speech-to-text/src/main/java/com/ibm/watson/developer_cloud/speech_to_text/v1/model/RecognizeOptions.java
+++ b/speech-to-text/src/main/java/com/ibm/watson/developer_cloud/speech_to_text/v1/model/RecognizeOptions.java
@@ -117,6 +117,7 @@ public class RecognizeOptions extends GenericModel {
   private Boolean profanityFilter;
   private Boolean smartFormatting;
   private Boolean speakerLabels;
+  private Boolean interimResults;
 
   /**
    * Builder.
@@ -139,6 +140,7 @@ public class RecognizeOptions extends GenericModel {
     private Boolean profanityFilter;
     private Boolean smartFormatting;
     private Boolean speakerLabels;
+    private Boolean interimResults;
 
     private Builder(RecognizeOptions recognizeOptions) {
       audio = recognizeOptions.audio;
@@ -158,6 +160,7 @@ public class RecognizeOptions extends GenericModel {
       profanityFilter = recognizeOptions.profanityFilter;
       smartFormatting = recognizeOptions.smartFormatting;
       speakerLabels = recognizeOptions.speakerLabels;
+      interimResults = recognizeOptions.interimResults;
     }
 
     /**
@@ -379,6 +382,19 @@ public class RecognizeOptions extends GenericModel {
     }
 
     /**
+     * Set the interimResults.
+     *
+     * NOTE: This parameter only works for the `recognizeUsingWebSocket` method.
+     *
+     * @param interimResults the interimResults
+     * @return the interimResults
+     */
+    public Builder interimResults(Boolean interimResults) {
+      this.interimResults = interimResults;
+      return this;
+    }
+
+    /**
      * Set the audio.
      *
      * @param audio the audio
@@ -411,6 +427,7 @@ public class RecognizeOptions extends GenericModel {
     profanityFilter = builder.profanityFilter;
     smartFormatting = builder.smartFormatting;
     speakerLabels = builder.speakerLabels;
+    interimResults = builder.interimResults;
   }
 
   /**
@@ -649,5 +666,19 @@ public class RecognizeOptions extends GenericModel {
    */
   public Boolean speakerLabels() {
     return speakerLabels;
+  }
+
+  /**
+   * Gets the interimResults.
+   *
+   * If `true`, the service returns interim results as a stream of `SpeechRecognitionResults` objects. By default,
+   * the service returns a single `SpeechRecognitionResults` object with final results only.
+   *
+   * NOTE: This parameter only works for the `recognizeUsingWebSocket` method.
+   *
+   * @return the interimResults
+   */
+  public Boolean interimResults() {
+    return interimResults;
   }
 }

--- a/speech-to-text/src/test/java/com/ibm/watson/developer_cloud/speech_to_text/v1/SpeechToTextTest.java
+++ b/speech-to-text/src/test/java/com/ibm/watson/developer_cloud/speech_to_text/v1/SpeechToTextTest.java
@@ -72,6 +72,7 @@ import com.ibm.watson.developer_cloud.speech_to_text.v1.model.Words;
 import com.ibm.watson.developer_cloud.speech_to_text.v1.util.MediaTypeUtils;
 import com.ibm.watson.developer_cloud.speech_to_text.v1.websocket.RecognizeCallback;
 import com.ibm.watson.developer_cloud.util.GsonSingleton;
+import com.ibm.watson.developer_cloud.util.RequestUtils;
 import com.ibm.watson.developer_cloud.util.TestUtils;
 import okhttp3.WebSocket;
 import okhttp3.internal.ws.WebSocketRecorder;
@@ -474,7 +475,7 @@ public class SpeechToTextTest extends WatsonServiceUnitTest {
         + "&base_model_version=" + version
         + "&customization_weight=" + customizationWeight
         + "&inactivity_timeout=" + inactivityTimeout
-        + "&keywords=" + StringUtils.join(keywords, ',')
+        + "&keywords=" + RequestUtils.encode(StringUtils.join(keywords, ','))
         + "&keywords_threshold=" + keywordsThreshold
         + "&word_confidence=" + wordConfidence
         + "&timestamps=" + timestamps
@@ -1302,7 +1303,8 @@ public class SpeechToTextTest extends WatsonServiceUnitTest {
     final RecordedRequest registerRequest = server.takeRequest();
 
     assertEquals("POST", registerRequest.getMethod());
-    assertEquals(String.format(REGISTER_CALLBACK, callbackUrl, secret), registerRequest.getPath());
+    assertEquals(String.format(REGISTER_CALLBACK, RequestUtils.encode(callbackUrl), RequestUtils.encode(secret)),
+        registerRequest.getPath());
     assertEquals(RegisterStatus.Status.CREATED, result.getStatus());
     assertEquals(callbackUrl, result.getUrl());
   }
@@ -1319,7 +1321,7 @@ public class SpeechToTextTest extends WatsonServiceUnitTest {
     final RecordedRequest unregisterRequest = server.takeRequest();
 
     assertEquals("POST", unregisterRequest.getMethod());
-    assertEquals(String.format(UNREGISTER_CALLBACK, callbackUrl), unregisterRequest.getPath());
+    assertEquals(String.format(UNREGISTER_CALLBACK, RequestUtils.encode(callbackUrl)), unregisterRequest.getPath());
   }
 
   @Test

--- a/text-to-speech/README.md
+++ b/text-to-speech/README.md
@@ -7,13 +7,13 @@
 <dependency>
   <groupId>com.ibm.watson.developer_cloud</groupId>
   <artifactId>text-to-speech</artifactId>
-  <version>6.4.0</version>
+  <version>6.5.0</version>
 </dependency>
 ```
 
 ##### Gradle
 ```gradle
-'com.ibm.watson.developer_cloud:text-to-speech:6.4.0'
+'com.ibm.watson.developer_cloud:text-to-speech:6.5.0'
 ```
 
 ## Usage

--- a/text-to-speech/build.gradle
+++ b/text-to-speech/build.gradle
@@ -25,7 +25,7 @@ task javadocJar(type: Jar, dependsOn: javadoc) {
 }
 
 repositories {
-    mavenCentral()
+    maven { url = "http://repo.maven.apache.org/maven2" }
 }
 
 artifacts {

--- a/tone-analyzer/README.md
+++ b/tone-analyzer/README.md
@@ -7,13 +7,13 @@
 <dependency>
   <groupId>com.ibm.watson.developer_cloud</groupId>
   <artifactId>tone-analyzer</artifactId>
-  <version>6.4.0</version>
+  <version>6.5.0</version>
 </dependency>
 ```
 
 ##### Gradle
 ```gradle
-'com.ibm.watson.developer_cloud:tone-analyzer:6.4.0'
+'com.ibm.watson.developer_cloud:tone-analyzer:6.5.0'
 ```
 
 ## Usage

--- a/tone-analyzer/build.gradle
+++ b/tone-analyzer/build.gradle
@@ -25,7 +25,7 @@ task javadocJar(type: Jar, dependsOn: javadoc) {
 }
 
 repositories {
-    mavenCentral()
+    maven { url = "http://repo.maven.apache.org/maven2" }
 }
 
 artifacts {

--- a/tone-analyzer/src/test/java/com/ibm/watson/developer_cloud/tone_analyzer/v3/ToneAnalyzerTest.java
+++ b/tone-analyzer/src/test/java/com/ibm/watson/developer_cloud/tone_analyzer/v3/ToneAnalyzerTest.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.ibm.watson.developer_cloud.tone_analyzer.v3.model.UtteranceAnalyses;
+import com.ibm.watson.developer_cloud.util.RequestUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.Before;
 import org.junit.Test;
@@ -148,7 +149,7 @@ public class ToneAnalyzerTest extends WatsonServiceUnitTest {
         .build();
     serviceResponse = service.tone(toneOptions1).execute();
     request = server.takeRequest();
-    path = path + "&tones=emotion,language,social";
+    path = path + "&tones=" + RequestUtils.encode("emotion,language,social");
     assertEquals(path, request.getPath());
   }
 

--- a/visual-recognition/README.md
+++ b/visual-recognition/README.md
@@ -7,13 +7,13 @@
 <dependency>
   <groupId>com.ibm.watson.developer_cloud</groupId>
   <artifactId>visual-recognition</artifactId>
-  <version>6.4.0</version>
+  <version>6.5.0</version>
 </dependency>
 ```
 
 ##### Gradle
 ```gradle
-'com.ibm.watson.developer_cloud:visual-recognition:6.4.0'
+'com.ibm.watson.developer_cloud:visual-recognition:6.5.0'
 ```
 
 ## Usage

--- a/visual-recognition/build.gradle
+++ b/visual-recognition/build.gradle
@@ -25,7 +25,7 @@ task javadocJar(type: Jar, dependsOn: javadoc) {
 }
 
 repositories {
-    mavenCentral()
+    maven { url = "http://repo.maven.apache.org/maven2" }
 }
 
 artifacts {


### PR DESCRIPTION
It was reported and later confirmed by a user that there seemed to be a limit of 5 concurrent WebSocket connections that was being created by the SDK and not the Speech to Text service.

This PR updates the internal WebSocket library (OkHttp), which removes this limit. It also adds some code to avoid overflowing the WebSocket queue, which results in a closed connection. The end result is that many more connections can be handled simultaneously (I tested with 20, but assume this can go much higher).

The final change adds back the `interimResults` parameter in `RecognizeOptions`. I removed it in the last release because it seemed like the property had been unsupported for months. However, I confirmed with a member of the Speech to Text team that, while it's unsupported for the `recognize()` method of the Java SDK, it still works in the `recognizeUsingWebSocket()` method, so it should indeed be in the SDK.