### PR TITLE
Gracefully handle common errors in credential values

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 6.11.1
+current_version = 6.11.2
 commit = True
 message = [skip ci] docs: Update version numbers from {current_version} -> {new_version}
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ All the services:
 <dependency>
 	<groupId>com.ibm.watson.developer_cloud</groupId>
 	<artifactId>java-sdk</artifactId>
-	<version>6.11.1</version>
+	<version>6.11.2</version>
 </dependency>
 ```
 
@@ -71,7 +71,7 @@ Only Discovery:
 <dependency>
 	<groupId>com.ibm.watson.developer_cloud</groupId>
 	<artifactId>discovery</artifactId>
-	<version>6.11.1</version>
+	<version>6.11.2</version>
 </dependency>
 ```
 
@@ -80,13 +80,13 @@ Only Discovery:
 All the services:
 
 ```gradle
-'com.ibm.watson.developer_cloud:java-sdk:6.11.1'
+'com.ibm.watson.developer_cloud:java-sdk:6.11.2'
 ```
 
 Only Assistant:
 
 ```gradle
-'com.ibm.watson.developer_cloud:assistant:6.11.1'
+'com.ibm.watson.developer_cloud:assistant:6.11.2'
 ```
 
 ##### Development snapshots
@@ -109,7 +109,7 @@ And then reference the snapshot version on your app module gradle
 Only Speech to Text:
 
 ```gradle
-'com.ibm.watson.developer_cloud:speech-to-text:6.11.2-SNAPSHOT'
+'com.ibm.watson.developer_cloud:speech-to-text:6.11.3-SNAPSHOT'
 ```
 
 ##### JAR
@@ -348,7 +348,7 @@ Gradle:
 
 ```sh
 cd java-sdk
-gradle jar  # build jar file (build/libs/watson-developer-cloud-6.11.1.jar)
+gradle jar  # build jar file (build/libs/watson-developer-cloud-6.11.2.jar)
 gradle test # run tests
 gradle check # performs quality checks on source files and generates reports
 gradle testReport # run tests and generate the aggregated test report (build/reports/allTests)
@@ -401,4 +401,4 @@ or [Stack Overflow](http://stackoverflow.com/questions/ask?tags=ibm-watson).
 [ibm-cloud-onboarding]: http://console.bluemix.net/registration?target=/developer/watson&cm_sp=WatsonPlatform-WatsonServices-_-OnPageNavLink-IBMWatson_SDKs-_-Java
 
 
-[jar]: https://github.com/watson-developer-cloud/java-sdk/releases/download/java-sdk-6.11.1/java-sdk-6.11.1-jar-with-dependencies.jar
+[jar]: https://github.com/watson-developer-cloud/java-sdk/releases/download/java-sdk-6.11.2/java-sdk-6.11.2-jar-with-dependencies.jar

--- a/assistant/README.md
+++ b/assistant/README.md
@@ -7,13 +7,13 @@
 <dependency>
   <groupId>com.ibm.watson.developer_cloud</groupId>
   <artifactId>assistant</artifactId>
-  <version>6.11.1</version>
+  <version>6.11.2</version>
 </dependency>
 ```
 
 ##### Gradle
 ```gradle
-'com.ibm.watson.developer_cloud:assistant:6.11.1'
+'com.ibm.watson.developer_cloud:assistant:6.11.2'
 ```
 
 ## Usage

--- a/conversation/README.md
+++ b/conversation/README.md
@@ -10,13 +10,13 @@ Conversation will be removed in the next major release. Please migrate to Assist
 <dependency>
   <groupId>com.ibm.watson.developer_cloud</groupId>
   <artifactId>conversation</artifactId>
-  <version>6.11.1</version>
+  <version>6.11.2</version>
 </dependency>
 ```
 
 ##### Gradle
 ```gradle
