### PR TITLE
Add support for ICP auth

### DIFF
--- a/core/src/main/java/com/ibm/watson/developer_cloud/service/WatsonService.java
+++ b/core/src/main/java/com/ibm/watson/developer_cloud/service/WatsonService.java
@@ -70,6 +70,7 @@ public abstract class WatsonService {
   private static final String BASIC = "Basic ";
   private static final String BEARER = "Bearer ";
   private static final String APIKEY_AS_USERNAME = "apikey";
+  private static final String ICP_PREFIX = "icp-";
   private static final Logger LOG = Logger.getLogger(WatsonService.class.getName());
   private static final String AUTH_HEADER_DEPRECATION_MESSAGE = "Authenticating with the X-Watson-Authorization-Token"
       + "header is deprecated. The token continues to work with Cloud Foundry services, but is not supported for "
@@ -350,7 +351,8 @@ public abstract class WatsonService {
    * @param password the password
    */
   public void setUsernameAndPassword(final String username, final String password) {
-    if (username.equals(APIKEY_AS_USERNAME)) {
+    // we'll perform the token exchange for users UNLESS they're on ICP
+    if (username.equals(APIKEY_AS_USERNAME) && !password.startsWith(ICP_PREFIX)) {
       IamOptions iamOptions = new IamOptions.Builder()
           .apiKey(password)
           .build();

--- a/core/src/test/java/com/ibm/watson/developer_cloud/service/AuthenticationTest.java
+++ b/core/src/test/java/com/ibm/watson/developer_cloud/service/AuthenticationTest.java
@@ -3,9 +3,12 @@ package com.ibm.watson.developer_cloud.service;
 import org.junit.Test;
 
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 
 public class AuthenticationTest {
+  private static final String APIKEY_USERNAME = "apikey";
   private static final String APIKEY = "12345";
+  private static final String ICP_APIKEY = "icp-12345";
 
   public class TestService extends WatsonService {
     private static final String SERVICE_NAME = "test";
@@ -18,7 +21,14 @@ public class AuthenticationTest {
   @Test
   public void authenticateWithApiKeyAsUsername() {
     TestService service = new TestService();
-    service.setUsernameAndPassword("apikey", APIKEY);
+    service.setUsernameAndPassword(APIKEY_USERNAME, APIKEY);
     assertTrue(service.isTokenManagerSet());
+  }
+
+  @Test
+  public void authenticateWithIcp() {
+    TestService service = new TestService();
+    service.setUsernameAndPassword(APIKEY_USERNAME, ICP_APIKEY);
+    assertFalse(service.isTokenManagerSet());
   }
 }


### PR DESCRIPTION
This PR ensures that users authenticating with an API key on ICP do not perform the usual token exchange, instead going through basic auth.