### PR TITLE
feat(Core): Add HTTP HEAD method to RequestBuilder

### DIFF
--- a/core/src/main/java/com/ibm/watson/developer_cloud/http/RequestBuilder.java
+++ b/core/src/main/java/com/ibm/watson/developer_cloud/http/RequestBuilder.java
@@ -34,7 +34,7 @@ import okhttp3.RequestBody;
 public class RequestBuilder {
 
   private enum HTTPMethod {
-    DELETE, GET, POST, PUT, PATCH
+    DELETE, GET, POST, PUT, PATCH, HEAD
   }
 
   /**
@@ -91,6 +91,17 @@ public class RequestBuilder {
    */
   public static RequestBuilder patch(HttpUrl url) {
     return new RequestBuilder(HTTPMethod.PATCH, url);
+  }
+
+  /**
+   * The HEAD method means retrieve the headers for the resource identified by the Request-URI.
+   *
+   * @param url the URL
+   *
+   * @return this
+   */
+  public static RequestBuilder head(HttpUrl url) {
+    return new RequestBuilder(HTTPMethod.HEAD, url);
   }
 
   /**
@@ -203,8 +214,8 @@ public class RequestBuilder {
     // URL
     builder.url(toUrl());
 
-    if (method == HTTPMethod.GET) {
-      Validator.isNull(body, "cannot send a RequestBody in a GET request");
+    if (method == HTTPMethod.GET || method == HTTPMethod.HEAD) {
+      Validator.isNull(body, "cannot send a RequestBody in a GET or HEAD request");
     } else if (!formParams.isEmpty()) {
       // The current behaviour of the RequestBuilder is to replace the body when formParams is
       // present

--- a/core/src/test/java/com/ibm/watson/developer_cloud/service/RequestBuilderTest.java
+++ b/core/src/test/java/com/ibm/watson/developer_cloud/service/RequestBuilderTest.java
@@ -90,6 +90,16 @@ public class RequestBuilderTest {
   }
 
   /**
+   * Test head.
+   */
+  @Test
+  public void testHead() {
+    final Request request = RequestBuilder.head(HttpUrl.parse(urlWithQuery)).build();
+    assertEquals("HEAD", request.method());
+    assertEquals(urlWithQuery, request.url().toString());
+  }
+
+  /**
    * Test illegal argument exception.
    */
   @Test(expected = IllegalArgumentException.class)


### PR DESCRIPTION
### Summary

Add the HTTP `HEAD` method to `com.ibm.watson.developer_cloud.http.RequestBuilder`, which did not include it.

Added two new tests:
* `RequestBuilderTest#testHead()` to check we can build a head request
* `ResponseTest#testExecuteWithDetailsForHead()` to validate that the headers can be retrieved from the `Response` when using the head method.

### Other Information

There is a slight weirdness in the test's header assertion `assertEquals(expectedHeaders, actualHeaders)` appears not to work because the underlying `Headers` class equality fails - I believe the `MockWebServer` and the `Headers.of(...)` methods produce different whitespace in the `Headers` object. Calling `toString()` on both objects produces identical strings that do pass an `equals` assertion.
