### PR TITLE
Added StringHelper.createFormPartName and tests

### DIFF
--- a/core/src/main/java/com/ibm/watson/developer_cloud/util/StringHelper.java
+++ b/core/src/main/java/com/ibm/watson/developer_cloud/util/StringHelper.java
@@ -33,4 +33,22 @@ public class StringHelper {
         // TODO - check to see if we need to be concerned with the encoding of the string!
         return new ByteArrayInputStream(s.getBytes());
     }
+
+    /**
+     * Creates a parameterized part name for a form part based on a template and a key name and value.
+     * Example:
+     *     template: "{classname}_positive_examples"
+     *     keyName:  "classname"
+     *     keyValue: "truck"
+     *     result: "truck_positive_examples"
+     *
+     * @param template the part name template
+     * @param keyName the name of the key within the template
+     * @param keyValue the value of the key to use as a replacement
+     * @return the part name formed from the template, key name and key value
+     */
+    public static String createFormPartName(String template, String keyName, String keyValue) {
+        String toBeReplaced = "{" + keyName + "}";
+        return template.replace(toBeReplaced, keyValue);
+    }
 }

--- a/core/src/test/java/com/ibm/watson/developer_cloud/util/StringHelperTest.java
+++ b/core/src/test/java/com/ibm/watson/developer_cloud/util/StringHelperTest.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright 2018 IBM Corp. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.ibm.watson.developer_cloud.util;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.junit.Test;
+
+/**
+ *
+ */
+public class StringHelperTest {
+
+  @Test
+  public void testToInputStream() throws IOException {
+    assertEquals("",
+      inputStreamToString(StringHelper.toInputStream("")));
+    assertEquals("this is a test",
+      inputStreamToString(StringHelper.toInputStream("this is a test")));
+    assertEquals("this is a slightly longer test... hope it still works",
+      inputStreamToString(StringHelper.toInputStream("this is a slightly longer test... hope it still works")));
+  }
+
+  private String inputStreamToString(InputStream is) throws IOException {
+    String result = null;
+    int numBytes = is.available();
+    byte[] bytes = new byte[numBytes];
+    is.read(bytes, 0, numBytes);
+    result = new String(bytes);
+
+    return result;
+  }
+
+  @Test
+  public void testCreatePartName() {
+    assertEquals("class1_positive_examples",
+      StringHelper.createFormPartName("{classname}_positive_examples", "classname", "class1"));
+    assertEquals("class2_positive_examples",
+      StringHelper.createFormPartName("{classname}_positive_examples", "classname", "class2"));
+    assertEquals("this_is_a_test",
+      StringHelper.createFormPartName("this_is_{word}_test", "word", "a"));
+    assertEquals("this_is_not_a_test",
+      StringHelper.createFormPartName("this_is_{word}_test", "word", "not_a"));
+  }
+}


### PR DESCRIPTION
### Summary

The new StringHelper.createFormPartName() function introduced by this PR will be used by generated java code when the "mapified form parameter" feature is used.
