### PR TITLE
Allow for files to be sent when logging is set to ALL

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -74,6 +74,7 @@ dependencies {
     compile group: 'com.squareup.okhttp3', name: 'okhttp-urlconnection', version: '3.11.0'
     compile group: 'com.google.code.gson', name: 'gson', version: '2.8.0'
     compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.5'
+    compile group: 'commons-io', name: 'commons-io', version: '2.6'
     compile group: 'org.glassfish.jersey.bundles.repackaged', name: 'jersey-jsr166e', version: '2.25.1'
     testCompile group: 'simple-jndi', name: 'simple-jndi', version: '0.11.4.1'
 

--- a/core/src/main/java/com/ibm/watson/developer_cloud/http/InputStreamRequestBody.java
+++ b/core/src/main/java/com/ibm/watson/developer_cloud/http/InputStreamRequestBody.java
@@ -12,15 +12,20 @@
  */
 package com.ibm.watson.developer_cloud.http;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
+import com.ibm.watson.developer_cloud.util.HttpLogging;
 import okhttp3.MediaType;
 import okhttp3.RequestBody;
 import okhttp3.internal.Util;
+import okhttp3.logging.HttpLoggingInterceptor;
 import okio.BufferedSink;
 import okio.Okio;
 import okio.Source;
+import org.apache.commons.io.IOUtils;
 
 /**
  * RequestBody that takes an {@link InputStream}.
@@ -30,6 +35,7 @@ public class InputStreamRequestBody extends RequestBody {
 
   private InputStream inputStream;
   private MediaType mediaType;
+  private byte[] bytes;
 
   /**
    * Creates the @link {@link RequestBody} from an @link {@link InputStream}.
@@ -45,6 +51,19 @@ public class InputStreamRequestBody extends RequestBody {
   private InputStreamRequestBody(InputStream inputStream, MediaType mediaType) {
     this.inputStream = inputStream;
     this.mediaType = mediaType;
+
+    // if we're logging everything, we'll need to store the bytes to reuse later
+    if (HttpLogging.getLoggingInterceptor().getLevel().equals(HttpLoggingInterceptor.Level.BODY)) {
+      ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+
+      try {
+        IOUtils.copy(inputStream, outputStream);
+      } catch (IOException e) {
+        e.printStackTrace();
+      }
+
+      this.bytes = outputStream.toByteArray();
+    }
   }
 
   /*
@@ -65,8 +84,13 @@ public class InputStreamRequestBody extends RequestBody {
   @Override
   public void writeTo(BufferedSink sink) throws IOException {
     Source source = null;
+
     try {
-      source = Okio.source(inputStream);
+      if (bytes != null) {
+        source = Okio.source(new ByteArrayInputStream(bytes));
+      } else {
+        source = Okio.source(inputStream);
+      }
       sink.writeAll(source);
     } finally {
       Util.closeQuietly(source);


### PR DESCRIPTION
Fixes #1018 

As described in the issue, setting the logging level to ALL was causing issues with sending files. The underlying reason for this is that the provided `InputStream` was being accessed twice: once for logging purposes, and the other for sending to the service. On the second attempt, the stream was already closed.

This PR checks the logging level before creating the internal request body for the `InputStream` and if the user is logging everything, we copy the `InputStream` contents into a `byte[]` to be accessed multiple times. Otherwise, the behavior is the same as before.