### PR TITLE
Add missing property to Assistant v1 DialogNode model

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 6.11.2
+current_version = 6.11.3
 commit = True
 message = [skip ci] docs: Update version numbers from {current_version} -> {new_version}
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ All the services:
 <dependency>
 	<groupId>com.ibm.watson.developer_cloud</groupId>
 	<artifactId>java-sdk</artifactId>
-	<version>6.11.2</version>
+	<version>6.11.3</version>
 </dependency>
 ```
 
@@ -71,7 +71,7 @@ Only Discovery:
 <dependency>
 	<groupId>com.ibm.watson.developer_cloud</groupId>
 	<artifactId>discovery</artifactId>
-	<version>6.11.2</version>
+	<version>6.11.3</version>
 </dependency>
 ```
 
@@ -80,13 +80,13 @@ Only Discovery:
 All the services:
 
 ```gradle
-'com.ibm.watson.developer_cloud:java-sdk:6.11.2'
+'com.ibm.watson.developer_cloud:java-sdk:6.11.3'
 ```
 
 Only Assistant:
 
 ```gradle
-'com.ibm.watson.developer_cloud:assistant:6.11.2'
+'com.ibm.watson.developer_cloud:assistant:6.11.3'
 ```
 
 ##### Development snapshots
@@ -109,7 +109,7 @@ And then reference the snapshot version on your app module gradle
 Only Speech to Text:
 
 ```gradle
-'com.ibm.watson.developer_cloud:speech-to-text:6.11.3-SNAPSHOT'
+'com.ibm.watson.developer_cloud:speech-to-text:6.11.4-SNAPSHOT'
 ```
 
 ##### JAR
@@ -348,7 +348,7 @@ Gradle:
 
 ```sh
 cd java-sdk
-gradle jar  # build jar file (build/libs/watson-developer-cloud-6.11.2.jar)
+gradle jar  # build jar file (build/libs/watson-developer-cloud-6.11.3.jar)
 gradle test # run tests
 gradle check # performs quality checks on source files and generates reports
 gradle testReport # run tests and generate the aggregated test report (build/reports/allTests)
@@ -401,4 +401,4 @@ or [Stack Overflow](http://stackoverflow.com/questions/ask?tags=ibm-watson).
 [ibm-cloud-onboarding]: http://console.bluemix.net/registration?target=/developer/watson&cm_sp=WatsonPlatform-WatsonServices-_-OnPageNavLink-IBMWatson_SDKs-_-Java
 
 
-[jar]: https://github.com/watson-developer-cloud/java-sdk/releases/download/java-sdk-6.11.2/java-sdk-6.11.2-jar-with-dependencies.jar
+[jar]: https://github.com/watson-developer-cloud/java-sdk/releases/download/java-sdk-6.11.3/java-sdk-6.11.3-jar-with-dependencies.jar

--- a/assistant/README.md
+++ b/assistant/README.md
@@ -7,13 +7,13 @@
 <dependency>
   <groupId>com.ibm.watson.developer_cloud</groupId>
   <artifactId>assistant</artifactId>
-  <version>6.11.2</version>
+  <version>6.11.3</version>
 </dependency>
 ```
 
 ##### Gradle
 ```gradle
-'com.ibm.watson.developer_cloud:assistant:6.11.2'
+'com.ibm.watson.developer_cloud:assistant:6.11.3'
 ```
 
 ## Usage

