### PR TITLE
Fix Speech to Text bugs

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 6.9.1
+current_version = 6.9.2
 commit = True
 message = docs: Update version numbers from {current_version} -> {new_version}
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ All the services:
 <dependency>
 	<groupId>com.ibm.watson.developer_cloud</groupId>
 	<artifactId>java-sdk</artifactId>
-	<version>6.9.1</version>
+	<version>6.9.2</version>
 </dependency>
 ```
 
@@ -70,7 +70,7 @@ Only Discovery:
 <dependency>
 	<groupId>com.ibm.watson.developer_cloud</groupId>
 	<artifactId>discovery</artifactId>
-	<version>6.9.1</version>
+	<version>6.9.2</version>
 </dependency>
 ```
 
@@ -79,13 +79,13 @@ Only Discovery:
 All the services:
 
 ```gradle
-'com.ibm.watson.developer_cloud:java-sdk:6.9.1'
+'com.ibm.watson.developer_cloud:java-sdk:6.9.2'
 ```
 
 Only Assistant:
 
 ```gradle
-'com.ibm.watson.developer_cloud:assistant:6.9.1'
+'com.ibm.watson.developer_cloud:assistant:6.9.2'
 ```
 
 ##### Development snapshots
@@ -108,7 +108,7 @@ And then reference the snapshot version on your app module gradle
 Only Speech to Text:
 
 ```gradle
-'com.ibm.watson.developer_cloud:speech-to-text:6.9.2-SNAPSHOT'
+'com.ibm.watson.developer_cloud:speech-to-text:6.9.3-SNAPSHOT'
 ```
 
 ##### JAR
@@ -347,7 +347,7 @@ Gradle:
 
 ```sh
 cd java-sdk
-gradle jar  # build jar file (build/libs/watson-developer-cloud-6.9.1.jar)
+gradle jar  # build jar file (build/libs/watson-developer-cloud-6.9.2.jar)
 gradle test # run tests
 gradle check # performs quality checks on source files and generates reports
 gradle testReport # run tests and generate the aggregated test report (build/reports/allTests)
@@ -400,4 +400,4 @@ or [Stack Overflow](http://stackoverflow.com/questions/ask?tags=ibm-watson).
 [ibm-cloud-onboarding]: http://console.bluemix.net/registration?target=/developer/watson&cm_sp=WatsonPlatform-WatsonServices-_-OnPageNavLink-IBMWatson_SDKs-_-Java
 
 
-[jar]: https://github.com/watson-developer-cloud/java-sdk/releases/download/java-sdk-6.9.1/java-sdk-6.9.1-jar-with-dependencies.jar
+[jar]: https://github.com/watson-developer-cloud/java-sdk/releases/download/java-sdk-6.9.2/java-sdk-6.9.2-jar-with-dependencies.jar

--- a/assistant/README.md
+++ b/assistant/README.md
@@ -10,13 +10,13 @@ This service is currently in **private beta** and requires access to use. To lea
 <dependency>
   <groupId>com.ibm.watson.developer_cloud</groupId>
   <artifactId>assistant</artifactId>
-  <version>6.9.1</version>
+  <version>6.9.2</version>
 </dependency>
 ```
 
 ##### Gradle
 ```gradle
-'com.ibm.watson.developer_cloud:assistant:6.9.1'
+'com.ibm.watson.developer_cloud:assistant:6.9.2'
 ```
 
 ## Usage

--- a/conversation/README.md
+++ b/conversation/README.md
@@ -10,13 +10,13 @@ Conversation will be removed in the next major release. Please migrate to Assist
 <dependency>
   <groupId>com.ibm.watson.developer_cloud</groupId>
   <artifactId>conversation</artifactId>
-  <version>6.9.1</version>
+  <version>6.9.2</version>
 </dependency>
 ```
 
 ##### Gradle
 ```gradle