-'com.ibm.watson.developer_cloud:conversation:6.11.1'
+'com.ibm.watson.developer_cloud:conversation:6.11.2'
 ```
 
 ## Usage

--- a/core/src/main/java/com/ibm/watson/developer_cloud/service/WatsonService.java
+++ b/core/src/main/java/com/ibm/watson/developer_cloud/service/WatsonService.java
@@ -121,6 +121,11 @@ public abstract class WatsonService {
     client = configureHttpClient();
   }
 
+  /**
+   * Calls appropriate methods to set credential values based on parsed ServiceCredentials object.
+   *
+   * @param serviceCredentials object containing parsed credential values
+   */
   private void setCredentialFields(CredentialUtils.ServiceCredentials serviceCredentials) {
     setEndPoint(serviceCredentials.getUrl());
 
@@ -341,6 +346,11 @@ public abstract class WatsonService {
    * @param apiKey the new API key
    */
   public void setApiKey(String apiKey) {
+    if (CredentialUtils.hasBadStartOrEndChar(apiKey)) {
+      throw new IllegalArgumentException("The API key shouldn't start or end with curly brackets or quotes. Please "
+          + "remove any surrounding {, }, or \" characters.");
+    }
+
     if (this.endPoint.equals(this.defaultEndPoint)) {
       this.endPoint = "https://gateway-a.watsonplatform.net/visual-recognition/api";
     }
@@ -376,6 +386,11 @@ public abstract class WatsonService {
    * @param endPoint the new end point. Will be ignored if empty or null
    */
   public void setEndPoint(final String endPoint) {
+    if (CredentialUtils.hasBadStartOrEndChar(endPoint)) {
+      throw new IllegalArgumentException("The URL shouldn't start or end with curly brackets or quotes. Please "
+          + "remove any surrounding {, }, or \" characters.");
+    }
+
     if ((endPoint != null) && !endPoint.isEmpty()) {
       String newEndPoint = endPoint.endsWith("/") ? endPoint.substring(0, endPoint.length() - 1) : endPoint;
       if (this.endPoint == null) {
@@ -392,6 +407,11 @@ public abstract class WatsonService {
    * @param password the password
    */
   public void setUsernameAndPassword(final String username, final String password) {
+    if (CredentialUtils.hasBadStartOrEndChar(username) || CredentialUtils.hasBadStartOrEndChar(password)) {
+      throw new IllegalArgumentException("The username and password shouldn't start or end with curly brackets or "
+          + "quotes. Please remove any surrounding {, }, or \" characters.");
+    }
+
     // we'll perform the token exchange for users UNLESS they're on ICP
     if (username.equals(APIKEY_AS_USERNAME) && !password.startsWith(ICP_PREFIX)) {
       IamOptions iamOptions = new IamOptions.Builder()

--- a/core/src/main/java/com/ibm/watson/developer_cloud/service/security/IamTokenManager.java
+++ b/core/src/main/java/com/ibm/watson/developer_cloud/service/security/IamTokenManager.java
@@ -17,6 +17,7 @@ import com.ibm.watson.developer_cloud.http.HttpHeaders;
 import com.ibm.watson.developer_cloud.http.HttpMediaType;
 import com.ibm.watson.developer_cloud.http.RequestBuilder;
 import com.ibm.watson.developer_cloud.http.ResponseConverter;
+import com.ibm.watson.developer_cloud.util.CredentialUtils;
 import com.ibm.watson.developer_cloud.util.ResponseConverterUtils;
 import okhttp3.Call;
 import okhttp3.FormBody;
@@ -44,6 +45,11 @@ public class IamTokenManager {
   private static final String REFRESH_TOKEN = "refresh_token";
 
   public IamTokenManager(IamOptions options) {
+    if (CredentialUtils.hasBadStartOrEndChar(options.getApiKey())) {
+      throw new IllegalArgumentException("The IAM API key shouldn't start or end with curly brackets or quotes. "
+          + "Please remove any surrounding {, }, or \" characters.");
+    }
+
     this.apiKey = options.getApiKey();
     this.url = (options.getUrl() != null) ? options.getUrl() : DEFAULT_IAM_URL;
     this.userManagedAccessToken = options.getAccessToken();

--- a/core/src/main/java/com/ibm/watson/developer_cloud/util/CredentialUtils.java
+++ b/core/src/main/java/com/ibm/watson/developer_cloud/util/CredentialUtils.java
@@ -163,6 +163,19 @@ public final class CredentialUtils {
     // This is a utility class - no instantiation allowed.
   }
 
+  /**
+   * Returns true if the supplied value begins or ends with curly brackets or quotation marks.
+   *
+   * @param credentialValue the credential value to check
+   * @return true if the value starts or ends with these characters and is therefore invalid
+   */
+  public static boolean hasBadStartOrEndChar(String credentialValue) {
+    return credentialValue.startsWith("{")
+        || credentialValue.startsWith("\"")
+        || credentialValue.endsWith("}")
+        || credentialValue.endsWith("\"");
+  }
+
   // VCAP-related methods
 
   /**

--- a/core/src/main/java/com/ibm/watson/developer_cloud/util/CredentialUtils.java
+++ b/core/src/main/java/com/ibm/watson/developer_cloud/util/CredentialUtils.java
@@ -26,8 +26,6 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.google.gson.JsonSyntaxException;
 
-import okhttp3.Credentials;
-
 /**
  * CredentialUtils retrieves service credentials from the environment.
  */
@@ -38,12 +36,30 @@ public final class CredentialUtils {
    *
    */
   public static class ServiceCredentials {
-    private String password;
     private String username;
+    private String oldApiKey;
+    private String url;
+    private String iamApiKey;
+    private String iamUrl;
+    private String password;
 
-    private ServiceCredentials(String username, String password) {
+    private ServiceCredentials(String username, String oldApiKey, String url, String iamApiKey, String iamUrl,
+                               String password) {
       this.username = username;
       this.password = password;
+      this.oldApiKey = oldApiKey;
+      this.url = url;
+      this.iamApiKey = iamApiKey;
+      this.iamUrl = iamUrl;
+    }
+
+    /**
+     * Gets the username.
+     *
+     * @return the username
+     */
+    public String getUsername() {
+      return username;
     }
 
     /**
@@ -56,29 +72,47 @@ public final class CredentialUtils {
     }
 
     /**
-     * Gets the username.
+     * Gets the API used for older service instances.
      *
-     * @return the username
+     * @return the oldApiKey
      */
-    public String getUsername() {
-      return username;
+    public String getOldApiKey() {
+      return oldApiKey;
+    }
+
+    /**
+     * Gets the API URL.
+     *
+     * @return the url
+     */
+    public String getUrl() {
+      return url;
+    }
+
+    /**
+     * Gets the IAM API key.
+     *
+     * @return the iamApiKey
+     */
+    public String getIamApiKey() {
+      return iamApiKey;
+    }
+
+    /**
+     * Gets the IAM URL.
+     *
+     * @return the iamUrl
+     */
+    public String getIamUrl() {
+      return iamUrl;
     }
   }
-
-  /** The Constant ALCHEMY_API. */
-  private static final String ALCHEMY_API = "alchemy_api";
-
-  /** The Constant VISUAL_RECOGNITION. */
-  private static final String VISUAL_RECOGNITION = "watson_vision_combined";
 
   /** The Constant VCAP_SERVICES. */
   private static final String VCAP_SERVICES = "VCAP_SERVICES";
 
   /** The Constant APIKEY. */
   private static final String APIKEY = "apikey";
-
-  /** The Constant IAM_API_KEY_NAME. */
-  private static final String IAM_API_KEY_NAME = "iam_apikey_name";
 
   /** The Constant CREDENTIALS. */
   private static final String CREDENTIALS = "credentials";
@@ -129,6 +163,34 @@ public final class CredentialUtils {
     // This is a utility class - no instantiation allowed.
   }
 
+  // VCAP-related methods
+
+  /**
+   * Calls methods to parse VCAP_SERVICES and retrieve credential values. For some values, if VCAP_SERVICES aren't
+   * present, it'll fall back to checking JDNI.
+   *
+   * @param serviceName the service name
+   * @return ServiceCredentials object containing parsed values
+   */
+  public static ServiceCredentials getCredentialsFromVcap(String serviceName) {
+    String username = getVcapValue(serviceName, USERNAME);
+    String password = getVcapValue(serviceName, PASSWORD);
+    String oldApiKey = getVcapValue(serviceName, API_KEY);
+    if (username == null && password == null && oldApiKey == null) {
+      oldApiKey = getJdniValue(serviceName, LOOKUP_NAME_EXTENSION_API_KEY);
+    }
+
+    String url = getVcapValue(serviceName, URL);
+    if (url == null) {
+      url = getJdniValue(serviceName, LOOKUP_NAME_EXTENSION_URL);
+    }
+
+    String iamApiKey = getVcapValue(serviceName, APIKEY);
+    String iamUrl = getVcapValue(serviceName, IAM_URL);
+
+    return new ServiceCredentials(username, password, oldApiKey, url, iamApiKey, iamUrl);
+  }
+
   /**
    * Builds the lookup name to be searched for in JDNI
    * and uses it to call the overloaded JDNI method.
@@ -137,8 +199,8 @@ public final class CredentialUtils {
    * @param lookupNameExtension Extension to determine which value should be retrieved through JDNI
    * @return The encoded desired value
    */
-  private static String getJDNIValue(String serviceName, String lookupNameExtension) {
-    return getJDNIValue("watson-developer-cloud/" + serviceName + lookupNameExtension);
+  private static String getJdniValue(String serviceName, String lookupNameExtension) {
+    return getJdniValue("watson-developer-cloud/" + serviceName + lookupNameExtension);
   }
 
   /**
@@ -149,7 +211,7 @@ public final class CredentialUtils {
    * @param lookupName Key to lookup in JDNI
    * @return The encoded desired value
    */
-  private static String getJDNIValue(String lookupName) {
+  private static String getJdniValue(String lookupName) {
     if (!isClassAvailable("javax.naming.Context") || !isClassAvailable("javax.naming.InitialContext")) {
       log.info("JNDI string lookups is not available.");
       return null;
@@ -180,7 +242,7 @@ public final class CredentialUtils {
    *
    * @return the VCAP_SERVICES as a {@link JsonObject}.
    */
-  private static JsonObject getVCAPServices() {
+  private static JsonObject getVcapServices() {
     final String envServices = services != null ? services : System.getenv(VCAP_SERVICES);
     if (envServices == null) {
       return null;
@@ -195,122 +257,6 @@ public final class CredentialUtils {
       log.log(Level.INFO, "Error parsing VCAP_SERVICES", e);
     }
     return vcapServices;
-  }
-
-  /**
-   * Returns the IAM API key from the VCAP_SERVICES, or null if it doesn't exist.
-   *
-   * @param serviceName the service name
-   * @return the IAM API key or null if the service cannot be found
-   */
-  public static String getIAMKey(String serviceName) {
-    final JsonObject services = getVCAPServices();
-
-    if (serviceName == null || services == null) {
-      return null;
-    }
-
-    final JsonObject credentials = getCredentialsObject(services, serviceName, null);
-    if (credentials != null && credentials.get(APIKEY) != null && credentials.get(IAM_API_KEY_NAME) != null) {
-      return credentials.get(APIKEY).getAsString();
-    }
-
-    return null;
-  }
-
-  /**
-   * Returns the apiKey from the VCAP_SERVICES or null if doesn't exists.
-   *
-   * @param serviceName the service name
-   * @return the API key or null if the service cannot be found.
-   */
-  public static String getAPIKey(String serviceName) {
-    return getAPIKey(serviceName, null);
-  }
-
-  /**
-   * Returns the apiKey from the VCAP_SERVICES or null if doesn't exists. If plan is specified, then only credentials
-   * for the given plan will be returned.
-   *
-   * @param serviceName the service name
-   * @param plan the service plan: standard, free or experimental
-   * @return the API key
-   */
-  public static String getAPIKey(String serviceName, String plan) {
-    if ((serviceName == null) || serviceName.isEmpty()) {
-      return null;
-    }
-
-    final JsonObject services = getVCAPServices();
-    if (services == null) {
-      return getJDNIValue(serviceName, LOOKUP_NAME_EXTENSION_API_KEY);
-    }
-    if (serviceName.equalsIgnoreCase(ALCHEMY_API)) {
-      final JsonObject credentials = getCredentialsObject(services, serviceName, plan);
-      if (credentials != null) {
-        return credentials.get(APIKEY).getAsString();
-      }
-    } else if (serviceName.equalsIgnoreCase(VISUAL_RECOGNITION)) {
-      final JsonObject credentials = getCredentialsObject(services, serviceName, plan);
-      if (credentials != null) {
-        return credentials.get(API_KEY).getAsString();
-      }
-    } else {
-      ServiceCredentials credentials = getUserNameAndPassword(serviceName, plan);
-      if (credentials != null) {
-        return Credentials.basic(credentials.getUsername(), credentials.getPassword());
-      }
-    }
-    return null;
-  }
-
-  /**
-   * Returns the username and password as defined in the VCAP_SERVICES or null if they do not exist or are not
-   * accessible. This is a utility method for {@link #getUserNameAndPassword(String, String)}. Invoking this method is
-   * identical to calling <code>getUserNameAndPassword(serviceName, null);</code>
-   *
-   * @param serviceName the name of the service whose credentials are sought
-   * @return an object representing the service's credentials
-   */
-  public static ServiceCredentials getUserNameAndPassword(String serviceName) {
-    return getUserNameAndPassword(serviceName, null);
-  }
-
-  /**
-   * Returns the username and password as defined in the VCAP_SERVICES or null if they do not exist or are not
-   * accessible. If a plan is provided then only the credentials for that plan (and service) will be returned. Null will
-   * be returned if the plan does not exist.
-   *
-   * @param serviceName the name of the service whose credentials are sought
-   * @param plan the plan name
-   * @return an object representing the service's credentials
-   */
-  public static ServiceCredentials getUserNameAndPassword(String serviceName, String plan) {
-    if ((serviceName == null) || serviceName.isEmpty()) {
-      return null;
-    }
-
-    final JsonObject services = getVCAPServices();
-    if (services == null) {
-      return null;
-    }
-
-    JsonObject jsonCredentials = getCredentialsObject(services, serviceName, plan);
-    if (jsonCredentials != null) {
-      String username = null;
-      if (jsonCredentials.has(USERNAME)) {
-        username = jsonCredentials.get(USERNAME).getAsString();
-      }
-      String password = null;
-      if (jsonCredentials.has(PASSWORD)) {
-        password = jsonCredentials.get(PASSWORD).getAsString();
-      }
-      if ((username != null) || (password != null)) {
-        // both will be null in the case of Alchemy API
-        return new ServiceCredentials(username, password);
-      }
-    }
-    return null;
   }
 
   /**
@@ -338,55 +284,35 @@ public final class CredentialUtils {
     return null;
   }
 
-  /**
-   * Gets the API url.
-   *
-   * @param serviceName the service name
-   * @return the API url
-   */
-
-  public static String getAPIUrl(String serviceName) {
-    return getAPIUrl(serviceName, null);
+  static String getVcapValue(String serviceName, String key) {
+    return getVcapValue(serviceName, key, null);
   }
 
   /**
-   * Returns the API URL from the VCAP_SERVICES, JDNI, or null if doesn't exists. If plan is specified, then only
-   * credentials for the given plan will be returned.
+   * Returns the value associated with the provided key from the VCAP_SERVICES, or null if it doesn't exist. In the
+   * case of the API URL, if VCAP_SERVICES aren't present, this method will also search in JDNI.
    *
    * @param serviceName the service name
-   * @param plan the service plan: standard, free or experimental
-   * @return the API URL
+   * @param key the key whose value should be returned
+   * @param plan the plan name
+   * @return the value of the provided key
    */
-  public static String getAPIUrl(String serviceName, String plan) {
+  static String getVcapValue(String serviceName, String key, String plan) {
     if ((serviceName == null) || serviceName.isEmpty()) {
       return null;
     }
 
-    final JsonObject services = getVCAPServices();
+    final JsonObject services = getVcapServices();
     if (services == null) {
-      return getJDNIValue(serviceName, LOOKUP_NAME_EXTENSION_URL);
-    }
-
-    final JsonObject credentials = getCredentialsObject(services, serviceName, plan);
-    if ((credentials != null) && credentials.has(URL)) {
-      return credentials.get(URL).getAsString();
-    }
-
-    return null;
-  }
-
-  public static String getIAMUrl(String serviceName) {
-    final JsonObject services = getVCAPServices();
-
-    if (serviceName == null || services == null) {
       return null;
     }
 
-    final JsonObject credentials = getCredentialsObject(services, serviceName, null);
-    if (credentials != null && credentials.get(IAM_URL) != null) {
-      return credentials.get(IAM_URL).getAsString();
+    JsonObject jsonCredentials = getCredentialsObject(services, serviceName, plan);
+    if (jsonCredentials != null) {
+      if (jsonCredentials.has(key)) {
+        return jsonCredentials.get(key).getAsString();
+      }
     }
-
     return null;
   }
 
@@ -410,20 +336,5 @@ public final class CredentialUtils {
     } catch (Exception e) {
       log.fine("Error setting up JDNI context: " + e.getMessage());
     }
-  }
-
-  /**
-   * Method for testing the getAPIUrl method that bypasses the VCAP
-   * services to ensure retrieval from JDNI.
-   *
-   * @param serviceName the service name
-   * @return the API URL
-   */
-  public static String getAPIUrlTest(String serviceName) {
-    if ((serviceName == null) || serviceName.isEmpty()) {
-      return null;
-    }
-
-    return getJDNIValue("jdni/watson-developer-cloud/" + serviceName + LOOKUP_NAME_EXTENSION_URL);
   }
 }

--- a/core/src/test/java/com/ibm/watson/developer_cloud/util/CredentialUtilsTest.java
+++ b/core/src/test/java/com/ibm/watson/developer_cloud/util/CredentialUtilsTest.java
@@ -20,7 +20,9 @@ import java.io.InputStream;
 import java.util.Hashtable;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * The Class CredentialUtilsTest.
@@ -72,5 +74,27 @@ public class CredentialUtilsTest extends WatsonServiceTest {
   @Test
   public void testGetVcapValueWithMultiplePlans() {
     assertEquals(NOT_A_FREE_USERNAME, CredentialUtils.getVcapValue(SERVICE_NAME, USERNAME));
+  }
+
+  @Test
+  public void testBadCredentialChar() {
+    // valid
+    assertFalse(CredentialUtils.hasBadStartOrEndChar("this_is_fine"));
+
+    // starting bracket
+    assertTrue(CredentialUtils.hasBadStartOrEndChar("{bad_username"));
+    assertTrue(CredentialUtils.hasBadStartOrEndChar("{{still_bad"));
+
+    // ending bracket
+    assertTrue(CredentialUtils.hasBadStartOrEndChar("invalid}"));
+    assertTrue(CredentialUtils.hasBadStartOrEndChar("also_invalid}}"));
+
+    // starting quote
+    assertTrue(CredentialUtils.hasBadStartOrEndChar("\"not_allowed_either"));
+    assertTrue(CredentialUtils.hasBadStartOrEndChar("\"\"still_not"));
+
+    // ending quote
+    assertTrue(CredentialUtils.hasBadStartOrEndChar("nope\""));
+    assertTrue(CredentialUtils.hasBadStartOrEndChar("sorry\"\""));
   }
 }

--- a/core/src/test/java/com/ibm/watson/developer_cloud/util/CredentialUtilsTest.java
+++ b/core/src/test/java/com/ibm/watson/developer_cloud/util/CredentialUtilsTest.java
@@ -13,9 +13,7 @@
 package com.ibm.watson.developer_cloud.util;
 
 import com.ibm.watson.developer_cloud.WatsonServiceTest;
-import com.ibm.watson.developer_cloud.util.CredentialUtils.ServiceCredentials;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.InputStream;
@@ -23,37 +21,20 @@ import java.util.Hashtable;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 
 /**
  * The Class CredentialUtilsTest.
  */
 public class CredentialUtilsTest extends WatsonServiceTest {
-
-  /** The Constant API_KEY_FREE. */
-  private static final String API_KEY_FREE = "Basic bm90LWEtZnJlZS11c2VybmFtZTpub3QtYS1mcmVlLXBhc3N3b3Jk";
-
-  /** The Constant API_KEY_STANDARD. */
-  private static final String API_KEY_STANDARD = "Basic bm90LWEtdXNlcm5hbWU6bm90LWEtcGFzc3dvcmQ=";
-
-  /** The Constant SERVICE_NAME. */
   private static final String SERVICE_NAME = "personality_insights";
-
-  /** The Constant VCAP_SERVICES. */
   private static final String VCAP_SERVICES = "vcap_services.json";
-
+  private static final String APIKEY = "apikey";
+  private static final String USERNAME = "username";
+  private static final String OLD_API_KEY = "api_key";
   private static final String NOT_A_USERNAME = "not-a-username";
   private static final String NOT_A_PASSWORD = "not-a-password";
   private static final String NOT_A_FREE_USERNAME = "not-a-free-username";
-  private static final String NOT_A_FREE_PASSWORD = "not-a-free-password";
-  private static final String PLAN = "standard";
-
   private static final String VISUAL_RECOGNITION = "watson_vision_combined";
-
-  private static final String PERSONALITY_INSIGHTS_URL = "https://gateway.watsonplatform.net/personality-insights/api";
-
-  private static final String IAM_SERVICE_NAME = "language_translator";
-  private static final String IAM_KEY_TEST_VALUE = "123456789";
 
   /**
    * Setup.
@@ -72,76 +53,24 @@ public class CredentialUtilsTest extends WatsonServiceTest {
     CredentialUtils.setContext(env);
   }
 
-  /**
-   * Test get api key with null or empty service. There are two instances of Personality Insights: ['free', 'standard']
-   */
   @Test
-  public void testGetAPIKeyWithNullOrEmptyService() {
-    assertNull(CredentialUtils.getAPIKey(null, null));
-    assertNull(CredentialUtils.getAPIKey("", ""));
-
-    assertEquals(API_KEY_FREE, CredentialUtils.getAPIKey(SERVICE_NAME, null));
-    assertEquals(API_KEY_FREE, CredentialUtils.getAPIKey(SERVICE_NAME, CredentialUtils.PLAN_FREE));
-    assertEquals(API_KEY_STANDARD, CredentialUtils.getAPIKey(SERVICE_NAME, CredentialUtils.PLAN_STANDARD));
+  public void testGetVcapValueWithNullOrEmptyService() {
+    assertNull(CredentialUtils.getVcapValue(null, APIKEY));
+    assertNull(CredentialUtils.getVcapValue("", APIKEY));
   }
 
-  /**
-   * Test get api key for visual recognition.
-   */
   @Test
-  public void testGetApiKeyForVisualRecognition() {
-    assertNull(CredentialUtils.getAPIKey(VISUAL_RECOGNITION, NOT_A_PASSWORD));
+  public void testGetVcapValueWithPlan() {
+    assertEquals(NOT_A_USERNAME, CredentialUtils.getVcapValue(SERVICE_NAME, USERNAME, CredentialUtils.PLAN_STANDARD));
   }
 
-  /**
-   * Test get user name and password without plan.
-   */
   @Test
-  public void testGetUserNameAndPasswordWithoutPlan() {
-    assertNull(CredentialUtils.getUserNameAndPassword(null));
-    assertNull(CredentialUtils.getUserNameAndPassword(null, null));
-
-    ServiceCredentials credentials = CredentialUtils.getUserNameAndPassword(SERVICE_NAME);
-    assertTrue(credentials != null);
-    assertEquals(credentials.getUsername(), NOT_A_FREE_USERNAME);
-    assertEquals(credentials.getPassword(), NOT_A_FREE_PASSWORD);
-
-    credentials = CredentialUtils.getUserNameAndPassword(SERVICE_NAME, null);
-    assertTrue(credentials != null);
-    assertEquals(credentials.getUsername(), NOT_A_FREE_USERNAME);
-    assertEquals(credentials.getPassword(), NOT_A_FREE_PASSWORD);
+  public void testGetVcapValueWithoutPlan() {
+    assertEquals(NOT_A_PASSWORD, CredentialUtils.getVcapValue(VISUAL_RECOGNITION, OLD_API_KEY));
   }
 
-  /**
-   * Test get user credentials with plan.
-   */
   @Test
-  public void testGetUserCredentialsWithPlan() {
-    assertNull(CredentialUtils.getUserNameAndPassword(null));
-    assertNull(CredentialUtils.getUserNameAndPassword(null, null));
-
-    ServiceCredentials credentials = CredentialUtils.getUserNameAndPassword(SERVICE_NAME, PLAN);
-    assertTrue(credentials != null);
-    assertEquals(credentials.getUsername(), NOT_A_USERNAME);
-    assertEquals(credentials.getPassword(), NOT_A_PASSWORD);
-  }
-
-  /**
-   * Test getting IAM API key from VCAP_SERVICES.
-   */
-  @Test
-  public void testGetIAMKey() {
-    String key = CredentialUtils.getIAMKey(IAM_SERVICE_NAME);
-    assertEquals(IAM_KEY_TEST_VALUE, key);
-  }
-
-  /**
-   * Test getting the API URL using JDNI. We ignore this test in Travis because
-   * it always fails there.
-   */
-  @Test
-  @Ignore
-  public void testGetAPIUrlFromJDNI() {
-    assertEquals(CredentialUtils.getAPIUrlTest(SERVICE_NAME), PERSONALITY_INSIGHTS_URL);
+  public void testGetVcapValueWithMultiplePlans() {
+    assertEquals(NOT_A_FREE_USERNAME, CredentialUtils.getVcapValue(SERVICE_NAME, USERNAME));
   }
 }

--- a/discovery/README.md
+++ b/discovery/README.md
@@ -7,13 +7,13 @@
 <dependency>
   <groupId>com.ibm.watson.developer_cloud</groupId>
   <artifactId>discovery</artifactId>
-  <version>6.11.1</version>
+  <version>6.11.2</version>
 </dependency>
 ```
 
 ##### Gradle
 ```gradle
-'com.ibm.watson.developer_cloud:discovery:6.11.1'
+'com.ibm.watson.developer_cloud:discovery:6.11.2'
 ```
 
 ## Usage