--- a/assistant/src/main/java/com/ibm/watson/developer_cloud/assistant/v1/Assistant.java
+++ b/assistant/src/main/java/com/ibm/watson/developer_cloud/assistant/v1/Assistant.java
@@ -1594,7 +1594,7 @@ public class Assistant extends WatsonService {
    *
    * You associate a customer ID with data by passing the `X-Watson-Metadata` header with a request that passes data.
    * For more information about personal data and customer IDs, see [Information
-   * security](https://console.bluemix.net/docs/services/conversation/information-security.html).
+   * security](https://cloud.ibm.com/docs/services/assistant/information-security.html).
    *
    * @param deleteUserDataOptions the {@link DeleteUserDataOptions} containing the options for the call
    * @return a {@link ServiceCall} with a response type of Void

--- a/assistant/src/main/java/com/ibm/watson/developer_cloud/assistant/v1/model/CreateDialogNode.java
+++ b/assistant/src/main/java/com/ibm/watson/developer_cloud/assistant/v1/model/CreateDialogNode.java
@@ -508,7 +508,7 @@ public class CreateDialogNode extends GenericModel {
    * Gets the output.
    *
    * The output of the dialog node. For more information about how to specify dialog node output, see the
-   * [documentation](https://console.bluemix.net/docs/services/conversation/dialog-overview.html#complex).
+   * [documentation](https://cloud.ibm.com/docs/services/assistant/dialog-overview.html#complex).
    *
    * @return the output
    */

--- a/assistant/src/main/java/com/ibm/watson/developer_cloud/assistant/v1/model/CreateDialogNodeOptions.java
+++ b/assistant/src/main/java/com/ibm/watson/developer_cloud/assistant/v1/model/CreateDialogNodeOptions.java
@@ -527,7 +527,7 @@ public class CreateDialogNodeOptions extends GenericModel {
    * Gets the output.
    *
    * The output of the dialog node. For more information about how to specify dialog node output, see the
-   * [documentation](https://console.bluemix.net/docs/services/conversation/dialog-overview.html#complex).
+   * [documentation](https://cloud.ibm.com/docs/services/assistant/dialog-overview.html#complex).
    *
    * @return the output
    */

--- a/assistant/src/main/java/com/ibm/watson/developer_cloud/assistant/v1/model/CreateValue.java
+++ b/assistant/src/main/java/com/ibm/watson/developer_cloud/assistant/v1/model/CreateValue.java
@@ -236,7 +236,7 @@ public class CreateValue extends GenericModel {
    * An array of patterns for the entity value. You can provide either synonyms or patterns (as indicated by **type**),
    * but not both. A pattern is a regular expression no longer than 512 characters. For more information about how to
    * specify a pattern, see the
-   * [documentation](https://console.bluemix.net/docs/services/conversation/entities.html#creating-entities).
+   * [documentation](https://cloud.ibm.com/docs/services/assistant/entities.html#creating-entities).
    *
    * @return the patterns
    */

--- a/assistant/src/main/java/com/ibm/watson/developer_cloud/assistant/v1/model/CreateValueOptions.java
+++ b/assistant/src/main/java/com/ibm/watson/developer_cloud/assistant/v1/model/CreateValueOptions.java
@@ -292,7 +292,7 @@ public class CreateValueOptions extends GenericModel {
    * An array of patterns for the entity value. You can provide either synonyms or patterns (as indicated by **type**),
    * but not both. A pattern is a regular expression no longer than 512 characters. For more information about how to
    * specify a pattern, see the
-   * [documentation](https://console.bluemix.net/docs/services/conversation/entities.html#creating-entities).
+   * [documentation](https://cloud.ibm.com/docs/services/assistant/entities.html#creating-entities).
    *
    * @return the patterns
    */

--- a/assistant/src/main/java/com/ibm/watson/developer_cloud/assistant/v1/model/DialogNode.java
+++ b/assistant/src/main/java/com/ibm/watson/developer_cloud/assistant/v1/model/DialogNode.java
@@ -118,6 +118,7 @@ public class DialogNode extends GenericModel {
   private Date updated;
   private List<DialogNodeAction> actions;
   private String title;
+  private Boolean disabled;
   @SerializedName("type")
   private String nodeType;
   @SerializedName("event_name")
@@ -192,7 +193,7 @@ public class DialogNode extends GenericModel {
    * Gets the output.
    *
    * The output of the dialog node. For more information about how to specify dialog node output, see the
-   * [documentation](https://console.bluemix.net/docs/services/conversation/dialog-overview.html#complex).
+   * [documentation](https://cloud.ibm.com/docs/services/assistant/dialog-overview.html#complex).
    *
    * @return the output
    */
@@ -275,6 +276,17 @@ public class DialogNode extends GenericModel {
    */
   public String getTitle() {
     return title;
+  }
+
+  /**
+   * Gets the disabled.
+   *
+   * For internal use only.
+   *
+   * @return the disabled
+   */
+  public Boolean isDisabled() {
+    return disabled;
   }
 
   /**

--- a/assistant/src/main/java/com/ibm/watson/developer_cloud/assistant/v1/model/DialogNodeOutput.java
+++ b/assistant/src/main/java/com/ibm/watson/developer_cloud/assistant/v1/model/DialogNodeOutput.java
@@ -21,7 +21,7 @@ import com.ibm.watson.developer_cloud.util.GsonSerializationHelper;
 
 /**
  * The output of the dialog node. For more information about how to specify dialog node output, see the
- * [documentation](https://console.bluemix.net/docs/services/conversation/dialog-overview.html#complex).
+ * [documentation](https://cloud.ibm.com/docs/services/assistant/dialog-overview.html#complex).
  */
 public class DialogNodeOutput extends DynamicModel {
   private Type genericType = new TypeToken<List<DialogNodeOutputGeneric>>() {

--- a/assistant/src/main/java/com/ibm/watson/developer_cloud/assistant/v1/model/DialogNodeOutputOptionsElementValue.java
+++ b/assistant/src/main/java/com/ibm/watson/developer_cloud/assistant/v1/model/DialogNodeOutputOptionsElementValue.java
@@ -25,7 +25,7 @@ public class DialogNodeOutputOptionsElementValue extends GenericModel {
   /**
    * Gets the input.
    *
-   * The user input.
+   * An input object that includes the input text.
    *
    * @return the input
    */

--- a/assistant/src/main/java/com/ibm/watson/developer_cloud/assistant/v1/model/DialogSuggestionValue.java
+++ b/assistant/src/main/java/com/ibm/watson/developer_cloud/assistant/v1/model/DialogSuggestionValue.java
@@ -29,7 +29,7 @@ public class DialogSuggestionValue extends GenericModel {
   /**
    * Gets the input.
    *
-   * The user input.
+   * An input object that includes the input text.
    *
    * @return the input
    */

--- a/assistant/src/main/java/com/ibm/watson/developer_cloud/assistant/v1/model/InputData.java
+++ b/assistant/src/main/java/com/ibm/watson/developer_cloud/assistant/v1/model/InputData.java
@@ -16,7 +16,7 @@ import com.ibm.watson.developer_cloud.service.model.GenericModel;
 import com.ibm.watson.developer_cloud.util.Validator;
 
 /**
- * The user input.
+ * An input object that includes the input text.
  */
 public class InputData extends GenericModel {
 

--- a/assistant/src/main/java/com/ibm/watson/developer_cloud/assistant/v1/model/ListAllLogsOptions.java
+++ b/assistant/src/main/java/com/ibm/watson/developer_cloud/assistant/v1/model/ListAllLogsOptions.java
@@ -133,7 +133,7 @@ public class ListAllLogsOptions extends GenericModel {
    * A cacheable parameter that limits the results to those matching the specified filter. You must specify a filter
    * query that includes a value for `language`, as well as a value for `workspace_id` or
    * `request.context.metadata.deployment`. For more information, see the
-   * [documentation](https://console.bluemix.net/docs/services/conversation/filter-reference.html#filter-query-syntax).
+   * [documentation](https://cloud.ibm.com/docs/services/assistant/filter-reference.html#filter-query-syntax).
    *
    * @return the filter
    */

--- a/assistant/src/main/java/com/ibm/watson/developer_cloud/assistant/v1/model/ListLogsOptions.java
+++ b/assistant/src/main/java/com/ibm/watson/developer_cloud/assistant/v1/model/ListLogsOptions.java
@@ -169,7 +169,7 @@ public class ListLogsOptions extends GenericModel {
    * Gets the filter.
    *
    * A cacheable parameter that limits the results to those matching the specified filter. For more information, see the
-   * [documentation](https://console.bluemix.net/docs/services/conversation/filter-reference.html#filter-query-syntax).
+   * [documentation](https://cloud.ibm.com/docs/services/assistant/filter-reference.html#filter-query-syntax).
    *
    * @return the filter
    */

--- a/assistant/src/main/java/com/ibm/watson/developer_cloud/assistant/v1/model/LogExport.java
+++ b/assistant/src/main/java/com/ibm/watson/developer_cloud/assistant/v1/model/LogExport.java
@@ -35,7 +35,7 @@ public class LogExport extends GenericModel {
   /**
    * Gets the request.
    *
-   * A message request formatted for the Watson Assistant service.
+   * A request sent to the workspace, including the user input and context.
    *
    * @return the request
    */
@@ -46,7 +46,7 @@ public class LogExport extends GenericModel {
   /**
    * Gets the response.
    *
-   * A response from the Watson Assistant service.
+   * The response sent by the workspace, including the output text, detected intents and entities, and context.
    *
    * @return the response
    */

--- a/assistant/src/main/java/com/ibm/watson/developer_cloud/assistant/v1/model/MessageOptions.java
+++ b/assistant/src/main/java/com/ibm/watson/developer_cloud/assistant/v1/model/MessageOptions.java
@@ -252,7 +252,7 @@ public class MessageOptions extends GenericModel {
   /**
    * Gets the input.
    *
-   * The user input.
+   * An input object that includes the input text.
    *
    * @return the input
    */

--- a/assistant/src/main/java/com/ibm/watson/developer_cloud/assistant/v1/model/MessageRequest.java
+++ b/assistant/src/main/java/com/ibm/watson/developer_cloud/assistant/v1/model/MessageRequest.java
@@ -18,7 +18,7 @@ import com.google.gson.annotations.SerializedName;
 import com.ibm.watson.developer_cloud.service.model.GenericModel;
 
 /**
- * A message request formatted for the Watson Assistant service.
+ * A request sent to the workspace, including the user input and context.
  */
 public class MessageRequest extends GenericModel {
 
@@ -33,7 +33,7 @@ public class MessageRequest extends GenericModel {
   /**
    * Gets the input.
    *
-   * The user input.
+   * An input object that includes the input text.
    *
    * @return the input
    */

--- a/assistant/src/main/java/com/ibm/watson/developer_cloud/assistant/v1/model/MessageResponse.java
+++ b/assistant/src/main/java/com/ibm/watson/developer_cloud/assistant/v1/model/MessageResponse.java
@@ -20,7 +20,7 @@ import com.ibm.watson.developer_cloud.service.model.DynamicModel;
 import com.ibm.watson.developer_cloud.util.GsonSerializationHelper;
 
 /**
- * A response from the Watson Assistant service.
+ * The response sent by the workspace, including the output text, detected intents and entities, and context.
  */
 public class MessageResponse extends DynamicModel {
   private Type inputType = new TypeToken<MessageInput>() {

--- a/assistant/src/main/java/com/ibm/watson/developer_cloud/assistant/v1/model/UpdateDialogNodeOptions.java
+++ b/assistant/src/main/java/com/ibm/watson/developer_cloud/assistant/v1/model/UpdateDialogNodeOptions.java
@@ -664,7 +664,7 @@ public class UpdateDialogNodeOptions extends GenericModel {
    * Gets the newOutput.
    *
    * The output of the dialog node. For more information about how to specify dialog node output, see the
-   * [documentation](https://console.bluemix.net/docs/services/conversation/dialog-overview.html#complex).
+   * [documentation](https://cloud.ibm.com/docs/services/assistant/dialog-overview.html#complex).
    *
    * @return the newOutput
    */

--- a/assistant/src/main/java/com/ibm/watson/developer_cloud/assistant/v1/model/UpdateValueOptions.java
+++ b/assistant/src/main/java/com/ibm/watson/developer_cloud/assistant/v1/model/UpdateValueOptions.java
@@ -315,7 +315,7 @@ public class UpdateValueOptions extends GenericModel {
    * An array of patterns for the entity value. You can provide either synonyms or patterns (as indicated by **type**),
    * but not both. A pattern is a regular expression no longer than 512 characters. For more information about how to
    * specify a pattern, see the
-   * [documentation](https://console.bluemix.net/docs/services/conversation/entities.html#creating-entities).
+   * [documentation](https://cloud.ibm.com/docs/services/assistant/entities.html#creating-entities).
    *
    * @return the newPatterns
    */

--- a/assistant/src/main/java/com/ibm/watson/developer_cloud/assistant/v1/model/WorkspaceSystemSettings.java
+++ b/assistant/src/main/java/com/ibm/watson/developer_cloud/assistant/v1/model/WorkspaceSystemSettings.java
@@ -18,7 +18,7 @@ import com.google.gson.annotations.SerializedName;
 import com.ibm.watson.developer_cloud.service.model.GenericModel;
 
 /**
- * WorkspaceSystemSettings.
+ * Global settings for the workspace.
  */
 public class WorkspaceSystemSettings extends GenericModel {
 

--- a/assistant/src/main/java/com/ibm/watson/developer_cloud/assistant/v1/model/WorkspaceSystemSettingsDisambiguation.java
+++ b/assistant/src/main/java/com/ibm/watson/developer_cloud/assistant/v1/model/WorkspaceSystemSettingsDisambiguation.java
@@ -16,7 +16,9 @@ import com.google.gson.annotations.SerializedName;
 import com.ibm.watson.developer_cloud.service.model.GenericModel;
 
 /**
- * WorkspaceSystemSettingsDisambiguation.
+ * Workspace settings related to the disambiguation feature.
+ *
+ * **Note:** This feature is available only to Premium users.
  */
 public class WorkspaceSystemSettingsDisambiguation extends GenericModel {
 

--- a/assistant/src/main/java/com/ibm/watson/developer_cloud/assistant/v1/model/WorkspaceSystemSettingsTooling.java
+++ b/assistant/src/main/java/com/ibm/watson/developer_cloud/assistant/v1/model/WorkspaceSystemSettingsTooling.java
@@ -16,7 +16,7 @@ import com.google.gson.annotations.SerializedName;
 import com.ibm.watson.developer_cloud.service.model.GenericModel;
 
 /**
- * WorkspaceSystemSettingsTooling.
+ * Workspace settings related to the Watson Assistant tool.
  */
 public class WorkspaceSystemSettingsTooling extends GenericModel {
 

--- a/compare-comply/src/test/java/com/ibm/watson/developer_cloud/compare_comply/v1/CompareComplyServiceIT.java
+++ b/compare-comply/src/test/java/com/ibm/watson/developer_cloud/compare_comply/v1/CompareComplyServiceIT.java
@@ -122,6 +122,7 @@ public class CompareComplyServiceIT extends CompareComplyServiceTest {
     feedbackDataInput.setText(text);
     feedbackDataInput.setOriginalLabels(originalLabelsIn);
     feedbackDataInput.setUpdatedLabels(updatedLabelsIn);
+    feedbackDataInput.setFeedbackType("element_classification");
 
     AddFeedbackOptions addFeedbackOptions = new AddFeedbackOptions.Builder()
         .userId(userId)

--- a/conversation/README.md
+++ b/conversation/README.md
@@ -10,13 +10,13 @@ Conversation will be removed in the next major release. Please migrate to Assist
 <dependency>
   <groupId>com.ibm.watson.developer_cloud</groupId>
   <artifactId>conversation</artifactId>
-  <version>6.11.2</version>
+  <version>6.11.3</version>
 </dependency>
 ```
 
 ##### Gradle
 ```gradle
-'com.ibm.watson.developer_cloud:conversation:6.11.2'
+'com.ibm.watson.developer_cloud:conversation:6.11.3'
 ```
 
 ## Usage

--- a/discovery/README.md
+++ b/discovery/README.md
@@ -7,13 +7,13 @@
 <dependency>
   <groupId>com.ibm.watson.developer_cloud</groupId>
   <artifactId>discovery</artifactId>
-  <version>6.11.2</version>
+  <version>6.11.3</version>
 </dependency>
 ```
 
 ##### Gradle
 ```gradle
-'com.ibm.watson.developer_cloud:discovery:6.11.2'
+'com.ibm.watson.developer_cloud:discovery:6.11.3'
 ```
 
 ## Usage

--- a/discovery/src/test/java/com/ibm/watson/developer_cloud/discovery/v1/DiscoveryServiceIT.java
+++ b/discovery/src/test/java/com/ibm/watson/developer_cloud/discovery/v1/DiscoveryServiceIT.java
@@ -1901,7 +1901,7 @@ public class DiscoveryServiceIT extends WatsonServiceTest {
     // collections
     CreateCollectionOptions createCollectionOptions = new CreateCollectionOptions.Builder()
         .environmentId(environmentId)
-        .name("tokenization-dict-testing-collection")
+        .name("tokenization-dict-testing-collection " + UUID.randomUUID().toString())
         .language(CreateCollectionOptions.Language.JA)
         .build();
     Collection tokenDictTestCollection = discovery.createCollection(createCollectionOptions).execute();

--- a/language-translator/README.md
+++ b/language-translator/README.md
@@ -7,13 +7,13 @@
 <dependency>
   <groupId>com.ibm.watson.developer_cloud</groupId>
   <artifactId>language-translator</artifactId>
-  <version>6.11.2</version>
+  <version>6.11.3</version>
 </dependency>
 ```
 
 ##### Gradle
 ```gradle
-'com.ibm.watson.developer_cloud:language-translator:6.11.2'
+'com.ibm.watson.developer_cloud:language-translator:6.11.3'
 ```
 
 ## Usage

--- a/natural-language-classifier/README.md
+++ b/natural-language-classifier/README.md
@@ -7,13 +7,13 @@
 <dependency>
   <groupId>com.ibm.watson.developer_cloud</groupId>
   <artifactId>natural-language-classifier</artifactId>
-  <version>6.11.2</version>
+  <version>6.11.3</version>
 </dependency>
 ```
 
 ##### Gradle
 ```gradle
-'com.ibm.watson.developer_cloud:natural-language-classifier:6.11.2'
+'com.ibm.watson.developer_cloud:natural-language-classifier:6.11.3'
 ```
 
 ## Usage

--- a/natural-language-understanding/README.md
+++ b/natural-language-understanding/README.md
@@ -7,13 +7,13 @@
 <dependency>
   <groupId>com.ibm.watson.developer_cloud</groupId>
   <artifactId>natural-language-understanding</artifactId>
-  <version>6.11.2</version>
+  <version>6.11.3</version>
 </dependency>
 ```
 
 ##### Gradle
 ```gradle
-'com.ibm.watson.developer_cloud:natural-language-understanding:6.11.2'
+'com.ibm.watson.developer_cloud:natural-language-understanding:6.11.3'
 ```
 
 ## Usage

--- a/personality-insights/README.md
+++ b/personality-insights/README.md
@@ -7,13 +7,13 @@
 <dependency>
   <groupId>com.ibm.watson.developer_cloud</groupId>
   <artifactId>personality-insights</artifactId>
-  <version>6.11.2</version>
+  <version>6.11.3</version>
 </dependency>
 ```
 
 ##### Gradle
 ```gradle
-'com.ibm.watson.developer_cloud:personality-insights:6.11.2'
+'com.ibm.watson.developer_cloud:personality-insights:6.11.3'
 ```
 
 ## Usage

--- a/speech-to-text/README.md
+++ b/speech-to-text/README.md
@@ -7,13 +7,13 @@
 <dependency>
   <groupId>com.ibm.watson.developer_cloud</groupId>
   <artifactId>speech-to-text</artifactId>
-  <version>6.11.2</version>
+  <version>6.11.3</version>
 </dependency>
 ```
 
 ##### Gradle
 ```gradle
-'com.ibm.watson.developer_cloud:speech-to-text:6.11.2'
+'com.ibm.watson.developer_cloud:speech-to-text:6.11.3'
 ```
 
 ## Usage

--- a/text-to-speech/README.md
+++ b/text-to-speech/README.md
@@ -7,13 +7,13 @@
 <dependency>
   <groupId>com.ibm.watson.developer_cloud</groupId>
   <artifactId>text-to-speech</artifactId>
-  <version>6.11.2</version>
+  <version>6.11.3</version>
 </dependency>
 ```
 
 ##### Gradle
 ```gradle
-'com.ibm.watson.developer_cloud:text-to-speech:6.11.2'
+'com.ibm.watson.developer_cloud:text-to-speech:6.11.3'
 ```
 
 ## Usage

--- a/tone-analyzer/README.md
+++ b/tone-analyzer/README.md
@@ -7,13 +7,13 @@
 <dependency>
   <groupId>com.ibm.watson.developer_cloud</groupId>
   <artifactId>tone-analyzer</artifactId>
-  <version>6.11.2</version>
+  <version>6.11.3</version>
 </dependency>
 ```
 
 ##### Gradle
 ```gradle
-'com.ibm.watson.developer_cloud:tone-analyzer:6.11.2'
+'com.ibm.watson.developer_cloud:tone-analyzer:6.11.3'
 ```
 
 ## Usage

--- a/visual-recognition/README.md
+++ b/visual-recognition/README.md
@@ -7,13 +7,13 @@
 <dependency>
   <groupId>com.ibm.watson.developer_cloud</groupId>
   <artifactId>visual-recognition</artifactId>
-  <version>6.11.2</version>
+  <version>6.11.3</version>
 </dependency>
 ```
 
 ##### Gradle
 ```gradle
-'com.ibm.watson.developer_cloud:visual-recognition:6.11.2'
+'com.ibm.watson.developer_cloud:visual-recognition:6.11.3'
 ```
 
 ## Usage


### PR DESCRIPTION
This PR regenerates the Assistant v1 service to add a missing `disabled` field to the `DialogNode` model. Other than that, only documentation has been updated.