### PR TITLE
Update version numbers from 6.13.0 -> 6.13.1

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 6.13.0
+current_version = 6.13.1
 commit = True
 message = [skip ci] docs: Update version numbers from {current_version} -> {new_version}
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ All the services:
 <dependency>
 	<groupId>com.ibm.watson.developer_cloud</groupId>
 	<artifactId>java-sdk</artifactId>
-	<version>6.13.0</version>
+	<version>6.13.1</version>
 </dependency>
 ```
 
@@ -71,7 +71,7 @@ Only Discovery:
 <dependency>
 	<groupId>com.ibm.watson.developer_cloud</groupId>
 	<artifactId>discovery</artifactId>
-	<version>6.13.0</version>
+	<version>6.13.1</version>
 </dependency>
 ```
 
@@ -80,13 +80,13 @@ Only Discovery:
 All the services:
 
 ```gradle
-'com.ibm.watson.developer_cloud:java-sdk:6.13.0'
+'com.ibm.watson.developer_cloud:java-sdk:6.13.1'
 ```
 
 Only Assistant:
 
 ```gradle
-'com.ibm.watson.developer_cloud:assistant:6.13.0'
+'com.ibm.watson.developer_cloud:assistant:6.13.1'
 ```
 
 ##### Development snapshots
@@ -109,7 +109,7 @@ And then reference the snapshot version on your app module gradle
 Only Speech to Text:
 
 ```gradle
-'com.ibm.watson.developer_cloud:speech-to-text:6.13.1-SNAPSHOT'
+'com.ibm.watson.developer_cloud:speech-to-text:6.13.2-SNAPSHOT'
 ```
 
 ##### JAR
@@ -388,7 +388,7 @@ Gradle:
 
 ```sh
 cd java-sdk
-gradle jar  # build jar file (build/libs/watson-developer-cloud-6.13.0.jar)
+gradle jar  # build jar file (build/libs/watson-developer-cloud-6.13.1.jar)
 gradle test # run tests
 gradle check # performs quality checks on source files and generates reports
 gradle testReport # run tests and generate the aggregated test report (build/reports/allTests)
@@ -441,4 +441,4 @@ or [Stack Overflow](http://stackoverflow.com/questions/ask?tags=ibm-watson).
 [ibm-cloud-onboarding]: http://cloud.ibm.com/registration?target=/developer/watson&cm_sp=WatsonPlatform-WatsonServices-_-OnPageNavLink-IBMWatson_SDKs-_-Java
 
 
-[jar]: https://github.com/watson-developer-cloud/java-sdk/releases/download/java-sdk-6.13.0/java-sdk-6.13.0-jar-with-dependencies.jar
+[jar]: https://github.com/watson-developer-cloud/java-sdk/releases/download/java-sdk-6.13.1/java-sdk-6.13.1-jar-with-dependencies.jar

--- a/assistant/README.md
+++ b/assistant/README.md
@@ -7,13 +7,13 @@
 <dependency>
   <groupId>com.ibm.watson.developer_cloud</groupId>
   <artifactId>assistant</artifactId>
-  <version>6.13.0</version>
+  <version>6.13.1</version>
 </dependency>
 ```
 
 ##### Gradle
 ```gradle
-'com.ibm.watson.developer_cloud:assistant:6.13.0'
+'com.ibm.watson.developer_cloud:assistant:6.13.1'
 ```
 
 ## Usage

--- a/conversation/README.md
+++ b/conversation/README.md
@@ -10,13 +10,13 @@ Conversation will be removed in the next major release. Please migrate to Assist
 <dependency>
   <groupId>com.ibm.watson.developer_cloud</groupId>
   <artifactId>conversation</artifactId>
-  <version>6.13.0</version>
+  <version>6.13.1</version>
 </dependency>
 ```
 
 ##### Gradle
 ```gradle
-'com.ibm.watson.developer_cloud:conversation:6.13.0'
+'com.ibm.watson.developer_cloud:conversation:6.13.1'
 ```
 
 ## Usage

--- a/discovery/README.md
+++ b/discovery/README.md
@@ -7,13 +7,13 @@
 <dependency>
   <groupId>com.ibm.watson.developer_cloud</groupId>
   <artifactId>discovery</artifactId>
-  <version>6.13.0</version>
+  <version>6.13.1</version>
 </dependency>
 ```
 
 ##### Gradle
 ```gradle
-'com.ibm.watson.developer_cloud:discovery:6.13.0'
+'com.ibm.watson.developer_cloud:discovery:6.13.1'
 ```
 
 ## Usage

--- a/language-translator/README.md
+++ b/language-translator/README.md
@@ -7,13 +7,13 @@
 <dependency>
   <groupId>com.ibm.watson.developer_cloud</groupId>
   <artifactId>language-translator</artifactId>