--- a/language-translator/README.md
+++ b/language-translator/README.md
@@ -7,13 +7,13 @@
 <dependency>
   <groupId>com.ibm.watson.developer_cloud</groupId>
   <artifactId>language-translator</artifactId>
-  <version>6.11.1</version>
+  <version>6.11.2</version>
 </dependency>
 ```
 
 ##### Gradle
 ```gradle
-'com.ibm.watson.developer_cloud:language-translator:6.11.1'
+'com.ibm.watson.developer_cloud:language-translator:6.11.2'
 ```
 
 ## Usage

--- a/natural-language-classifier/README.md
+++ b/natural-language-classifier/README.md
@@ -7,13 +7,13 @@
 <dependency>
   <groupId>com.ibm.watson.developer_cloud</groupId>
   <artifactId>natural-language-classifier</artifactId>
-  <version>6.11.1</version>
+  <version>6.11.2</version>
 </dependency>
 ```
 
 ##### Gradle
 ```gradle
-'com.ibm.watson.developer_cloud:natural-language-classifier:6.11.1'
+'com.ibm.watson.developer_cloud:natural-language-classifier:6.11.2'
 ```
 
 ## Usage

--- a/natural-language-understanding/README.md
+++ b/natural-language-understanding/README.md
@@ -7,13 +7,13 @@
 <dependency>
   <groupId>com.ibm.watson.developer_cloud</groupId>
   <artifactId>natural-language-understanding</artifactId>
