### PR TITLE
Add ability to disable SSL verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Java client library to use the [Watson APIs][wdc].
     * [Tradeoff Analytics](tradeoff-analytics)
     * [Visual Recognition](visual-recognition)
   * [Android](#android)
-  * [Using a proxy](#using-a-proxy)
+  * [Configuring the HTTP client](#configuring-the-http-client)
   * [Default headers](#default-headers)
   * [Sending request headers](#sending-request-headers)
   * [Parsing HTTP response info](#parsing-http-response-info)
@@ -228,33 +228,24 @@ service.setApiKey("<api_key>");
 
 The Android SDK utilizes the Java SDK while making some Android-specific additions. This repository can be found [here](https://github.com/watson-developer-cloud/android-sdk). It depends on [OkHttp][] and [gson][].
 
-## Using a proxy
+## Configuring the HTTP client
 
-Override the `configureHttpClient()` method and add the proxy using the `OkHttpClient.Builder` object.
+The HTTP client can be configured by using the `configureClient()` method on your service object, passing in an `HttpConfigOptions` object. Currently, the following options are supported:
+- Disabling SSL verification (only do this if you really mean to!) ⚠️
+- Using a proxy (more info here: [OkHTTPClient Proxy authentication how to?](https://stackoverflow.com/a/35567936/456564))
 
-For example:
-
-```java
-Assistant service = new Assistant("2018-02-16") {
-  @Override
-  protected OkHttpClient configureHttpClient() {
-    Proxy proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress("proxyHost", 8080));
-    return super.configureHttpClient().newBuilder().proxy(proxy).build();
-  }
-};
-
-service.setUsernameAndPassword("<username>", "<password>");
-
-WorkspaceCollection workspaces = service.listWorkspaces().execute();
-System.out.println(workspaces);
-```
-
-For more information see: [OkHTTPClient Proxy authentication how to?](https://stackoverflow.com/a/35567936/456564)
+Here's an example of setting both of the above:
 
 ```java
-PersonalityInsights service = new PersonalityInsights("2016-10-19");
-String apiKey = CredentialUtils.getAPIKey(service.getName(), CredentialUtils.PLAN_STANDARD);
-service.setApiKey(apiKey);
+Discovery service = new Discovery("2017-11-07");
+
+// setting configuration options
+HttpConfigOptions options = new HttpConfigOptions.Builder()
+  .disableSslVerification(true)
+  .proxy(new Proxy(Proxy.Type.HTTP, new InetSocketAddress("proxyHost", 8080)))
+  .build();
+
+service.configureClient(options);
 ```
 
 ## Sending request headers

--- a/core/src/main/java/com/ibm/watson/developer_cloud/http/HttpClientSingleton.java
+++ b/core/src/main/java/com/ibm/watson/developer_cloud/http/HttpClientSingleton.java
@@ -31,6 +31,7 @@ import javax.net.ssl.X509TrustManager;
 import java.io.IOException;
 import java.net.CookieManager;
 import java.net.CookiePolicy;
+import java.net.Proxy;
 import java.security.KeyManagementException;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
@@ -158,6 +159,16 @@ public class HttpClientSingleton {
   }
 
   /**
+   * Sets a proxy for the current {@link OkHttpClient} instance.
+   *
+   * @param proxy the {@link Proxy}
+   */
+  private void setProxy(Proxy proxy) {
+    OkHttpClient.Builder builder = okHttpClient.newBuilder().proxy(proxy);
+    okHttpClient = builder.build();
+  }
+
+  /**
    * Specifically enable all TLS protocols. See: https://github.com/watson-developer-cloud/java-sdk/issues/610
    *
    * @param builder the {@link OkHttpClient} builder.
@@ -223,6 +234,9 @@ public class HttpClientSingleton {
 
     if (options.shouldDisableSslVerification()) {
       disableSslVerification();
+    }
+    if (options.getProxy() != null) {
+      setProxy(options.getProxy());
     }
   }
 }

--- a/core/src/main/java/com/ibm/watson/developer_cloud/http/HttpConfigOptions.java
+++ b/core/src/main/java/com/ibm/watson/developer_cloud/http/HttpConfigOptions.java
@@ -9,11 +9,11 @@ public class HttpConfigOptions {
   private boolean disableSslVerification;
   private Proxy proxy;
 
-  boolean shouldDisableSslVerification() {
+  public boolean shouldDisableSslVerification() {
     return this.disableSslVerification;
   }
 
-  Proxy getProxy() {
+  public Proxy getProxy() {
     return this.proxy;
   }
 

--- a/core/src/main/java/com/ibm/watson/developer_cloud/http/HttpConfigOptions.java
+++ b/core/src/main/java/com/ibm/watson/developer_cloud/http/HttpConfigOptions.java
@@ -1,0 +1,56 @@
+package com.ibm.watson.developer_cloud.http;
+
+import java.net.Proxy;
+
+/**
+ * Options class for configuring the HTTP client.
+ */
+public class HttpConfigOptions {
+  private boolean disableSslVerification;
+  private Proxy proxy;
+
+  boolean shouldDisableSslVerification() {
+    return this.disableSslVerification;
+  }
+
+  Proxy getProxy() {
+    return this.proxy;
+  }
+
+  public static class Builder {
+    private boolean disableSslVerification;
+    private Proxy proxy;
+
+    public HttpConfigOptions build() {
+      return new HttpConfigOptions(this);
+    }
+
+    /**
+     * Sets flag to disable any SSL certificate verification during HTTP requests. This should ONLY be used if truly
+     * intended, as it's unsafe otherwise.
+     *
+     * @param disableSslVerification whether to disable SSL verification or not
+     * @return the builder
+     */
+    public Builder disableSslVerification(boolean disableSslVerification) {
+      this.disableSslVerification = disableSslVerification;
+      return this;
+    }
+
+    /**
+     * Sets HTTP proxy to be used by connections with the current client.
+     *
+     * @param proxy the desired {@link Proxy}
+     * @return the builder
+     */
+    public Builder proxy(Proxy proxy) {
+      this.proxy = proxy;
+      return this;
+    }
+  }
+
+  private HttpConfigOptions(Builder builder) {
+    this.disableSslVerification = builder.disableSslVerification;
+    this.proxy = builder.proxy;
+  }
+}

--- a/core/src/main/java/com/ibm/watson/developer_cloud/service/WatsonService.java
+++ b/core/src/main/java/com/ibm/watson/developer_cloud/service/WatsonService.java
@@ -14,6 +14,7 @@ package com.ibm.watson.developer_cloud.service;
 
 import com.google.gson.JsonObject;
 import com.ibm.watson.developer_cloud.http.HttpClientSingleton;
+import com.ibm.watson.developer_cloud.http.HttpConfigOptions;
 import com.ibm.watson.developer_cloud.http.HttpHeaders;
 import com.ibm.watson.developer_cloud.http.HttpMediaType;
 import com.ibm.watson.developer_cloud.http.HttpStatus;
@@ -163,6 +164,15 @@ public abstract class WatsonService {
    */
   protected OkHttpClient configureHttpClient() {
     return HttpClientSingleton.getInstance().createHttpClient();
+  }
+
+  /**
+   * Configures the inner HTML client based on the passed-in options.
+   *
+   * @param options the {@link HttpConfigOptions} object for modifying the client
+   */
+  public void configureClient(HttpConfigOptions options) {
+    HttpClientSingleton.getInstance().configureClient(options);
   }
 
   /**

--- a/core/src/test/java/com/ibm/watson/developer_cloud/http/HttpConfigTest.java
+++ b/core/src/test/java/com/ibm/watson/developer_cloud/http/HttpConfigTest.java
@@ -1,0 +1,26 @@
+package com.ibm.watson.developer_cloud.http;
+
+import org.junit.Test;
+
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Unit tests for the HttpConfigOptions object.
+ */
+public class HttpConfigTest {
+
+  @Test
+  public void testHttpConfigOptions() {
+    Proxy proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress("proxyHost", 8080));
+    HttpConfigOptions configOptions = new HttpConfigOptions.Builder()
+        .disableSslVerification(true)
+        .proxy(proxy)
+        .build();
+
+    assertEquals(true, configOptions.shouldDisableSslVerification());
+    assertEquals(proxy, configOptions.getProxy());
+  }
+}

--- a/core/src/test/java/com/ibm/watson/developer_cloud/service/WatsonServiceTest.java
+++ b/core/src/test/java/com/ibm/watson/developer_cloud/service/WatsonServiceTest.java
@@ -23,28 +23,27 @@ import org.junit.Test;
  */
 public class WatsonServiceTest {
 
+  @Test
+  public void testMimeTypes() {
+    assertTrue(WatsonService.isJsonMimeType("application/json"));
+    assertTrue(WatsonService.isJsonMimeType("application/json; charset=utf-8"));
+    assertTrue(WatsonService.isJsonMimeType("application/json;charset=utf-8"));
+    assertTrue(WatsonService.isJsonMimeType("APPLICATION/JSON;charset=utf-16"));
+    assertFalse(WatsonService.isJsonMimeType("application/notjson"));
+    assertFalse(WatsonService.isJsonMimeType("application/json-patch+json"));
+    assertFalse(WatsonService.isJsonMimeType("APPlication/JSON-patCH+jSoN;charset=utf-8"));
+    assertTrue(WatsonService.isJsonPatchMimeType("APPlication/JSON-patCH+jSoN;charset=utf-8"));
+    assertTrue(WatsonService.isJsonMimeType("application/merge-patch+json"));
+    assertTrue(WatsonService.isJsonMimeType("application/merge-patch+json;charset=utf-8"));
+    assertFalse(WatsonService.isJsonMimeType("application/json2-patch+json"));
+    assertFalse(WatsonService.isJsonMimeType("application/merge-patch+json-blah"));
+    assertFalse(WatsonService.isJsonMimeType("application/merge patch json"));
 
-    @Test
-    public void testMimeTypes() {
-        assertTrue(WatsonService.isJsonMimeType("application/json"));
-        assertTrue(WatsonService.isJsonMimeType("application/json; charset=utf-8"));
-        assertTrue(WatsonService.isJsonMimeType("application/json;charset=utf-8"));
-        assertTrue(WatsonService.isJsonMimeType("APPLICATION/JSON;charset=utf-16"));
-        assertFalse(WatsonService.isJsonMimeType("application/notjson"));
-        assertFalse(WatsonService.isJsonMimeType("application/json-patch+json"));
-        assertFalse(WatsonService.isJsonMimeType("APPlication/JSON-patCH+jSoN;charset=utf-8"));
-        assertTrue(WatsonService.isJsonPatchMimeType("APPlication/JSON-patCH+jSoN;charset=utf-8"));
-        assertTrue(WatsonService.isJsonMimeType("application/merge-patch+json"));
-        assertTrue(WatsonService.isJsonMimeType("application/merge-patch+json;charset=utf-8"));
-        assertFalse(WatsonService.isJsonMimeType("application/json2-patch+json"));
-        assertFalse(WatsonService.isJsonMimeType("application/merge-patch+json-blah"));
-        assertFalse(WatsonService.isJsonMimeType("application/merge patch json"));
-
-        assertTrue(WatsonService.isJsonPatchMimeType("application/json-patch+json"));
-        assertTrue(WatsonService.isJsonPatchMimeType("application/json-patch+json;charset=utf-8"));
-        assertFalse(WatsonService.isJsonPatchMimeType("application/json"));
-        assertFalse(WatsonService.isJsonPatchMimeType("APPLICATION/JsOn; charset=utf-8"));
-        assertFalse(WatsonService.isJsonPatchMimeType("application/merge-patch+json"));
-        assertFalse(WatsonService.isJsonPatchMimeType("application/merge-patch+json;charset=utf-8"));
-    }
+    assertTrue(WatsonService.isJsonPatchMimeType("application/json-patch+json"));
+    assertTrue(WatsonService.isJsonPatchMimeType("application/json-patch+json;charset=utf-8"));
+    assertFalse(WatsonService.isJsonPatchMimeType("application/json"));
+    assertFalse(WatsonService.isJsonPatchMimeType("APPLICATION/JsOn; charset=utf-8"));
+    assertFalse(WatsonService.isJsonPatchMimeType("application/merge-patch+json"));
+    assertFalse(WatsonService.isJsonPatchMimeType("application/merge-patch+json;charset=utf-8"));
+  }
 }


### PR DESCRIPTION
This PR gives users the ability to disable SSL verification in subsequent HTTP requests. The new way to set this also includes setting a proxy, and this is all wrapped up in a new `HttpConfigOptions` class.

Documentation has been added to the main README to explain this to users.