-'com.ibm.watson.developer_cloud:conversation:6.9.1'
+'com.ibm.watson.developer_cloud:conversation:6.9.2'
 ```
 
 ## Usage

--- a/discovery/README.md
+++ b/discovery/README.md
@@ -7,13 +7,13 @@
 <dependency>
   <groupId>com.ibm.watson.developer_cloud</groupId>
   <artifactId>discovery</artifactId>
-  <version>6.9.1</version>
+  <version>6.9.2</version>
 </dependency>
 ```
 
 ##### Gradle
 ```gradle
-'com.ibm.watson.developer_cloud:discovery:6.9.1'
+'com.ibm.watson.developer_cloud:discovery:6.9.2'
 ```
 
 ## Usage

--- a/language-translator/README.md
+++ b/language-translator/README.md
@@ -10,13 +10,13 @@ Language Translator v3 is now available. The v2 Language Translator API will no 
 <dependency>
   <groupId>com.ibm.watson.developer_cloud</groupId>
   <artifactId>language-translator</artifactId>
-  <version>6.9.1</version>
+  <version>6.9.2</version>
 </dependency>
 ```
 
 ##### Gradle
 ```gradle
-'com.ibm.watson.developer_cloud:language-translator:6.9.1'
+'com.ibm.watson.developer_cloud:language-translator:6.9.2'
 ```
 
 ## Usage

--- a/natural-language-classifier/README.md
+++ b/natural-language-classifier/README.md
@@ -7,13 +7,13 @@
 <dependency>
   <groupId>com.ibm.watson.developer_cloud</groupId>
   <artifactId>natural-language-classifier</artifactId>
-  <version>6.9.1</version>
+  <version>6.9.2</version>
 </dependency>
 ```
 
 ##### Gradle
 ```gradle
-'com.ibm.watson.developer_cloud:natural-language-classifier:6.9.1'
+'com.ibm.watson.developer_cloud:natural-language-classifier:6.9.2'
 ```
 
 ## Usage

--- a/natural-language-understanding/README.md
+++ b/natural-language-understanding/README.md
@@ -7,13 +7,13 @@
 <dependency>
   <groupId>com.ibm.watson.developer_cloud</groupId>
   <artifactId>natural-language-understanding</artifactId>
-  <version>6.9.1</version>
+  <version>6.9.2</version>
 </dependency>
 ```
 
 ##### Gradle
 ```gradle
-'com.ibm.watson.developer_cloud:natural-language-understanding:6.9.1'
+'com.ibm.watson.developer_cloud:natural-language-understanding:6.9.2'
 ```
 
 ## Usage

--- a/personality-insights/README.md
+++ b/personality-insights/README.md
@@ -7,13 +7,13 @@
 <dependency>
   <groupId>com.ibm.watson.developer_cloud</groupId>
   <artifactId>personality-insights</artifactId>
-  <version>6.9.1</version>
+  <version>6.9.2</version>
 </dependency>
 ```
 
 ##### Gradle
 ```gradle
-'com.ibm.watson.developer_cloud:personality-insights:6.9.1'
+'com.ibm.watson.developer_cloud:personality-insights:6.9.2'
 ```
 
 ## Usage

--- a/speech-to-text/README.md
+++ b/speech-to-text/README.md
@@ -7,13 +7,13 @@
 <dependency>
   <groupId>com.ibm.watson.developer_cloud</groupId>
   <artifactId>speech-to-text</artifactId>
-  <version>6.9.1</version>
+  <version>6.9.2</version>
 </dependency>
 ```
 
 ##### Gradle
 ```gradle