-  <version>6.11.1</version>
+  <version>6.11.2</version>
 </dependency>
 ```
 
 ##### Gradle
 ```gradle
-'com.ibm.watson.developer_cloud:natural-language-understanding:6.11.1'
+'com.ibm.watson.developer_cloud:natural-language-understanding:6.11.2'
 ```
 
 ## Usage

--- a/personality-insights/README.md
+++ b/personality-insights/README.md
@@ -7,13 +7,13 @@
 <dependency>
   <groupId>com.ibm.watson.developer_cloud</groupId>
   <artifactId>personality-insights</artifactId>
-  <version>6.11.1</version>
+  <version>6.11.2</version>
 </dependency>
 ```
 
 ##### Gradle
 ```gradle
-'com.ibm.watson.developer_cloud:personality-insights:6.11.1'
+'com.ibm.watson.developer_cloud:personality-insights:6.11.2'
 ```
 
 ## Usage

--- a/speech-to-text/README.md
+++ b/speech-to-text/README.md
@@ -7,13 +7,13 @@
 <dependency>
   <groupId>com.ibm.watson.developer_cloud</groupId>
   <artifactId>speech-to-text</artifactId>
-  <version>6.11.1</version>
+  <version>6.11.2</version>
 </dependency>
 ```
 
 ##### Gradle
 ```gradle