-  <version>6.13.0</version>
+  <version>6.13.1</version>
 </dependency>
 ```
 
 ##### Gradle
 ```gradle
-'com.ibm.watson.developer_cloud:language-translator:6.13.0'
+'com.ibm.watson.developer_cloud:language-translator:6.13.1'
 ```
 
 ## Usage

--- a/natural-language-classifier/README.md
+++ b/natural-language-classifier/README.md
@@ -7,13 +7,13 @@
 <dependency>
   <groupId>com.ibm.watson.developer_cloud</groupId>
   <artifactId>natural-language-classifier</artifactId>
-  <version>6.13.0</version>
+  <version>6.13.1</version>
 </dependency>
 ```
 
 ##### Gradle
 ```gradle
-'com.ibm.watson.developer_cloud:natural-language-classifier:6.13.0'
+'com.ibm.watson.developer_cloud:natural-language-classifier:6.13.1'
 ```
 
 ## Usage

--- a/natural-language-understanding/README.md
+++ b/natural-language-understanding/README.md
@@ -7,13 +7,13 @@
 <dependency>
   <groupId>com.ibm.watson.developer_cloud</groupId>
   <artifactId>natural-language-understanding</artifactId>
-  <version>6.13.0</version>
+  <version>6.13.1</version>
 </dependency>
 ```
 
 ##### Gradle
 ```gradle
-'com.ibm.watson.developer_cloud:natural-language-understanding:6.13.0'
+'com.ibm.watson.developer_cloud:natural-language-understanding:6.13.1'
 ```
 
 ## Usage

--- a/personality-insights/README.md
+++ b/personality-insights/README.md
@@ -7,13 +7,13 @@
 <dependency>
   <groupId>com.ibm.watson.developer_cloud</groupId>
   <artifactId>personality-insights</artifactId>
-  <version>6.13.0</version>
+  <version>6.13.1</version>
 </dependency>
 ```
 
 ##### Gradle
 ```gradle
-'com.ibm.watson.developer_cloud:personality-insights:6.13.0'
+'com.ibm.watson.developer_cloud:personality-insights:6.13.1'
 ```
 
 ## Usage

--- a/speech-to-text/README.md
+++ b/speech-to-text/README.md
@@ -7,13 +7,13 @@
 <dependency>
   <groupId>com.ibm.watson.developer_cloud</groupId>
   <artifactId>speech-to-text</artifactId>
-  <version>6.13.0</version>
+  <version>6.13.1</version>
 </dependency>
 ```
 
 ##### Gradle
 ```gradle
-'com.ibm.watson.developer_cloud:speech-to-text:6.13.0'
+'com.ibm.watson.developer_cloud:speech-to-text:6.13.1'
 ```
 
 ## Usage

--- a/text-to-speech/README.md
+++ b/text-to-speech/README.md
@@ -7,13 +7,13 @@
 <dependency>
   <groupId>com.ibm.watson.developer_cloud</groupId>
   <artifactId>text-to-speech</artifactId>
-  <version>6.13.0</version>
+  <version>6.13.1</version>
 </dependency>
 ```
 
 ##### Gradle
 ```gradle
-'com.ibm.watson.developer_cloud:text-to-speech:6.13.0'
+'com.ibm.watson.developer_cloud:text-to-speech:6.13.1'
 ```
 
 ## Usage

--- a/tone-analyzer/README.md
+++ b/tone-analyzer/README.md
@@ -7,13 +7,13 @@
 <dependency>
   <groupId>com.ibm.watson.developer_cloud</groupId>
   <artifactId>tone-analyzer</artifactId>
-  <version>6.13.0</version>
+  <version>6.13.1</version>
 </dependency>
 ```
 
 ##### Gradle
 ```gradle
-'com.ibm.watson.developer_cloud:tone-analyzer:6.13.0'
+'com.ibm.watson.developer_cloud:tone-analyzer:6.13.1'
 ```
 
 ## Usage

--- a/visual-recognition/README.md
+++ b/visual-recognition/README.md
@@ -7,13 +7,13 @@
 <dependency>
   <groupId>com.ibm.watson.developer_cloud</groupId>
   <artifactId>visual-recognition</artifactId>
-  <version>6.13.0</version>
+  <version>6.13.1</version>
 </dependency>
 ```
 
 ##### Gradle
 ```gradle
-'com.ibm.watson.developer_cloud:visual-recognition:6.13.0'
+'com.ibm.watson.developer_cloud:visual-recognition:6.13.1'
 ```
 
 ## Usage


### PR DESCRIPTION
This PR updates version numbers across the SDK to prepare for a patch release involving some credential logic. The changes in the release can be found [here](https://github.com/watson-developer-cloud/java-sdk/pull/1032).