### PR TITLE
Fix automatic deployment of javadocs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ deploy:
     skip_cleanup: true
     on:
       repo: watson-developer-cloud/java-sdk
-      jdk: oraclejdk7
+      jdk: openjdk7
       tags: true
 
 notifications:


### PR DESCRIPTION
This PR fixes the deployment of Javadocs from Travis on releases. Somehow I didn't catch that we needed to change the target JDK when we switched from `oraclejdk7` to `openjdk7` in [this PR](https://github.com/watson-developer-cloud/java-sdk/pull/981).