-'com.ibm.watson.developer_cloud:speech-to-text:6.11.1'
+'com.ibm.watson.developer_cloud:speech-to-text:6.11.2'
 ```
 
 ## Usage

--- a/speech-to-text/src/test/java/com/ibm/watson/developer_cloud/speech_to_text/v1/SpeechToTextIT.java
+++ b/speech-to-text/src/test/java/com/ibm/watson/developer_cloud/speech_to_text/v1/SpeechToTextIT.java
@@ -465,7 +465,9 @@ public class SpeechToTextIT extends WatsonServiceTest {
   /**
    * Test check jobs.
    *
+   * Ignoring while the endpoint is broken.
    */
+  @Ignore
   @Test
   public void testCheckJobs() {
     RecognitionJobs jobs = service.checkJobs().execute();

--- a/text-to-speech/README.md
+++ b/text-to-speech/README.md
@@ -7,13 +7,13 @@
 <dependency>
   <groupId>com.ibm.watson.developer_cloud</groupId>
   <artifactId>text-to-speech</artifactId>
-  <version>6.11.1</version>
+  <version>6.11.2</version>
 </dependency>
 ```
 
 ##### Gradle
 ```gradle
-'com.ibm.watson.developer_cloud:text-to-speech:6.11.1'
+'com.ibm.watson.developer_cloud:text-to-speech:6.11.2'
 ```
 
 ## Usage

