### PR TITLE
Make Assistant v2 MessageOutput dynamic to capture extra keys

### DIFF
--- a/assistant/src/main/java/com/ibm/watson/developer_cloud/assistant/v2/model/MessageOutput.java
+++ b/assistant/src/main/java/com/ibm/watson/developer_cloud/assistant/v2/model/MessageOutput.java
@@ -12,14 +12,14 @@
  */
 package com.ibm.watson.developer_cloud.assistant.v2.model;
 
-import java.util.List;
+import com.ibm.watson.developer_cloud.service.model.DynamicModel;
 
-import com.ibm.watson.developer_cloud.service.model.GenericModel;
+import java.util.List;
 
 /**
  * Assistant output to be rendered or processed by the client.
  */
-public class MessageOutput extends GenericModel {
+public class MessageOutput extends DynamicModel {
 
   private List<DialogRuntimeResponseGeneric> generic;
   private List<RuntimeIntent> intents;

--- a/assistant/src/main/java/com/ibm/watson/developer_cloud/assistant/v2/model/MessageOutput.java
+++ b/assistant/src/main/java/com/ibm/watson/developer_cloud/assistant/v2/model/MessageOutput.java
@@ -12,8 +12,11 @@
  */
 package com.ibm.watson.developer_cloud.assistant.v2.model;
 
+import com.google.gson.reflect.TypeToken;
 import com.ibm.watson.developer_cloud.service.model.DynamicModel;
+import com.ibm.watson.developer_cloud.util.GsonSerializationHelper;
 
+import java.lang.reflect.Type;
 import java.util.List;
 
 /**
@@ -21,11 +24,16 @@ import java.util.List;
  */
 public class MessageOutput extends DynamicModel {
 
-  private List<DialogRuntimeResponseGeneric> generic;
-  private List<RuntimeIntent> intents;
-  private List<RuntimeEntity> entities;
-  private List<DialogNodeAction> actions;
-  private MessageOutputDebug debug;
+  private Type genericType = new TypeToken<List<DialogRuntimeResponseGeneric>>() {
+  }.getType();
+  private Type intentsType = new TypeToken<List<RuntimeIntent>>() {
+  }.getType();
+  private Type entitiesType = new TypeToken<List<RuntimeEntity>>() {
+  }.getType();
+  private Type actionsType = new TypeToken<List<DialogNodeAction>>() {
+  }.getType();
+  private Type debugType = new TypeToken<MessageOutputDebug>() {
+  }.getType();
 
   /**
    * Gets the generic.
@@ -36,7 +44,7 @@ public class MessageOutput extends DynamicModel {
    * @return the generic
    */
   public List<DialogRuntimeResponseGeneric> getGeneric() {
-    return generic;
+    return GsonSerializationHelper.serializeDynamicModelProperty(this.get("generic"), genericType);
   }
 
   /**
@@ -47,7 +55,7 @@ public class MessageOutput extends DynamicModel {
    * @return the intents
    */
   public List<RuntimeIntent> getIntents() {
-    return intents;
+    return GsonSerializationHelper.serializeDynamicModelProperty(this.get("intents"), intentsType);
   }
 
   /**
@@ -58,7 +66,7 @@ public class MessageOutput extends DynamicModel {
    * @return the entities
    */
   public List<RuntimeEntity> getEntities() {
-    return entities;
+    return GsonSerializationHelper.serializeDynamicModelProperty(this.get("entities"), entitiesType);
   }
 
   /**
@@ -69,7 +77,7 @@ public class MessageOutput extends DynamicModel {
    * @return the actions
    */
   public List<DialogNodeAction> getActions() {
-    return actions;
+    return GsonSerializationHelper.serializeDynamicModelProperty(this.get("actions"), actionsType);
   }
 
   /**
@@ -80,6 +88,6 @@ public class MessageOutput extends DynamicModel {
    * @return the debug
    */
   public MessageOutputDebug getDebug() {
-    return debug;
+    return GsonSerializationHelper.serializeDynamicModelProperty(this.get("debug"), debugType);
   }
 }


### PR DESCRIPTION
Fixes #1021 

This PR makes the `MessageOutput` model in the Assistant v2 service extend `DynamicModel` instead of `GenericModel` to make sure it captures other keys like `user_defined`. This may be enhanced later by adding concrete models for that key depending on whether it's a static response item or not.

With this change, other keys like `user_defined` can be accessed from the `MessageResponse` with the following lines:
```java
MessageResponse messageResponse = service.message(messageOptions).execute();
Object userDefined = messageResponse.getOutput().get("user_defined")); // can now be converted to JSON, used as Map, etc.
```