-'com.ibm.watson.developer_cloud:speech-to-text:6.9.1'
+'com.ibm.watson.developer_cloud:speech-to-text:6.9.2'
 ```
 
 ## Usage

--- a/speech-to-text/src/main/java/com/ibm/watson/developer_cloud/speech_to_text/v1/SpeechToText.java
+++ b/speech-to-text/src/main/java/com/ibm/watson/developer_cloud/speech_to_text/v1/SpeechToText.java
@@ -81,6 +81,8 @@ import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.WebSocket;
 
+import java.util.concurrent.TimeUnit;
+
 /**
  * The IBM&reg; Speech to Text service provides APIs that use IBM's speech-recognition capabilities to produce
  * transcripts of spoken audio. The service can transcribe speech from various languages and audio formats. It addition
@@ -371,6 +373,7 @@ public class SpeechToText extends WatsonService {
     setDefaultHeaders(builder);
 
     OkHttpClient client = configureHttpClient();
+    client = client.newBuilder().pingInterval(30, TimeUnit.SECONDS).build();
     return client.newWebSocket(builder.build(), new SpeechToTextWebSocketListener(recognizeOptions, callback));
   }
 

--- a/speech-to-text/src/main/java/com/ibm/watson/developer_cloud/speech_to_text/v1/model/RecognizeOptions.java
+++ b/speech-to-text/src/main/java/com/ibm/watson/developer_cloud/speech_to_text/v1/model/RecognizeOptions.java
@@ -459,6 +459,7 @@ public class RecognizeOptions extends GenericModel {
     smartFormatting = builder.smartFormatting;
     speakerLabels = builder.speakerLabels;
     customizationId = builder.customizationId;
+    interimResults = builder.interimResults;
   }
 
   /**

--- a/speech-to-text/src/test/java/com/ibm/watson/developer_cloud/speech_to_text/v1/SpeechToTextIT.java
+++ b/speech-to-text/src/test/java/com/ibm/watson/developer_cloud/speech_to_text/v1/SpeechToTextIT.java
@@ -305,8 +305,7 @@ public class SpeechToTextIT extends WatsonServiceTest {
 
       @Override
       public void onTranscription(SpeechRecognitionResults speechResults) {
-        Long resultIndex = speechResults.getResultIndex();
-        if (speechResults != null && speechResults.getResults().get(resultIndex.intValue()).isFinalResults()) {
+        if (speechResults != null && speechResults.getResults().get(0).isFinalResults()) {
           asyncResults = speechResults;
         }
       }

--- a/text-to-speech/README.md
+++ b/text-to-speech/README.md
@@ -7,13 +7,13 @@
 <dependency>
   <groupId>com.ibm.watson.developer_cloud</groupId>
   <artifactId>text-to-speech</artifactId>
-  <version>6.9.1</version>
+  <version>6.9.2</version>
 </dependency>
 ```
 
 ##### Gradle
 ```gradle
-'com.ibm.watson.developer_cloud:text-to-speech:6.9.1'
+'com.ibm.watson.developer_cloud:text-to-speech:6.9.2'
 ```
 
 ## Usage

--- a/tone-analyzer/README.md
+++ b/tone-analyzer/README.md
@@ -7,13 +7,13 @@
 <dependency>
   <groupId>com.ibm.watson.developer_cloud</groupId>
   <artifactId>tone-analyzer</artifactId>
-  <version>6.9.1</version>
+  <version>6.9.2</version>
 </dependency>
 ```
 
 ##### Gradle
 ```gradle
-'com.ibm.watson.developer_cloud:tone-analyzer:6.9.1'
+'com.ibm.watson.developer_cloud:tone-analyzer:6.9.2'
 ```
 
 ## Usage

--- a/visual-recognition/README.md
+++ b/visual-recognition/README.md
@@ -7,13 +7,13 @@
 <dependency>
   <groupId>com.ibm.watson.developer_cloud</groupId>
   <artifactId>visual-recognition</artifactId>
-  <version>6.9.1</version>
+  <version>6.9.2</version>
 </dependency>
 ```
 
 ##### Gradle
 ```gradle
-'com.ibm.watson.developer_cloud:visual-recognition:6.9.1'
+'com.ibm.watson.developer_cloud:visual-recognition:6.9.2'
 ```
 
 ## Usage


### PR DESCRIPTION
Fixes #1004 and fixes #1005.

A ping interval was added in the `recognizeUsingWebSocket()` method to ensure that no timeouts occur. Apparently, this was causing issue #1004, according to [this issue](https://github.com/square/okhttp/issues/3113) in the OkHttp repo.