--- a/tone-analyzer/README.md
+++ b/tone-analyzer/README.md
@@ -7,13 +7,13 @@
 <dependency>
   <groupId>com.ibm.watson.developer_cloud</groupId>
   <artifactId>tone-analyzer</artifactId>
-  <version>6.11.1</version>
+  <version>6.11.2</version>
 </dependency>
 ```
 
 ##### Gradle
 ```gradle
-'com.ibm.watson.developer_cloud:tone-analyzer:6.11.1'
+'com.ibm.watson.developer_cloud:tone-analyzer:6.11.2'
 ```
 
 ## Usage

--- a/visual-recognition/README.md
+++ b/visual-recognition/README.md
@@ -7,13 +7,13 @@
 <dependency>
   <groupId>com.ibm.watson.developer_cloud</groupId>
   <artifactId>visual-recognition</artifactId>
-  <version>6.11.1</version>
+  <version>6.11.2</version>
 </dependency>
 ```
 
 ##### Gradle
 ```gradle
-'com.ibm.watson.developer_cloud:visual-recognition:6.11.1'
+'com.ibm.watson.developer_cloud:visual-recognition:6.11.2'
 ```
 
 ## Usage


### PR DESCRIPTION
The functional change in this PR is that exceptions are thrown for credential values surrounded by `{}` or `""` characters. This prevents making a call to the service and provides a more helpful error message.

Besides that, there was a lot of refactoring done with the credential logic in the SDK. Things had gotten a bit messy with the various changes we've had in auth methods and one-off fixes, so I consolidated some things to make it a bit clearer to work with. This should also make it easier to add the next auth feature coming soon 👀 