### PR TITLE
Add headers for analytics

### DIFF
--- a/assistant/src/main/java/com/ibm/watson/developer_cloud/assistant/v1/Assistant.java
+++ b/assistant/src/main/java/com/ibm/watson/developer_cloud/assistant/v1/Assistant.java
@@ -166,6 +166,7 @@ public class Assistant extends WatsonService {
     RequestBuilder builder = RequestBuilder.post(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics", "service_name=conversation;service_version=v1;operation_id=message");
     if (messageOptions.nodesVisitedDetails() != null) {
       builder.query("nodes_visited_details", String.valueOf(messageOptions.nodesVisitedDetails()));
     }
@@ -207,6 +208,8 @@ public class Assistant extends WatsonService {
     String[] pathSegments = { "v1/workspaces" };
     RequestBuilder builder = RequestBuilder.post(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=conversation;service_version=v1;operation_id=createWorkspace");
     if (createWorkspaceOptions != null) {
       final JsonObject contentJson = new JsonObject();
       if (createWorkspaceOptions.name() != null) {
@@ -276,6 +279,8 @@ public class Assistant extends WatsonService {
     RequestBuilder builder = RequestBuilder.delete(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=conversation;service_version=v1;operation_id=deleteWorkspace");
     return createServiceCall(builder.build(), ResponseConverterUtils.getVoid());
   }
 
@@ -297,6 +302,8 @@ public class Assistant extends WatsonService {
     RequestBuilder builder = RequestBuilder.get(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=conversation;service_version=v1;operation_id=getWorkspace");
     if (getWorkspaceOptions.export() != null) {
       builder.query("export", String.valueOf(getWorkspaceOptions.export()));
     }
@@ -323,6 +330,8 @@ public class Assistant extends WatsonService {
     String[] pathSegments = { "v1/workspaces" };
     RequestBuilder builder = RequestBuilder.get(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=conversation;service_version=v1;operation_id=listWorkspaces");
     if (listWorkspacesOptions != null) {
       if (listWorkspacesOptions.pageLimit() != null) {
         builder.query("page_limit", String.valueOf(listWorkspacesOptions.pageLimit()));
@@ -374,6 +383,8 @@ public class Assistant extends WatsonService {
     RequestBuilder builder = RequestBuilder.post(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=conversation;service_version=v1;operation_id=updateWorkspace");
     if (updateWorkspaceOptions.append() != null) {
       builder.query("append", String.valueOf(updateWorkspaceOptions.append()));
     }
@@ -429,6 +440,8 @@ public class Assistant extends WatsonService {
     RequestBuilder builder = RequestBuilder.post(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=conversation;service_version=v1;operation_id=createIntent");
     final JsonObject contentJson = new JsonObject();
     contentJson.addProperty("intent", createIntentOptions.intent());
     if (createIntentOptions.description() != null) {
@@ -458,6 +471,8 @@ public class Assistant extends WatsonService {
     RequestBuilder builder = RequestBuilder.delete(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=conversation;service_version=v1;operation_id=deleteIntent");
     return createServiceCall(builder.build(), ResponseConverterUtils.getVoid());
   }
 
@@ -479,6 +494,7 @@ public class Assistant extends WatsonService {
     RequestBuilder builder = RequestBuilder.get(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics", "service_name=conversation;service_version=v1;operation_id=getIntent");
     if (getIntentOptions.export() != null) {
       builder.query("export", String.valueOf(getIntentOptions.export()));
     }
@@ -506,6 +522,7 @@ public class Assistant extends WatsonService {
     RequestBuilder builder = RequestBuilder.get(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics", "service_name=conversation;service_version=v1;operation_id=listIntents");
     if (listIntentsOptions.export() != null) {
       builder.query("export", String.valueOf(listIntentsOptions.export()));
     }
@@ -545,6 +562,8 @@ public class Assistant extends WatsonService {
     RequestBuilder builder = RequestBuilder.post(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=conversation;service_version=v1;operation_id=updateIntent");
     final JsonObject contentJson = new JsonObject();
     if (updateIntentOptions.newIntent() != null) {
       contentJson.addProperty("intent", updateIntentOptions.newIntent());
@@ -576,6 +595,8 @@ public class Assistant extends WatsonService {
     RequestBuilder builder = RequestBuilder.post(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=conversation;service_version=v1;operation_id=createExample");
     final JsonObject contentJson = new JsonObject();
     contentJson.addProperty("text", createExampleOptions.text());
     if (createExampleOptions.mentions() != null) {
@@ -603,6 +624,8 @@ public class Assistant extends WatsonService {
     RequestBuilder builder = RequestBuilder.delete(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=conversation;service_version=v1;operation_id=deleteExample");
     return createServiceCall(builder.build(), ResponseConverterUtils.getVoid());
   }
 
@@ -623,6 +646,7 @@ public class Assistant extends WatsonService {
     RequestBuilder builder = RequestBuilder.get(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics", "service_name=conversation;service_version=v1;operation_id=getExample");
     if (getExampleOptions.includeAudit() != null) {
       builder.query("include_audit", String.valueOf(getExampleOptions.includeAudit()));
     }
@@ -646,6 +670,8 @@ public class Assistant extends WatsonService {
     RequestBuilder builder = RequestBuilder.get(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=conversation;service_version=v1;operation_id=listExamples");
     if (listExamplesOptions.pageLimit() != null) {
       builder.query("page_limit", String.valueOf(listExamplesOptions.pageLimit()));
     }
@@ -682,6 +708,8 @@ public class Assistant extends WatsonService {
     RequestBuilder builder = RequestBuilder.post(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=conversation;service_version=v1;operation_id=updateExample");
     final JsonObject contentJson = new JsonObject();
     if (updateExampleOptions.newText() != null) {
       contentJson.addProperty("text", updateExampleOptions.newText());
@@ -710,6 +738,8 @@ public class Assistant extends WatsonService {
     RequestBuilder builder = RequestBuilder.post(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=conversation;service_version=v1;operation_id=createCounterexample");
     final JsonObject contentJson = new JsonObject();
     contentJson.addProperty("text", createCounterexampleOptions.text());
     builder.bodyJson(contentJson);
@@ -733,6 +763,8 @@ public class Assistant extends WatsonService {
     RequestBuilder builder = RequestBuilder.delete(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=conversation;service_version=v1;operation_id=deleteCounterexample");
     return createServiceCall(builder.build(), ResponseConverterUtils.getVoid());
   }
 
@@ -753,6 +785,8 @@ public class Assistant extends WatsonService {
     RequestBuilder builder = RequestBuilder.get(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=conversation;service_version=v1;operation_id=getCounterexample");
     if (getCounterexampleOptions.includeAudit() != null) {
       builder.query("include_audit", String.valueOf(getCounterexampleOptions.includeAudit()));
     }
@@ -777,6 +811,8 @@ public class Assistant extends WatsonService {
     RequestBuilder builder = RequestBuilder.get(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=conversation;service_version=v1;operation_id=listCounterexamples");
     if (listCounterexamplesOptions.pageLimit() != null) {
       builder.query("page_limit", String.valueOf(listCounterexamplesOptions.pageLimit()));
     }
@@ -812,6 +848,8 @@ public class Assistant extends WatsonService {
     RequestBuilder builder = RequestBuilder.post(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=conversation;service_version=v1;operation_id=updateCounterexample");
     final JsonObject contentJson = new JsonObject();
     if (updateCounterexampleOptions.newText() != null) {
       contentJson.addProperty("text", updateCounterexampleOptions.newText());
@@ -837,6 +875,8 @@ public class Assistant extends WatsonService {
     RequestBuilder builder = RequestBuilder.post(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=conversation;service_version=v1;operation_id=createEntity");
     final JsonObject contentJson = new JsonObject();
     contentJson.addProperty("entity", createEntityOptions.entity());
     if (createEntityOptions.description() != null) {
@@ -872,6 +912,8 @@ public class Assistant extends WatsonService {
     RequestBuilder builder = RequestBuilder.delete(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=conversation;service_version=v1;operation_id=deleteEntity");
     return createServiceCall(builder.build(), ResponseConverterUtils.getVoid());
   }
 
@@ -893,6 +935,7 @@ public class Assistant extends WatsonService {
     RequestBuilder builder = RequestBuilder.get(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics", "service_name=conversation;service_version=v1;operation_id=getEntity");
     if (getEntityOptions.export() != null) {
       builder.query("export", String.valueOf(getEntityOptions.export()));
     }
@@ -920,6 +963,8 @@ public class Assistant extends WatsonService {
     RequestBuilder builder = RequestBuilder.get(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=conversation;service_version=v1;operation_id=listEntities");
     if (listEntitiesOptions.export() != null) {
       builder.query("export", String.valueOf(listEntitiesOptions.export()));
     }
@@ -959,6 +1004,8 @@ public class Assistant extends WatsonService {
     RequestBuilder builder = RequestBuilder.post(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=conversation;service_version=v1;operation_id=updateEntity");
     final JsonObject contentJson = new JsonObject();
     if (updateEntityOptions.newFuzzyMatch() != null) {
       contentJson.addProperty("fuzzy_match", updateEntityOptions.newFuzzyMatch());
@@ -997,6 +1044,8 @@ public class Assistant extends WatsonService {
     RequestBuilder builder = RequestBuilder.get(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=conversation;service_version=v1;operation_id=listMentions");
     if (listMentionsOptions.export() != null) {
       builder.query("export", String.valueOf(listMentionsOptions.export()));
     }
@@ -1023,6 +1072,7 @@ public class Assistant extends WatsonService {
     RequestBuilder builder = RequestBuilder.post(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics", "service_name=conversation;service_version=v1;operation_id=createValue");
     final JsonObject contentJson = new JsonObject();
     contentJson.addProperty("value", createValueOptions.value());
     if (createValueOptions.metadata() != null) {
@@ -1059,6 +1109,7 @@ public class Assistant extends WatsonService {
     RequestBuilder builder = RequestBuilder.delete(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics", "service_name=conversation;service_version=v1;operation_id=deleteValue");
     return createServiceCall(builder.build(), ResponseConverterUtils.getVoid());
   }
 
@@ -1079,6 +1130,7 @@ public class Assistant extends WatsonService {
     RequestBuilder builder = RequestBuilder.get(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics", "service_name=conversation;service_version=v1;operation_id=getValue");
     if (getValueOptions.export() != null) {
       builder.query("export", String.valueOf(getValueOptions.export()));
     }
@@ -1105,6 +1157,7 @@ public class Assistant extends WatsonService {
     RequestBuilder builder = RequestBuilder.get(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics", "service_name=conversation;service_version=v1;operation_id=listValues");
     if (listValuesOptions.export() != null) {
       builder.query("export", String.valueOf(listValuesOptions.export()));
     }
@@ -1145,6 +1198,7 @@ public class Assistant extends WatsonService {
     RequestBuilder builder = RequestBuilder.post(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics", "service_name=conversation;service_version=v1;operation_id=updateValue");
     final JsonObject contentJson = new JsonObject();
     if (updateValueOptions.newSynonyms() != null) {
       contentJson.add("synonyms", GsonSingleton.getGson().toJsonTree(updateValueOptions.newSynonyms()));
@@ -1183,6 +1237,8 @@ public class Assistant extends WatsonService {
     RequestBuilder builder = RequestBuilder.post(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=conversation;service_version=v1;operation_id=createSynonym");
     final JsonObject contentJson = new JsonObject();
     contentJson.addProperty("synonym", createSynonymOptions.synonym());
     builder.bodyJson(contentJson);
@@ -1207,6 +1263,8 @@ public class Assistant extends WatsonService {
     RequestBuilder builder = RequestBuilder.delete(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=conversation;service_version=v1;operation_id=deleteSynonym");
     return createServiceCall(builder.build(), ResponseConverterUtils.getVoid());
   }
 
@@ -1228,6 +1286,7 @@ public class Assistant extends WatsonService {
     RequestBuilder builder = RequestBuilder.get(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics", "service_name=conversation;service_version=v1;operation_id=getSynonym");
     if (getSynonymOptions.includeAudit() != null) {
       builder.query("include_audit", String.valueOf(getSynonymOptions.includeAudit()));
     }
@@ -1252,6 +1311,8 @@ public class Assistant extends WatsonService {
     RequestBuilder builder = RequestBuilder.get(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=conversation;service_version=v1;operation_id=listSynonyms");
     if (listSynonymsOptions.pageLimit() != null) {
       builder.query("page_limit", String.valueOf(listSynonymsOptions.pageLimit()));
     }
@@ -1288,6 +1349,8 @@ public class Assistant extends WatsonService {
     RequestBuilder builder = RequestBuilder.post(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=conversation;service_version=v1;operation_id=updateSynonym");
     final JsonObject contentJson = new JsonObject();
     if (updateSynonymOptions.newSynonym() != null) {
       contentJson.addProperty("synonym", updateSynonymOptions.newSynonym());
@@ -1313,6 +1376,8 @@ public class Assistant extends WatsonService {
     RequestBuilder builder = RequestBuilder.post(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=conversation;service_version=v1;operation_id=createDialogNode");
     final JsonObject contentJson = new JsonObject();
     contentJson.addProperty("dialog_node", createDialogNodeOptions.dialogNode());
     if (createDialogNodeOptions.description() != null) {
@@ -1387,6 +1452,8 @@ public class Assistant extends WatsonService {
     RequestBuilder builder = RequestBuilder.delete(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=conversation;service_version=v1;operation_id=deleteDialogNode");
     return createServiceCall(builder.build(), ResponseConverterUtils.getVoid());
   }
 
@@ -1407,6 +1474,8 @@ public class Assistant extends WatsonService {
     RequestBuilder builder = RequestBuilder.get(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=conversation;service_version=v1;operation_id=getDialogNode");
     if (getDialogNodeOptions.includeAudit() != null) {
       builder.query("include_audit", String.valueOf(getDialogNodeOptions.includeAudit()));
     }
@@ -1430,6 +1499,8 @@ public class Assistant extends WatsonService {
     RequestBuilder builder = RequestBuilder.get(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=conversation;service_version=v1;operation_id=listDialogNodes");
     if (listDialogNodesOptions.pageLimit() != null) {
       builder.query("page_limit", String.valueOf(listDialogNodesOptions.pageLimit()));
     }
@@ -1465,6 +1536,8 @@ public class Assistant extends WatsonService {
     RequestBuilder builder = RequestBuilder.post(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=conversation;service_version=v1;operation_id=updateDialogNode");
     final JsonObject contentJson = new JsonObject();
     if (updateDialogNodeOptions.nodeType() != null) {
       contentJson.addProperty("type", updateDialogNodeOptions.nodeType());
@@ -1540,6 +1613,7 @@ public class Assistant extends WatsonService {
     String[] pathSegments = { "v1/logs" };
     RequestBuilder builder = RequestBuilder.get(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics", "service_name=conversation;service_version=v1;operation_id=listAllLogs");
     builder.query("filter", listAllLogsOptions.filter());
     if (listAllLogsOptions.sort() != null) {
       builder.query("sort", listAllLogsOptions.sort());
@@ -1571,6 +1645,7 @@ public class Assistant extends WatsonService {
     RequestBuilder builder = RequestBuilder.get(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics", "service_name=conversation;service_version=v1;operation_id=listLogs");
     if (listLogsOptions.sort() != null) {
       builder.query("sort", listLogsOptions.sort());
     }
@@ -1604,6 +1679,8 @@ public class Assistant extends WatsonService {
     String[] pathSegments = { "v1/user_data" };
     RequestBuilder builder = RequestBuilder.delete(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=conversation;service_version=v1;operation_id=deleteUserData");
     builder.query("customer_id", deleteUserDataOptions.customerId());
     return createServiceCall(builder.build(), ResponseConverterUtils.getVoid());
   }

--- a/assistant/src/main/java/com/ibm/watson/developer_cloud/assistant/v2/Assistant.java
+++ b/assistant/src/main/java/com/ibm/watson/developer_cloud/assistant/v2/Assistant.java
@@ -102,6 +102,8 @@ public class Assistant extends WatsonService {
     RequestBuilder builder = RequestBuilder.post(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=conversation;service_version=v2;operation_id=createSession");
     return createServiceCall(builder.build(), ResponseConverterUtils.getObject(SessionResponse.class));
   }
 
@@ -120,6 +122,8 @@ public class Assistant extends WatsonService {
     RequestBuilder builder = RequestBuilder.delete(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=conversation;service_version=v2;operation_id=deleteSession");
     return createServiceCall(builder.build(), ResponseConverterUtils.getVoid());
   }
 
@@ -140,6 +144,7 @@ public class Assistant extends WatsonService {
     RequestBuilder builder = RequestBuilder.post(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics", "service_name=conversation;service_version=v2;operation_id=message");
     final JsonObject contentJson = new JsonObject();
     if (messageOptions.input() != null) {
       contentJson.add("input", GsonSingleton.getGson().toJsonTree(messageOptions.input()));

--- a/compare-comply/src/main/java/com/ibm/watson/developer_cloud/compare_comply/v1/CompareComply.java
+++ b/compare-comply/src/main/java/com/ibm/watson/developer_cloud/compare_comply/v1/CompareComply.java
@@ -105,6 +105,8 @@ public class CompareComply extends WatsonService {
     String[] pathSegments = { "v1/html_conversion" };
     RequestBuilder builder = RequestBuilder.post(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=compare-comply;service_version=v1;operation_id=convertToHtml");
     if (convertToHtmlOptions.modelId() != null) {
       builder.query("model_id", convertToHtmlOptions.modelId());
     }
@@ -130,6 +132,8 @@ public class CompareComply extends WatsonService {
     String[] pathSegments = { "v1/element_classification" };
     RequestBuilder builder = RequestBuilder.post(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=compare-comply;service_version=v1;operation_id=classifyElements");
     if (classifyElementsOptions.modelId() != null) {
       builder.query("model_id", classifyElementsOptions.modelId());
     }
@@ -155,6 +159,8 @@ public class CompareComply extends WatsonService {
     String[] pathSegments = { "v1/tables" };
     RequestBuilder builder = RequestBuilder.post(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=compare-comply;service_version=v1;operation_id=extractTables");
     if (extractTablesOptions.modelId() != null) {
       builder.query("model_id", extractTablesOptions.modelId());
     }
@@ -181,6 +187,8 @@ public class CompareComply extends WatsonService {
     String[] pathSegments = { "v1/comparison" };
     RequestBuilder builder = RequestBuilder.post(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=compare-comply;service_version=v1;operation_id=compareDocuments");
     if (compareDocumentsOptions.file1Label() != null) {
       builder.query("file_1_label", compareDocumentsOptions.file1Label());
     }
@@ -217,6 +225,8 @@ public class CompareComply extends WatsonService {
     String[] pathSegments = { "v1/feedback" };
     RequestBuilder builder = RequestBuilder.post(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=compare-comply;service_version=v1;operation_id=addFeedback");
     final JsonObject contentJson = new JsonObject();
     if (addFeedbackOptions.userId() != null) {
       contentJson.addProperty("user_id", addFeedbackOptions.userId());
@@ -242,6 +252,8 @@ public class CompareComply extends WatsonService {
     RequestBuilder builder = RequestBuilder.delete(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=compare-comply;service_version=v1;operation_id=deleteFeedback");
     if (deleteFeedbackOptions.modelId() != null) {
       builder.query("model_id", deleteFeedbackOptions.modelId());
     }
@@ -261,6 +273,8 @@ public class CompareComply extends WatsonService {
     RequestBuilder builder = RequestBuilder.get(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=compare-comply;service_version=v1;operation_id=getFeedback");
     if (getFeedbackOptions.modelId() != null) {
       builder.query("model_id", getFeedbackOptions.modelId());
     }
@@ -277,6 +291,8 @@ public class CompareComply extends WatsonService {
     String[] pathSegments = { "v1/feedback" };
     RequestBuilder builder = RequestBuilder.get(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=compare-comply;service_version=v1;operation_id=listFeedback");
     if (listFeedbackOptions != null) {
       if (listFeedbackOptions.feedbackType() != null) {
         builder.query("feedback_type", listFeedbackOptions.feedbackType());
@@ -357,6 +373,8 @@ public class CompareComply extends WatsonService {
     String[] pathSegments = { "v1/batches" };
     RequestBuilder builder = RequestBuilder.post(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=compare-comply;service_version=v1;operation_id=createBatch");
     builder.query("function", createBatchOptions.function());
     if (createBatchOptions.modelId() != null) {
       builder.query("model_id", createBatchOptions.modelId());
@@ -394,6 +412,7 @@ public class CompareComply extends WatsonService {
     RequestBuilder builder = RequestBuilder.get(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics", "service_name=compare-comply;service_version=v1;operation_id=getBatch");
     return createServiceCall(builder.build(), ResponseConverterUtils.getObject(BatchStatus.class));
   }
 
@@ -409,6 +428,8 @@ public class CompareComply extends WatsonService {
     String[] pathSegments = { "v1/batches" };
     RequestBuilder builder = RequestBuilder.get(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=compare-comply;service_version=v1;operation_id=listBatches");
     if (listBatchesOptions != null) {
     }
     return createServiceCall(builder.build(), ResponseConverterUtils.getObject(Batches.class));
@@ -441,6 +462,8 @@ public class CompareComply extends WatsonService {
     RequestBuilder builder = RequestBuilder.put(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=compare-comply;service_version=v1;operation_id=updateBatch");
     builder.query("action", updateBatchOptions.action());
     if (updateBatchOptions.modelId() != null) {
       builder.query("model_id", updateBatchOptions.modelId());

--- a/core/src/main/java/com/ibm/watson/developer_cloud/util/RequestUtils.java
+++ b/core/src/main/java/com/ibm/watson/developer_cloud/util/RequestUtils.java
@@ -39,7 +39,7 @@ public final class RequestUtils {
   private static final Logger LOG = Logger.getLogger(RequestUtils.class.getName());
 
   private static final String[] properties =
-      new String[] { "java.vendor", "java.version", "os.arch", "os.name", "os.version" };
+      new String[] { "os.name", "os.version", "java.vendor", "java.version" };
   private static String userAgent;
 
   private RequestUtils() {
@@ -175,10 +175,10 @@ public final class RequestUtils {
   private static String buildUserAgent() {
     final List<String> details = new ArrayList<String>();
     for (String propertyName : properties) {
-      details.add(propertyName + "=" + System.getProperty(propertyName));
+      details.add(System.getProperty(propertyName));
     }
 
-    return "watson-apis-java-sdk/" + loadSdkVersion() + " (" + RequestUtils.join(details, "; ") + ")";
+    return "watson-apis-java-sdk-" + loadSdkVersion() + " " + RequestUtils.join(details, " ");
   }
 
   /**

--- a/core/src/test/java/com/ibm/watson/developer_cloud/service/RequestBuilderTest.java
+++ b/core/src/test/java/com/ibm/watson/developer_cloud/service/RequestBuilderTest.java
@@ -252,7 +252,7 @@ public class RequestBuilderTest {
   @Test
   public void testUserAgent() {
     assertNotNull(RequestUtils.getUserAgent());
-    assertTrue(RequestUtils.getUserAgent().startsWith("watson-apis-java-sdk/"));
+    assertTrue(RequestUtils.getUserAgent().startsWith("watson-apis-java-sdk-"));
   }
 
 }

--- a/discovery/src/main/java/com/ibm/watson/developer_cloud/discovery/v1/Discovery.java
+++ b/discovery/src/main/java/com/ibm/watson/developer_cloud/discovery/v1/Discovery.java
@@ -194,6 +194,8 @@ public class Discovery extends WatsonService {
     String[] pathSegments = { "v1/environments" };
     RequestBuilder builder = RequestBuilder.post(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=discovery;service_version=v1;operation_id=createEnvironment");
     final JsonObject contentJson = new JsonObject();
     contentJson.addProperty("name", createEnvironmentOptions.name());
     if (createEnvironmentOptions.description() != null) {
@@ -219,6 +221,8 @@ public class Discovery extends WatsonService {
     RequestBuilder builder = RequestBuilder.delete(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=discovery;service_version=v1;operation_id=deleteEnvironment");
     return createServiceCall(builder.build(), ResponseConverterUtils.getVoid());
   }
 
@@ -235,6 +239,7 @@ public class Discovery extends WatsonService {
     RequestBuilder builder = RequestBuilder.get(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics", "service_name=discovery;service_version=v1;operation_id=getEnvironment");
     return createServiceCall(builder.build(), ResponseConverterUtils.getObject(Environment.class));
   }
 
@@ -250,6 +255,8 @@ public class Discovery extends WatsonService {
     String[] pathSegments = { "v1/environments" };
     RequestBuilder builder = RequestBuilder.get(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=discovery;service_version=v1;operation_id=listEnvironments");
     if (listEnvironmentsOptions != null) {
       if (listEnvironmentsOptions.name() != null) {
         builder.query("name", listEnvironmentsOptions.name());
@@ -284,6 +291,7 @@ public class Discovery extends WatsonService {
     RequestBuilder builder = RequestBuilder.get(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics", "service_name=discovery;service_version=v1;operation_id=listFields");
     builder.query("collection_ids", RequestUtils.join(listFieldsOptions.collectionIds(), ","));
     return createServiceCall(builder.build(), ResponseConverterUtils.getObject(ListCollectionFieldsResponse.class));
   }
@@ -304,6 +312,8 @@ public class Discovery extends WatsonService {
     RequestBuilder builder = RequestBuilder.put(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=discovery;service_version=v1;operation_id=updateEnvironment");
     final JsonObject contentJson = new JsonObject();
     if (updateEnvironmentOptions.name() != null) {
       contentJson.addProperty("name", updateEnvironmentOptions.name());
@@ -341,6 +351,8 @@ public class Discovery extends WatsonService {
     RequestBuilder builder = RequestBuilder.post(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=discovery;service_version=v1;operation_id=createConfiguration");
     final JsonObject contentJson = new JsonObject();
     if (createConfigurationOptions.name() != null) {
       contentJson.addProperty("name", createConfigurationOptions.name());
@@ -384,6 +396,8 @@ public class Discovery extends WatsonService {
     RequestBuilder builder = RequestBuilder.delete(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=discovery;service_version=v1;operation_id=deleteConfiguration");
     return createServiceCall(builder.build(), ResponseConverterUtils.getVoid());
   }
 
@@ -400,6 +414,8 @@ public class Discovery extends WatsonService {
     RequestBuilder builder = RequestBuilder.get(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=discovery;service_version=v1;operation_id=getConfiguration");
     return createServiceCall(builder.build(), ResponseConverterUtils.getObject(Configuration.class));
   }
 
@@ -419,6 +435,8 @@ public class Discovery extends WatsonService {
     RequestBuilder builder = RequestBuilder.get(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=discovery;service_version=v1;operation_id=listConfigurations");
     if (listConfigurationsOptions.name() != null) {
       builder.query("name", listConfigurationsOptions.name());
     }
@@ -447,6 +465,8 @@ public class Discovery extends WatsonService {
     RequestBuilder builder = RequestBuilder.put(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=discovery;service_version=v1;operation_id=updateConfiguration");
     final JsonObject contentJson = new JsonObject();
     if (updateConfigurationOptions.name() != null) {
       contentJson.addProperty("name", updateConfigurationOptions.name());
@@ -492,6 +512,8 @@ public class Discovery extends WatsonService {
     RequestBuilder builder = RequestBuilder.post(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=discovery;service_version=v1;operation_id=testConfigurationInEnvironment");
     if (testConfigurationInEnvironmentOptions.step() != null) {
       builder.query("step", testConfigurationInEnvironmentOptions.step());
     }
@@ -528,6 +550,8 @@ public class Discovery extends WatsonService {
     RequestBuilder builder = RequestBuilder.post(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=discovery;service_version=v1;operation_id=createCollection");
     final JsonObject contentJson = new JsonObject();
     contentJson.addProperty("name", createCollectionOptions.name());
     if (createCollectionOptions.description() != null) {
@@ -556,6 +580,8 @@ public class Discovery extends WatsonService {
     RequestBuilder builder = RequestBuilder.delete(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=discovery;service_version=v1;operation_id=deleteCollection");
     return createServiceCall(builder.build(), ResponseConverterUtils.getVoid());
   }
 
@@ -572,6 +598,7 @@ public class Discovery extends WatsonService {
     RequestBuilder builder = RequestBuilder.get(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics", "service_name=discovery;service_version=v1;operation_id=getCollection");
     return createServiceCall(builder.build(), ResponseConverterUtils.getObject(Collection.class));
   }
 
@@ -592,6 +619,8 @@ public class Discovery extends WatsonService {
     RequestBuilder builder = RequestBuilder.get(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=discovery;service_version=v1;operation_id=listCollectionFields");
     return createServiceCall(builder.build(), ResponseConverterUtils.getObject(ListCollectionFieldsResponse.class));
   }
 
@@ -610,6 +639,8 @@ public class Discovery extends WatsonService {
     RequestBuilder builder = RequestBuilder.get(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=discovery;service_version=v1;operation_id=listCollections");
     if (listCollectionsOptions.name() != null) {
       builder.query("name", listCollectionsOptions.name());
     }
@@ -629,6 +660,8 @@ public class Discovery extends WatsonService {
     RequestBuilder builder = RequestBuilder.put(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=discovery;service_version=v1;operation_id=updateCollection");
     final JsonObject contentJson = new JsonObject();
     if (updateCollectionOptions.name() != null) {
       contentJson.addProperty("name", updateCollectionOptions.name());
@@ -660,6 +693,8 @@ public class Discovery extends WatsonService {
     RequestBuilder builder = RequestBuilder.post(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=discovery;service_version=v1;operation_id=createExpansions");
     final JsonObject contentJson = new JsonObject();
     if (createExpansionsOptions.expansions() != null) {
       contentJson.add("expansions", GsonSingleton.getGson().toJsonTree(createExpansionsOptions.expansions()));
@@ -683,6 +718,8 @@ public class Discovery extends WatsonService {
     RequestBuilder builder = RequestBuilder.post(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=discovery;service_version=v1;operation_id=createStopwordList");
     MultipartBody.Builder multipartBuilder = new MultipartBody.Builder();
     multipartBuilder.setType(MultipartBody.FORM);
     RequestBody stopwordFileBody = RequestUtils.inputStreamBody(createStopwordListOptions.stopwordFile(),
@@ -710,6 +747,8 @@ public class Discovery extends WatsonService {
     RequestBuilder builder = RequestBuilder.post(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=discovery;service_version=v1;operation_id=createTokenizationDictionary");
     final JsonObject contentJson = new JsonObject();
     if (createTokenizationDictionaryOptions.tokenizationRules() != null) {
       contentJson.add("tokenization_rules", GsonSingleton.getGson().toJsonTree(createTokenizationDictionaryOptions
@@ -735,6 +774,8 @@ public class Discovery extends WatsonService {
     RequestBuilder builder = RequestBuilder.delete(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=discovery;service_version=v1;operation_id=deleteExpansions");
     return createServiceCall(builder.build(), ResponseConverterUtils.getVoid());
   }
 
@@ -754,6 +795,8 @@ public class Discovery extends WatsonService {
     RequestBuilder builder = RequestBuilder.delete(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=discovery;service_version=v1;operation_id=deleteStopwordList");
     return createServiceCall(builder.build(), ResponseConverterUtils.getVoid());
   }
 
@@ -775,6 +818,8 @@ public class Discovery extends WatsonService {
     RequestBuilder builder = RequestBuilder.delete(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=discovery;service_version=v1;operation_id=deleteTokenizationDictionary");
     return createServiceCall(builder.build(), ResponseConverterUtils.getVoid());
   }
 
@@ -796,6 +841,8 @@ public class Discovery extends WatsonService {
     RequestBuilder builder = RequestBuilder.get(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=discovery;service_version=v1;operation_id=getTokenizationDictionaryStatus");
     return createServiceCall(builder.build(), ResponseConverterUtils.getObject(TokenDictStatusResponse.class));
   }
 
@@ -815,6 +862,7 @@ public class Discovery extends WatsonService {
     RequestBuilder builder = RequestBuilder.get(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics", "service_name=discovery;service_version=v1;operation_id=listExpansions");
     return createServiceCall(builder.build(), ResponseConverterUtils.getObject(Expansions.class));
   }
 
@@ -853,6 +901,7 @@ public class Discovery extends WatsonService {
     RequestBuilder builder = RequestBuilder.post(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics", "service_name=discovery;service_version=v1;operation_id=addDocument");
     MultipartBody.Builder multipartBuilder = new MultipartBody.Builder();
     multipartBuilder.setType(MultipartBody.FORM);
     if (addDocumentOptions.file() != null) {
@@ -884,6 +933,7 @@ public class Discovery extends WatsonService {
     RequestBuilder builder = RequestBuilder.delete(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics", "service_name=discovery;service_version=v1;operation_id=deleteDocument");
     return createServiceCall(builder.build(), ResponseConverterUtils.getVoid());
   }
 
@@ -905,6 +955,8 @@ public class Discovery extends WatsonService {
     RequestBuilder builder = RequestBuilder.get(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=discovery;service_version=v1;operation_id=getDocumentStatus");
     return createServiceCall(builder.build(), ResponseConverterUtils.getObject(DocumentStatus.class));
   }
 
@@ -926,6 +978,7 @@ public class Discovery extends WatsonService {
     RequestBuilder builder = RequestBuilder.post(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics", "service_name=discovery;service_version=v1;operation_id=updateDocument");
     MultipartBody.Builder multipartBuilder = new MultipartBody.Builder();
     multipartBuilder.setType(MultipartBody.FORM);
     if (updateDocumentOptions.file() != null) {
@@ -957,6 +1010,7 @@ public class Discovery extends WatsonService {
     RequestBuilder builder = RequestBuilder.post(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics", "service_name=discovery;service_version=v1;operation_id=federatedQuery");
     if (federatedQueryOptions.loggingOptOut() != null) {
       builder.header("X-Watson-Logging-Opt-Out", federatedQueryOptions.loggingOptOut());
     }
@@ -1045,6 +1099,8 @@ public class Discovery extends WatsonService {
     RequestBuilder builder = RequestBuilder.get(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=discovery;service_version=v1;operation_id=federatedQueryNotices");
     builder.query("collection_ids", RequestUtils.join(federatedQueryNoticesOptions.collectionIds(), ","));
     if (federatedQueryNoticesOptions.filter() != null) {
       builder.query("filter", federatedQueryNoticesOptions.filter());
@@ -1105,6 +1161,7 @@ public class Discovery extends WatsonService {
     RequestBuilder builder = RequestBuilder.post(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics", "service_name=discovery;service_version=v1;operation_id=query");
     if (queryOptions.loggingOptOut() != null) {
       builder.header("X-Watson-Logging-Opt-Out", queryOptions.loggingOptOut());
     }
@@ -1189,6 +1246,7 @@ public class Discovery extends WatsonService {
     RequestBuilder builder = RequestBuilder.post(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics", "service_name=discovery;service_version=v1;operation_id=queryEntities");
     final JsonObject contentJson = new JsonObject();
     if (queryEntitiesOptions.feature() != null) {
       contentJson.addProperty("feature", queryEntitiesOptions.feature());
@@ -1227,6 +1285,7 @@ public class Discovery extends WatsonService {
     RequestBuilder builder = RequestBuilder.get(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics", "service_name=discovery;service_version=v1;operation_id=queryNotices");
     if (queryNoticesOptions.filter() != null) {
       builder.query("filter", queryNoticesOptions.filter());
     }
@@ -1297,6 +1356,7 @@ public class Discovery extends WatsonService {
     RequestBuilder builder = RequestBuilder.post(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics", "service_name=discovery;service_version=v1;operation_id=queryRelations");
     final JsonObject contentJson = new JsonObject();
     if (queryRelationsOptions.entities() != null) {
       contentJson.add("entities", GsonSingleton.getGson().toJsonTree(queryRelationsOptions.entities()));
@@ -1335,6 +1395,8 @@ public class Discovery extends WatsonService {
     RequestBuilder builder = RequestBuilder.post(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=discovery;service_version=v1;operation_id=addTrainingData");
     final JsonObject contentJson = new JsonObject();
     if (addTrainingDataOptions.naturalLanguageQuery() != null) {
       contentJson.addProperty("natural_language_query", addTrainingDataOptions.naturalLanguageQuery());
@@ -1365,6 +1427,8 @@ public class Discovery extends WatsonService {
     RequestBuilder builder = RequestBuilder.post(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=discovery;service_version=v1;operation_id=createTrainingExample");
     final JsonObject contentJson = new JsonObject();
     if (createTrainingExampleOptions.documentId() != null) {
       contentJson.addProperty("document_id", createTrainingExampleOptions.documentId());
@@ -1395,6 +1459,8 @@ public class Discovery extends WatsonService {
     RequestBuilder builder = RequestBuilder.delete(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=discovery;service_version=v1;operation_id=deleteAllTrainingData");
     return createServiceCall(builder.build(), ResponseConverterUtils.getVoid());
   }
 
@@ -1414,6 +1480,8 @@ public class Discovery extends WatsonService {
     RequestBuilder builder = RequestBuilder.delete(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=discovery;service_version=v1;operation_id=deleteTrainingData");
     return createServiceCall(builder.build(), ResponseConverterUtils.getVoid());
   }
 
@@ -1433,6 +1501,8 @@ public class Discovery extends WatsonService {
     RequestBuilder builder = RequestBuilder.delete(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=discovery;service_version=v1;operation_id=deleteTrainingExample");
     return createServiceCall(builder.build(), ResponseConverterUtils.getVoid());
   }
 
@@ -1452,6 +1522,8 @@ public class Discovery extends WatsonService {
     RequestBuilder builder = RequestBuilder.get(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=discovery;service_version=v1;operation_id=getTrainingData");
     return createServiceCall(builder.build(), ResponseConverterUtils.getObject(TrainingQuery.class));
   }
 
@@ -1471,6 +1543,8 @@ public class Discovery extends WatsonService {
     RequestBuilder builder = RequestBuilder.get(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=discovery;service_version=v1;operation_id=getTrainingExample");
     return createServiceCall(builder.build(), ResponseConverterUtils.getObject(TrainingExample.class));
   }
 
@@ -1489,6 +1563,8 @@ public class Discovery extends WatsonService {
     RequestBuilder builder = RequestBuilder.get(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=discovery;service_version=v1;operation_id=listTrainingData");
     return createServiceCall(builder.build(), ResponseConverterUtils.getObject(TrainingDataSet.class));
   }
 
@@ -1509,6 +1585,8 @@ public class Discovery extends WatsonService {
     RequestBuilder builder = RequestBuilder.get(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=discovery;service_version=v1;operation_id=listTrainingExamples");
     return createServiceCall(builder.build(), ResponseConverterUtils.getObject(TrainingExampleList.class));
   }
 
@@ -1528,6 +1606,8 @@ public class Discovery extends WatsonService {
     RequestBuilder builder = RequestBuilder.put(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=discovery;service_version=v1;operation_id=updateTrainingExample");
     final JsonObject contentJson = new JsonObject();
     if (updateTrainingExampleOptions.crossReference() != null) {
       contentJson.addProperty("cross_reference", updateTrainingExampleOptions.crossReference());
@@ -1557,6 +1637,7 @@ public class Discovery extends WatsonService {
     String[] pathSegments = { "v1/user_data" };
     RequestBuilder builder = RequestBuilder.delete(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics", "service_name=discovery;service_version=v1;operation_id=deleteUserData");
     builder.query("customer_id", deleteUserDataOptions.customerId());
     return createServiceCall(builder.build(), ResponseConverterUtils.getVoid());
   }
@@ -1575,6 +1656,7 @@ public class Discovery extends WatsonService {
     String[] pathSegments = { "v1/events" };
     RequestBuilder builder = RequestBuilder.post(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics", "service_name=discovery;service_version=v1;operation_id=createEvent");
     final JsonObject contentJson = new JsonObject();
     contentJson.addProperty("type", createEventOptions.type());
     contentJson.add("data", GsonSingleton.getGson().toJsonTree(createEventOptions.data()));
@@ -1596,6 +1678,8 @@ public class Discovery extends WatsonService {
     String[] pathSegments = { "v1/metrics/event_rate" };
     RequestBuilder builder = RequestBuilder.get(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=discovery;service_version=v1;operation_id=getMetricsEventRate");
     if (getMetricsEventRateOptions != null) {
       if (getMetricsEventRateOptions.startTime() != null) {
         builder.query("start_time", String.valueOf(getMetricsEventRateOptions.startTime()));
@@ -1635,6 +1719,8 @@ public class Discovery extends WatsonService {
     String[] pathSegments = { "v1/metrics/number_of_queries" };
     RequestBuilder builder = RequestBuilder.get(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=discovery;service_version=v1;operation_id=getMetricsQuery");
     if (getMetricsQueryOptions != null) {
       if (getMetricsQueryOptions.startTime() != null) {
         builder.query("start_time", String.valueOf(getMetricsQueryOptions.startTime()));
@@ -1674,6 +1760,8 @@ public class Discovery extends WatsonService {
     String[] pathSegments = { "v1/metrics/number_of_queries_with_event" };
     RequestBuilder builder = RequestBuilder.get(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=discovery;service_version=v1;operation_id=getMetricsQueryEvent");
     if (getMetricsQueryEventOptions != null) {
       if (getMetricsQueryEventOptions.startTime() != null) {
         builder.query("start_time", String.valueOf(getMetricsQueryEventOptions.startTime()));
@@ -1716,6 +1804,8 @@ public class Discovery extends WatsonService {
     String[] pathSegments = { "v1/metrics/number_of_queries_with_no_search_results" };
     RequestBuilder builder = RequestBuilder.get(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=discovery;service_version=v1;operation_id=getMetricsQueryNoResults");
     if (getMetricsQueryNoResultsOptions != null) {
       if (getMetricsQueryNoResultsOptions.startTime() != null) {
         builder.query("start_time", String.valueOf(getMetricsQueryNoResultsOptions.startTime()));
@@ -1758,6 +1848,8 @@ public class Discovery extends WatsonService {
     String[] pathSegments = { "v1/metrics/top_query_tokens_with_event_rate" };
     RequestBuilder builder = RequestBuilder.get(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=discovery;service_version=v1;operation_id=getMetricsQueryTokenEvent");
     if (getMetricsQueryTokenEventOptions != null) {
       if (getMetricsQueryTokenEventOptions.count() != null) {
         builder.query("count", String.valueOf(getMetricsQueryTokenEventOptions.count()));
@@ -1792,6 +1884,7 @@ public class Discovery extends WatsonService {
     String[] pathSegments = { "v1/logs" };
     RequestBuilder builder = RequestBuilder.get(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics", "service_name=discovery;service_version=v1;operation_id=queryLog");
     if (queryLogOptions != null) {
       if (queryLogOptions.filter() != null) {
         builder.query("filter", queryLogOptions.filter());
@@ -1842,6 +1935,8 @@ public class Discovery extends WatsonService {
     RequestBuilder builder = RequestBuilder.post(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=discovery;service_version=v1;operation_id=createCredentials");
     final JsonObject contentJson = new JsonObject();
     if (createCredentialsOptions.sourceType() != null) {
       contentJson.addProperty("source_type", createCredentialsOptions.sourceType());
@@ -1869,6 +1964,8 @@ public class Discovery extends WatsonService {
     RequestBuilder builder = RequestBuilder.delete(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=discovery;service_version=v1;operation_id=deleteCredentials");
     return createServiceCall(builder.build(), ResponseConverterUtils.getVoid());
   }
 
@@ -1890,6 +1987,7 @@ public class Discovery extends WatsonService {
     RequestBuilder builder = RequestBuilder.get(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics", "service_name=discovery;service_version=v1;operation_id=getCredentials");
     return createServiceCall(builder.build(), ResponseConverterUtils.getObject(Credentials.class));
   }
 
@@ -1910,6 +2008,8 @@ public class Discovery extends WatsonService {
     RequestBuilder builder = RequestBuilder.get(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=discovery;service_version=v1;operation_id=listCredentials");
     return createServiceCall(builder.build(), ResponseConverterUtils.getObject(CredentialsList.class));
   }
 
@@ -1930,6 +2030,8 @@ public class Discovery extends WatsonService {
     RequestBuilder builder = RequestBuilder.put(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=discovery;service_version=v1;operation_id=updateCredentials");
     final JsonObject contentJson = new JsonObject();
     if (updateCredentialsOptions.sourceType() != null) {
       contentJson.addProperty("source_type", updateCredentialsOptions.sourceType());
@@ -1957,6 +2059,7 @@ public class Discovery extends WatsonService {
     RequestBuilder builder = RequestBuilder.post(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics", "service_name=discovery;service_version=v1;operation_id=createGateway");
     final JsonObject contentJson = new JsonObject();
     if (createGatewayOptions.name() != null) {
       contentJson.addProperty("name", createGatewayOptions.name());
@@ -1980,6 +2083,7 @@ public class Discovery extends WatsonService {
     RequestBuilder builder = RequestBuilder.delete(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics", "service_name=discovery;service_version=v1;operation_id=deleteGateway");
     return createServiceCall(builder.build(), ResponseConverterUtils.getVoid());
   }
 
@@ -1998,6 +2102,7 @@ public class Discovery extends WatsonService {
     RequestBuilder builder = RequestBuilder.get(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics", "service_name=discovery;service_version=v1;operation_id=getGateway");
     return createServiceCall(builder.build(), ResponseConverterUtils.getObject(Gateway.class));
   }
 
@@ -2016,6 +2121,7 @@ public class Discovery extends WatsonService {
     RequestBuilder builder = RequestBuilder.get(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics", "service_name=discovery;service_version=v1;operation_id=listGateways");
     return createServiceCall(builder.build(), ResponseConverterUtils.getObject(GatewayList.class));
   }
 

--- a/language-translator/src/main/java/com/ibm/watson/developer_cloud/language_translator/v3/LanguageTranslator.java
+++ b/language-translator/src/main/java/com/ibm/watson/developer_cloud/language_translator/v3/LanguageTranslator.java
@@ -111,6 +111,8 @@ public class LanguageTranslator extends WatsonService {
     String[] pathSegments = { "v3/translate" };
     RequestBuilder builder = RequestBuilder.post(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=language_translator;service_version=v3;operation_id=translate");
     final JsonObject contentJson = new JsonObject();
     contentJson.add("text", GsonSingleton.getGson().toJsonTree(translateOptions.text()));
     if (translateOptions.modelId() != null) {
@@ -139,6 +141,8 @@ public class LanguageTranslator extends WatsonService {
     String[] pathSegments = { "v3/identify" };
     RequestBuilder builder = RequestBuilder.post(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=language_translator;service_version=v3;operation_id=identify");
     builder.bodyContent(identifyOptions.text(), "text/plain");
     return createServiceCall(builder.build(), ResponseConverterUtils.getObject(IdentifiedLanguages.class));
   }
@@ -158,6 +162,8 @@ public class LanguageTranslator extends WatsonService {
     String[] pathSegments = { "v3/identifiable_languages" };
     RequestBuilder builder = RequestBuilder.get(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=language_translator;service_version=v3;operation_id=listIdentifiableLanguages");
     if (listIdentifiableLanguagesOptions != null) {
     }
     return createServiceCall(builder.build(), ResponseConverterUtils.getObject(IdentifiableLanguages.class));
@@ -201,6 +207,8 @@ public class LanguageTranslator extends WatsonService {
     String[] pathSegments = { "v3/models" };
     RequestBuilder builder = RequestBuilder.post(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=language_translator;service_version=v3;operation_id=createModel");
     builder.query("base_model_id", createModelOptions.baseModelId());
     if (createModelOptions.name() != null) {
       builder.query("name", createModelOptions.name());
@@ -238,6 +246,8 @@ public class LanguageTranslator extends WatsonService {
     RequestBuilder builder = RequestBuilder.delete(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=language_translator;service_version=v3;operation_id=deleteModel");
     return createServiceCall(builder.build(), ResponseConverterUtils.getVoid());
   }
 
@@ -257,6 +267,8 @@ public class LanguageTranslator extends WatsonService {
     RequestBuilder builder = RequestBuilder.get(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=language_translator;service_version=v3;operation_id=getModel");
     return createServiceCall(builder.build(), ResponseConverterUtils.getObject(TranslationModel.class));
   }
 
@@ -272,6 +284,8 @@ public class LanguageTranslator extends WatsonService {
     String[] pathSegments = { "v3/models" };
     RequestBuilder builder = RequestBuilder.get(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=language_translator;service_version=v3;operation_id=listModels");
     if (listModelsOptions != null) {
       if (listModelsOptions.source() != null) {
         builder.query("source", listModelsOptions.source());

--- a/natural-language-classifier/src/main/java/com/ibm/watson/developer_cloud/natural_language_classifier/v1/NaturalLanguageClassifier.java
+++ b/natural-language-classifier/src/main/java/com/ibm/watson/developer_cloud/natural_language_classifier/v1/NaturalLanguageClassifier.java
@@ -105,6 +105,8 @@ public class NaturalLanguageClassifier extends WatsonService {
     String[] pathParameters = { classifyOptions.classifierId() };
     RequestBuilder builder = RequestBuilder.post(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=natural_language_classifier;service_version=v1;operation_id=classify");
     final JsonObject contentJson = new JsonObject();
     contentJson.addProperty("text", classifyOptions.text());
     builder.bodyJson(contentJson);
@@ -128,6 +130,8 @@ public class NaturalLanguageClassifier extends WatsonService {
     String[] pathParameters = { classifyCollectionOptions.classifierId() };
     RequestBuilder builder = RequestBuilder.post(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=natural_language_classifier;service_version=v1;operation_id=classifyCollection");
     final JsonObject contentJson = new JsonObject();
     contentJson.add("collection", GsonSingleton.getGson().toJsonTree(classifyCollectionOptions.collection()));
     builder.bodyJson(contentJson);
@@ -146,6 +150,8 @@ public class NaturalLanguageClassifier extends WatsonService {
     Validator.notNull(createClassifierOptions, "createClassifierOptions cannot be null");
     String[] pathSegments = { "v1/classifiers" };
     RequestBuilder builder = RequestBuilder.post(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments));
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=natural_language_classifier;service_version=v1;operation_id=createClassifier");
     MultipartBody.Builder multipartBuilder = new MultipartBody.Builder();
     multipartBuilder.setType(MultipartBody.FORM);
     RequestBody trainingMetadataBody = RequestUtils.inputStreamBody(createClassifierOptions.metadata(),
@@ -170,6 +176,8 @@ public class NaturalLanguageClassifier extends WatsonService {
     String[] pathParameters = { deleteClassifierOptions.classifierId() };
     RequestBuilder builder = RequestBuilder.delete(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=natural_language_classifier;service_version=v1;operation_id=deleteClassifier");
     return createServiceCall(builder.build(), ResponseConverterUtils.getVoid());
   }
 
@@ -187,6 +195,8 @@ public class NaturalLanguageClassifier extends WatsonService {
     String[] pathParameters = { getClassifierOptions.classifierId() };
     RequestBuilder builder = RequestBuilder.get(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=natural_language_classifier;service_version=v1;operation_id=getClassifier");
     return createServiceCall(builder.build(), ResponseConverterUtils.getObject(Classifier.class));
   }
 
@@ -201,6 +211,8 @@ public class NaturalLanguageClassifier extends WatsonService {
   public ServiceCall<ClassifierList> listClassifiers(ListClassifiersOptions listClassifiersOptions) {
     String[] pathSegments = { "v1/classifiers" };
     RequestBuilder builder = RequestBuilder.get(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments));
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=natural_language_classifier;service_version=v1;operation_id=listClassifiers");
     if (listClassifiersOptions != null) {
     }
     return createServiceCall(builder.build(), ResponseConverterUtils.getObject(ClassifierList.class));

--- a/natural-language-understanding/src/main/java/com/ibm/watson/developer_cloud/natural_language_understanding/v1/NaturalLanguageUnderstanding.java
+++ b/natural-language-understanding/src/main/java/com/ibm/watson/developer_cloud/natural_language_understanding/v1/NaturalLanguageUnderstanding.java
@@ -114,6 +114,8 @@ public class NaturalLanguageUnderstanding extends WatsonService {
     String[] pathSegments = { "v1/analyze" };
     RequestBuilder builder = RequestBuilder.post(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=natural-language-understanding;service_version=v1;operation_id=analyze");
     final JsonObject contentJson = new JsonObject();
     if (analyzeOptions.text() != null) {
       contentJson.addProperty("text", analyzeOptions.text());
@@ -162,6 +164,8 @@ public class NaturalLanguageUnderstanding extends WatsonService {
     RequestBuilder builder = RequestBuilder.delete(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=natural-language-understanding;service_version=v1;operation_id=deleteModel");
     return createServiceCall(builder.build(), ResponseConverterUtils.getVoid());
   }
 
@@ -179,6 +183,8 @@ public class NaturalLanguageUnderstanding extends WatsonService {
     String[] pathSegments = { "v1/models" };
     RequestBuilder builder = RequestBuilder.get(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=natural-language-understanding;service_version=v1;operation_id=listModels");
     if (listModelsOptions != null) {
     }
     return createServiceCall(builder.build(), ResponseConverterUtils.getObject(ListModelsResults.class));

--- a/personality-insights/src/main/java/com/ibm/watson/developer_cloud/personality_insights/v3/PersonalityInsights.java
+++ b/personality-insights/src/main/java/com/ibm/watson/developer_cloud/personality_insights/v3/PersonalityInsights.java
@@ -140,6 +140,8 @@ public class PersonalityInsights extends WatsonService {
     String[] pathSegments = { "v3/profile" };
     RequestBuilder builder = RequestBuilder.post(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=personality_insights;service_version=v3;operation_id=profile");
     if (profileOptions.contentType() != null) {
       builder.header("Content-Type", profileOptions.contentType());
     }
@@ -203,6 +205,8 @@ public class PersonalityInsights extends WatsonService {
     String[] pathSegments = { "v3/profile" };
     RequestBuilder builder = RequestBuilder.post(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=personality_insights;service_version=v3;operation_id=profileAsCsv");
     if (profileOptions.contentType() != null) {
       builder.header("Content-Type", profileOptions.contentType());
     }

--- a/speech-to-text/src/main/java/com/ibm/watson/developer_cloud/speech_to_text/v1/SpeechToText.java
+++ b/speech-to-text/src/main/java/com/ibm/watson/developer_cloud/speech_to_text/v1/SpeechToText.java
@@ -89,7 +89,7 @@ import okhttp3.WebSocket;
 
 /**
  * The IBM&reg; Speech to Text service provides APIs that use IBM's speech-recognition capabilities to produce
- * transcripts of spoken audio. The service can transcribe speech from various languages and audio formats. It addition
+ * transcripts of spoken audio. The service can transcribe speech from various languages and audio formats. In addition
  * to basic transcription, the service can produce detailed information about many different aspects of the audio. For
  * most languages, the service supports two sampling rates, broadband and narrowband. It returns all JSON response
  * content in the UTF-8 character set.
@@ -167,6 +167,7 @@ public class SpeechToText extends WatsonService {
     String[] pathParameters = { getModelOptions.modelId() };
     RequestBuilder builder = RequestBuilder.get(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
+    builder.header("X-IBMCloud-SDK-Analytics", "service_name=speech_to_text;service_version=v1;operation_id=getModel");
     return createServiceCall(builder.build(), ResponseConverterUtils.getObject(SpeechModel.class));
   }
 
@@ -184,6 +185,8 @@ public class SpeechToText extends WatsonService {
   public ServiceCall<SpeechModels> listModels(ListModelsOptions listModelsOptions) {
     String[] pathSegments = { "v1/models" };
     RequestBuilder builder = RequestBuilder.get(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments));
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=speech_to_text;service_version=v1;operation_id=listModels");
     if (listModelsOptions != null) {
     }
     return createServiceCall(builder.build(), ResponseConverterUtils.getObject(SpeechModels.class));
@@ -282,6 +285,7 @@ public class SpeechToText extends WatsonService {
     Validator.notNull(recognizeOptions, "recognizeOptions cannot be null");
     String[] pathSegments = { "v1/recognize" };
     RequestBuilder builder = RequestBuilder.post(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments));
+    builder.header("X-IBMCloud-SDK-Analytics", "service_name=speech_to_text;service_version=v1;operation_id=recognize");
     if (recognizeOptions.contentType() != null) {
       builder.header("Content-Type", recognizeOptions.contentType());
     }
@@ -415,6 +419,7 @@ public class SpeechToText extends WatsonService {
     String[] pathParameters = { checkJobOptions.id() };
     RequestBuilder builder = RequestBuilder.get(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
+    builder.header("X-IBMCloud-SDK-Analytics", "service_name=speech_to_text;service_version=v1;operation_id=checkJob");
     return createServiceCall(builder.build(), ResponseConverterUtils.getObject(RecognitionJob.class));
   }
 
@@ -437,6 +442,7 @@ public class SpeechToText extends WatsonService {
   public ServiceCall<RecognitionJobs> checkJobs(CheckJobsOptions checkJobsOptions) {
     String[] pathSegments = { "v1/recognitions" };
     RequestBuilder builder = RequestBuilder.get(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments));
+    builder.header("X-IBMCloud-SDK-Analytics", "service_name=speech_to_text;service_version=v1;operation_id=checkJobs");
     if (checkJobsOptions != null) {
     }
     return createServiceCall(builder.build(), ResponseConverterUtils.getObject(RecognitionJobs.class));
@@ -548,6 +554,7 @@ public class SpeechToText extends WatsonService {
     Validator.notNull(createJobOptions, "createJobOptions cannot be null");
     String[] pathSegments = { "v1/recognitions" };
     RequestBuilder builder = RequestBuilder.post(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments));
+    builder.header("X-IBMCloud-SDK-Analytics", "service_name=speech_to_text;service_version=v1;operation_id=createJob");
     if (createJobOptions.contentType() != null) {
       builder.header("Content-Type", createJobOptions.contentType());
     }
@@ -639,6 +646,7 @@ public class SpeechToText extends WatsonService {
     String[] pathParameters = { deleteJobOptions.id() };
     RequestBuilder builder = RequestBuilder.delete(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
+    builder.header("X-IBMCloud-SDK-Analytics", "service_name=speech_to_text;service_version=v1;operation_id=deleteJob");
     return createServiceCall(builder.build(), ResponseConverterUtils.getVoid());
   }
 
@@ -679,6 +687,8 @@ public class SpeechToText extends WatsonService {
     Validator.notNull(registerCallbackOptions, "registerCallbackOptions cannot be null");
     String[] pathSegments = { "v1/register_callback" };
     RequestBuilder builder = RequestBuilder.post(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments));
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=speech_to_text;service_version=v1;operation_id=registerCallback");
     builder.query("callback_url", registerCallbackOptions.callbackUrl());
     if (registerCallbackOptions.userSecret() != null) {
       builder.query("user_secret", registerCallbackOptions.userSecret());
@@ -702,6 +712,8 @@ public class SpeechToText extends WatsonService {
     Validator.notNull(unregisterCallbackOptions, "unregisterCallbackOptions cannot be null");
     String[] pathSegments = { "v1/unregister_callback" };
     RequestBuilder builder = RequestBuilder.post(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments));
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=speech_to_text;service_version=v1;operation_id=unregisterCallback");
     builder.query("callback_url", unregisterCallbackOptions.callbackUrl());
     return createServiceCall(builder.build(), ResponseConverterUtils.getVoid());
   }
@@ -723,6 +735,8 @@ public class SpeechToText extends WatsonService {
     Validator.notNull(createLanguageModelOptions, "createLanguageModelOptions cannot be null");
     String[] pathSegments = { "v1/customizations" };
     RequestBuilder builder = RequestBuilder.post(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments));
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=speech_to_text;service_version=v1;operation_id=createLanguageModel");
     final JsonObject contentJson = new JsonObject();
     contentJson.addProperty("name", createLanguageModelOptions.name());
     contentJson.addProperty("base_model_name", createLanguageModelOptions.baseModelName());
@@ -755,6 +769,8 @@ public class SpeechToText extends WatsonService {
     String[] pathParameters = { deleteLanguageModelOptions.customizationId() };
     RequestBuilder builder = RequestBuilder.delete(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=speech_to_text;service_version=v1;operation_id=deleteLanguageModel");
     return createServiceCall(builder.build(), ResponseConverterUtils.getVoid());
   }
 
@@ -776,6 +792,8 @@ public class SpeechToText extends WatsonService {
     String[] pathParameters = { getLanguageModelOptions.customizationId() };
     RequestBuilder builder = RequestBuilder.get(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=speech_to_text;service_version=v1;operation_id=getLanguageModel");
     return createServiceCall(builder.build(), ResponseConverterUtils.getObject(LanguageModel.class));
   }
 
@@ -796,6 +814,8 @@ public class SpeechToText extends WatsonService {
   public ServiceCall<LanguageModels> listLanguageModels(ListLanguageModelsOptions listLanguageModelsOptions) {
     String[] pathSegments = { "v1/customizations" };
     RequestBuilder builder = RequestBuilder.get(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments));
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=speech_to_text;service_version=v1;operation_id=listLanguageModels");
     if (listLanguageModelsOptions != null) {
       if (listLanguageModelsOptions.language() != null) {
         builder.query("language", listLanguageModelsOptions.language());
@@ -841,6 +861,8 @@ public class SpeechToText extends WatsonService {
     String[] pathParameters = { resetLanguageModelOptions.customizationId() };
     RequestBuilder builder = RequestBuilder.post(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=speech_to_text;service_version=v1;operation_id=resetLanguageModel");
     return createServiceCall(builder.build(), ResponseConverterUtils.getVoid());
   }
 
@@ -881,6 +903,8 @@ public class SpeechToText extends WatsonService {
     String[] pathParameters = { trainLanguageModelOptions.customizationId() };
     RequestBuilder builder = RequestBuilder.post(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=speech_to_text;service_version=v1;operation_id=trainLanguageModel");
     if (trainLanguageModelOptions.wordTypeToAdd() != null) {
       builder.query("word_type_to_add", trainLanguageModelOptions.wordTypeToAdd());
     }
@@ -917,6 +941,8 @@ public class SpeechToText extends WatsonService {
     String[] pathParameters = { upgradeLanguageModelOptions.customizationId() };
     RequestBuilder builder = RequestBuilder.post(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=speech_to_text;service_version=v1;operation_id=upgradeLanguageModel");
     return createServiceCall(builder.build(), ResponseConverterUtils.getVoid());
   }
 
@@ -968,6 +994,7 @@ public class SpeechToText extends WatsonService {
     String[] pathParameters = { addCorpusOptions.customizationId(), addCorpusOptions.corpusName() };
     RequestBuilder builder = RequestBuilder.post(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
+    builder.header("X-IBMCloud-SDK-Analytics", "service_name=speech_to_text;service_version=v1;operation_id=addCorpus");
     if (addCorpusOptions.allowOverwrite() != null) {
       builder.query("allow_overwrite", String.valueOf(addCorpusOptions.allowOverwrite()));
     }
@@ -996,6 +1023,8 @@ public class SpeechToText extends WatsonService {
     String[] pathParameters = { deleteCorpusOptions.customizationId(), deleteCorpusOptions.corpusName() };
     RequestBuilder builder = RequestBuilder.delete(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=speech_to_text;service_version=v1;operation_id=deleteCorpus");
     return createServiceCall(builder.build(), ResponseConverterUtils.getVoid());
   }
 
@@ -1018,6 +1047,7 @@ public class SpeechToText extends WatsonService {
     String[] pathParameters = { getCorpusOptions.customizationId(), getCorpusOptions.corpusName() };
     RequestBuilder builder = RequestBuilder.get(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
+    builder.header("X-IBMCloud-SDK-Analytics", "service_name=speech_to_text;service_version=v1;operation_id=getCorpus");
     return createServiceCall(builder.build(), ResponseConverterUtils.getObject(Corpus.class));
   }
 
@@ -1040,6 +1070,8 @@ public class SpeechToText extends WatsonService {
     String[] pathParameters = { listCorporaOptions.customizationId() };
     RequestBuilder builder = RequestBuilder.get(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=speech_to_text;service_version=v1;operation_id=listCorpora");
     return createServiceCall(builder.build(), ResponseConverterUtils.getObject(Corpora.class));
   }
 
@@ -1085,6 +1117,7 @@ public class SpeechToText extends WatsonService {
     String[] pathParameters = { addWordOptions.customizationId(), addWordOptions.wordName() };
     RequestBuilder builder = RequestBuilder.put(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
+    builder.header("X-IBMCloud-SDK-Analytics", "service_name=speech_to_text;service_version=v1;operation_id=addWord");
     final JsonObject contentJson = new JsonObject();
     if (addWordOptions.word() != null) {
       contentJson.addProperty("word", addWordOptions.word());
@@ -1155,6 +1188,7 @@ public class SpeechToText extends WatsonService {
     String[] pathParameters = { addWordsOptions.customizationId() };
     RequestBuilder builder = RequestBuilder.post(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
+    builder.header("X-IBMCloud-SDK-Analytics", "service_name=speech_to_text;service_version=v1;operation_id=addWords");
     final JsonObject contentJson = new JsonObject();
     contentJson.add("words", GsonSingleton.getGson().toJsonTree(addWordsOptions.words()));
     builder.bodyJson(contentJson);
@@ -1182,6 +1216,8 @@ public class SpeechToText extends WatsonService {
     String[] pathParameters = { deleteWordOptions.customizationId(), deleteWordOptions.wordName() };
     RequestBuilder builder = RequestBuilder.delete(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=speech_to_text;service_version=v1;operation_id=deleteWord");
     return createServiceCall(builder.build(), ResponseConverterUtils.getVoid());
   }
 
@@ -1203,6 +1239,7 @@ public class SpeechToText extends WatsonService {
     String[] pathParameters = { getWordOptions.customizationId(), getWordOptions.wordName() };
     RequestBuilder builder = RequestBuilder.get(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
+    builder.header("X-IBMCloud-SDK-Analytics", "service_name=speech_to_text;service_version=v1;operation_id=getWord");
     return createServiceCall(builder.build(), ResponseConverterUtils.getObject(Word.class));
   }
 
@@ -1227,6 +1264,7 @@ public class SpeechToText extends WatsonService {
     String[] pathParameters = { listWordsOptions.customizationId() };
     RequestBuilder builder = RequestBuilder.get(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
+    builder.header("X-IBMCloud-SDK-Analytics", "service_name=speech_to_text;service_version=v1;operation_id=listWords");
     if (listWordsOptions.wordType() != null) {
       builder.query("word_type", listWordsOptions.wordType());
     }
@@ -1278,6 +1316,8 @@ public class SpeechToText extends WatsonService {
     String[] pathParameters = { addGrammarOptions.customizationId(), addGrammarOptions.grammarName() };
     RequestBuilder builder = RequestBuilder.post(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=speech_to_text;service_version=v1;operation_id=addGrammar");
     builder.header("Content-Type", addGrammarOptions.contentType());
     if (addGrammarOptions.allowOverwrite() != null) {
       builder.query("allow_overwrite", String.valueOf(addGrammarOptions.allowOverwrite()));
@@ -1307,6 +1347,8 @@ public class SpeechToText extends WatsonService {
     String[] pathParameters = { deleteGrammarOptions.customizationId(), deleteGrammarOptions.grammarName() };
     RequestBuilder builder = RequestBuilder.delete(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=speech_to_text;service_version=v1;operation_id=deleteGrammar");
     return createServiceCall(builder.build(), ResponseConverterUtils.getVoid());
   }
 
@@ -1328,6 +1370,8 @@ public class SpeechToText extends WatsonService {
     String[] pathParameters = { getGrammarOptions.customizationId(), getGrammarOptions.grammarName() };
     RequestBuilder builder = RequestBuilder.get(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=speech_to_text;service_version=v1;operation_id=getGrammar");
     return createServiceCall(builder.build(), ResponseConverterUtils.getObject(Grammar.class));
   }
 
@@ -1349,6 +1393,8 @@ public class SpeechToText extends WatsonService {
     String[] pathParameters = { listGrammarsOptions.customizationId() };
     RequestBuilder builder = RequestBuilder.get(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=speech_to_text;service_version=v1;operation_id=listGrammars");
     return createServiceCall(builder.build(), ResponseConverterUtils.getObject(Grammars.class));
   }
 
@@ -1369,6 +1415,8 @@ public class SpeechToText extends WatsonService {
     Validator.notNull(createAcousticModelOptions, "createAcousticModelOptions cannot be null");
     String[] pathSegments = { "v1/acoustic_customizations" };
     RequestBuilder builder = RequestBuilder.post(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments));
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=speech_to_text;service_version=v1;operation_id=createAcousticModel");
     final JsonObject contentJson = new JsonObject();
     contentJson.addProperty("name", createAcousticModelOptions.name());
     contentJson.addProperty("base_model_name", createAcousticModelOptions.baseModelName());
@@ -1398,6 +1446,8 @@ public class SpeechToText extends WatsonService {
     String[] pathParameters = { deleteAcousticModelOptions.customizationId() };
     RequestBuilder builder = RequestBuilder.delete(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=speech_to_text;service_version=v1;operation_id=deleteAcousticModel");
     return createServiceCall(builder.build(), ResponseConverterUtils.getVoid());
   }
 
@@ -1419,6 +1469,8 @@ public class SpeechToText extends WatsonService {
     String[] pathParameters = { getAcousticModelOptions.customizationId() };
     RequestBuilder builder = RequestBuilder.get(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=speech_to_text;service_version=v1;operation_id=getAcousticModel");
     return createServiceCall(builder.build(), ResponseConverterUtils.getObject(AcousticModel.class));
   }
 
@@ -1439,6 +1491,8 @@ public class SpeechToText extends WatsonService {
   public ServiceCall<AcousticModels> listAcousticModels(ListAcousticModelsOptions listAcousticModelsOptions) {
     String[] pathSegments = { "v1/acoustic_customizations" };
     RequestBuilder builder = RequestBuilder.get(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments));
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=speech_to_text;service_version=v1;operation_id=listAcousticModels");
     if (listAcousticModelsOptions != null) {
       if (listAcousticModelsOptions.language() != null) {
         builder.query("language", listAcousticModelsOptions.language());
@@ -1484,6 +1538,8 @@ public class SpeechToText extends WatsonService {
     String[] pathParameters = { resetAcousticModelOptions.customizationId() };
     RequestBuilder builder = RequestBuilder.post(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=speech_to_text;service_version=v1;operation_id=resetAcousticModel");
     return createServiceCall(builder.build(), ResponseConverterUtils.getVoid());
   }
 
@@ -1531,6 +1587,8 @@ public class SpeechToText extends WatsonService {
     String[] pathParameters = { trainAcousticModelOptions.customizationId() };
     RequestBuilder builder = RequestBuilder.post(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=speech_to_text;service_version=v1;operation_id=trainAcousticModel");
     if (trainAcousticModelOptions.customLanguageModelId() != null) {
       builder.query("custom_language_model_id", trainAcousticModelOptions.customLanguageModelId());
     }
@@ -1570,6 +1628,8 @@ public class SpeechToText extends WatsonService {
     String[] pathParameters = { upgradeAcousticModelOptions.customizationId() };
     RequestBuilder builder = RequestBuilder.post(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=speech_to_text;service_version=v1;operation_id=upgradeAcousticModel");
     if (upgradeAcousticModelOptions.customLanguageModelId() != null) {
       builder.query("custom_language_model_id", upgradeAcousticModelOptions.customLanguageModelId());
     }
@@ -1668,6 +1728,7 @@ public class SpeechToText extends WatsonService {
     String[] pathParameters = { addAudioOptions.customizationId(), addAudioOptions.audioName() };
     RequestBuilder builder = RequestBuilder.post(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
+    builder.header("X-IBMCloud-SDK-Analytics", "service_name=speech_to_text;service_version=v1;operation_id=addAudio");
     if (addAudioOptions.contentType() != null) {
       builder.header("Content-Type", addAudioOptions.contentType());
     }
@@ -1702,6 +1763,8 @@ public class SpeechToText extends WatsonService {
     String[] pathParameters = { deleteAudioOptions.customizationId(), deleteAudioOptions.audioName() };
     RequestBuilder builder = RequestBuilder.delete(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=speech_to_text;service_version=v1;operation_id=deleteAudio");
     return createServiceCall(builder.build(), ResponseConverterUtils.getVoid());
   }
 
@@ -1736,6 +1799,7 @@ public class SpeechToText extends WatsonService {
     String[] pathParameters = { getAudioOptions.customizationId(), getAudioOptions.audioName() };
     RequestBuilder builder = RequestBuilder.get(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
+    builder.header("X-IBMCloud-SDK-Analytics", "service_name=speech_to_text;service_version=v1;operation_id=getAudio");
     return createServiceCall(builder.build(), ResponseConverterUtils.getObject(AudioListing.class));
   }
 
@@ -1760,6 +1824,7 @@ public class SpeechToText extends WatsonService {
     String[] pathParameters = { listAudioOptions.customizationId() };
     RequestBuilder builder = RequestBuilder.get(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
+    builder.header("X-IBMCloud-SDK-Analytics", "service_name=speech_to_text;service_version=v1;operation_id=listAudio");
     return createServiceCall(builder.build(), ResponseConverterUtils.getObject(AudioResources.class));
   }
 
@@ -1783,6 +1848,8 @@ public class SpeechToText extends WatsonService {
     Validator.notNull(deleteUserDataOptions, "deleteUserDataOptions cannot be null");
     String[] pathSegments = { "v1/user_data" };
     RequestBuilder builder = RequestBuilder.delete(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments));
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=speech_to_text;service_version=v1;operation_id=deleteUserData");
     builder.query("customer_id", deleteUserDataOptions.customerId());
     return createServiceCall(builder.build(), ResponseConverterUtils.getVoid());
   }

--- a/text-to-speech/src/main/java/com/ibm/watson/developer_cloud/text_to_speech/v1/TextToSpeech.java
+++ b/text-to-speech/src/main/java/com/ibm/watson/developer_cloud/text_to_speech/v1/TextToSpeech.java
@@ -130,6 +130,7 @@ public class TextToSpeech extends WatsonService {
     String[] pathParameters = { getVoiceOptions.voice() };
     RequestBuilder builder = RequestBuilder.get(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
+    builder.header("X-IBMCloud-SDK-Analytics", "service_name=text_to_speech;service_version=v1;operation_id=getVoice");
     if (getVoiceOptions.customizationId() != null) {
       builder.query("customization_id", getVoiceOptions.customizationId());
     }
@@ -150,6 +151,8 @@ public class TextToSpeech extends WatsonService {
   public ServiceCall<Voices> listVoices(ListVoicesOptions listVoicesOptions) {
     String[] pathSegments = { "v1/voices" };
     RequestBuilder builder = RequestBuilder.get(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments));
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=text_to_speech;service_version=v1;operation_id=listVoices");
     if (listVoicesOptions != null) {
     }
     return createServiceCall(builder.build(), ResponseConverterUtils.getObject(Voices.class));
@@ -252,6 +255,8 @@ public class TextToSpeech extends WatsonService {
     Validator.notNull(synthesizeOptions, "synthesizeOptions cannot be null");
     String[] pathSegments = { "v1/synthesize" };
     RequestBuilder builder = RequestBuilder.post(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments));
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=text_to_speech;service_version=v1;operation_id=synthesize");
     if (synthesizeOptions.accept() != null) {
       builder.header("Accept", synthesizeOptions.accept());
     }
@@ -309,6 +314,8 @@ public class TextToSpeech extends WatsonService {
     Validator.notNull(getPronunciationOptions, "getPronunciationOptions cannot be null");
     String[] pathSegments = { "v1/pronunciation" };
     RequestBuilder builder = RequestBuilder.get(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments));
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=text_to_speech;service_version=v1;operation_id=getPronunciation");
     builder.query("text", getPronunciationOptions.text());
     if (getPronunciationOptions.voice() != null) {
       builder.query("voice", getPronunciationOptions.voice());
@@ -341,6 +348,8 @@ public class TextToSpeech extends WatsonService {
     Validator.notNull(createVoiceModelOptions, "createVoiceModelOptions cannot be null");
     String[] pathSegments = { "v1/customizations" };
     RequestBuilder builder = RequestBuilder.post(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments));
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=text_to_speech;service_version=v1;operation_id=createVoiceModel");
     final JsonObject contentJson = new JsonObject();
     contentJson.addProperty("name", createVoiceModelOptions.name());
     if (createVoiceModelOptions.language() != null) {
@@ -373,6 +382,8 @@ public class TextToSpeech extends WatsonService {
     String[] pathParameters = { deleteVoiceModelOptions.customizationId() };
     RequestBuilder builder = RequestBuilder.delete(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=text_to_speech;service_version=v1;operation_id=deleteVoiceModel");
     return createServiceCall(builder.build(), ResponseConverterUtils.getVoid());
   }
 
@@ -397,6 +408,8 @@ public class TextToSpeech extends WatsonService {
     String[] pathParameters = { getVoiceModelOptions.customizationId() };
     RequestBuilder builder = RequestBuilder.get(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=text_to_speech;service_version=v1;operation_id=getVoiceModel");
     return createServiceCall(builder.build(), ResponseConverterUtils.getObject(VoiceModel.class));
   }
 
@@ -419,6 +432,8 @@ public class TextToSpeech extends WatsonService {
   public ServiceCall<VoiceModels> listVoiceModels(ListVoiceModelsOptions listVoiceModelsOptions) {
     String[] pathSegments = { "v1/customizations" };
     RequestBuilder builder = RequestBuilder.get(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments));
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=text_to_speech;service_version=v1;operation_id=listVoiceModels");
     if (listVoiceModelsOptions != null) {
       if (listVoiceModelsOptions.language() != null) {
         builder.query("language", listVoiceModelsOptions.language());
@@ -482,6 +497,8 @@ public class TextToSpeech extends WatsonService {
     String[] pathParameters = { updateVoiceModelOptions.customizationId() };
     RequestBuilder builder = RequestBuilder.post(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=text_to_speech;service_version=v1;operation_id=updateVoiceModel");
     final JsonObject contentJson = new JsonObject();
     if (updateVoiceModelOptions.name() != null) {
       contentJson.addProperty("name", updateVoiceModelOptions.name());
@@ -532,6 +549,7 @@ public class TextToSpeech extends WatsonService {
     String[] pathParameters = { addWordOptions.customizationId(), addWordOptions.word() };
     RequestBuilder builder = RequestBuilder.put(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
+    builder.header("X-IBMCloud-SDK-Analytics", "service_name=text_to_speech;service_version=v1;operation_id=addWord");
     final JsonObject contentJson = new JsonObject();
     if (addWordOptions.translation() != null) {
       contentJson.addProperty("translation", addWordOptions.translation());
@@ -579,6 +597,7 @@ public class TextToSpeech extends WatsonService {
     String[] pathParameters = { addWordsOptions.customizationId() };
     RequestBuilder builder = RequestBuilder.post(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
+    builder.header("X-IBMCloud-SDK-Analytics", "service_name=text_to_speech;service_version=v1;operation_id=addWords");
     final JsonObject contentJson = new JsonObject();
     if (addWordsOptions.words() != null) {
       contentJson.add("words", GsonSingleton.getGson().toJsonTree(addWordsOptions.words()));
@@ -607,6 +626,8 @@ public class TextToSpeech extends WatsonService {
     String[] pathParameters = { deleteWordOptions.customizationId(), deleteWordOptions.word() };
     RequestBuilder builder = RequestBuilder.delete(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=text_to_speech;service_version=v1;operation_id=deleteWord");
     return createServiceCall(builder.build(), ResponseConverterUtils.getVoid());
   }
 
@@ -631,6 +652,7 @@ public class TextToSpeech extends WatsonService {
     String[] pathParameters = { getWordOptions.customizationId(), getWordOptions.word() };
     RequestBuilder builder = RequestBuilder.get(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
+    builder.header("X-IBMCloud-SDK-Analytics", "service_name=text_to_speech;service_version=v1;operation_id=getWord");
     return createServiceCall(builder.build(), ResponseConverterUtils.getObject(Translation.class));
   }
 
@@ -655,6 +677,7 @@ public class TextToSpeech extends WatsonService {
     String[] pathParameters = { listWordsOptions.customizationId() };
     RequestBuilder builder = RequestBuilder.get(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
+    builder.header("X-IBMCloud-SDK-Analytics", "service_name=text_to_speech;service_version=v1;operation_id=listWords");
     return createServiceCall(builder.build(), ResponseConverterUtils.getObject(Words.class));
   }
 
@@ -678,6 +701,8 @@ public class TextToSpeech extends WatsonService {
     Validator.notNull(deleteUserDataOptions, "deleteUserDataOptions cannot be null");
     String[] pathSegments = { "v1/user_data" };
     RequestBuilder builder = RequestBuilder.delete(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments));
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=text_to_speech;service_version=v1;operation_id=deleteUserData");
     builder.query("customer_id", deleteUserDataOptions.customerId());
     return createServiceCall(builder.build(), ResponseConverterUtils.getVoid());
   }

--- a/tone-analyzer/src/main/java/com/ibm/watson/developer_cloud/tone_analyzer/v3/ToneAnalyzer.java
+++ b/tone-analyzer/src/main/java/com/ibm/watson/developer_cloud/tone_analyzer/v3/ToneAnalyzer.java
@@ -120,6 +120,7 @@ public class ToneAnalyzer extends WatsonService {
     String[] pathSegments = { "v3/tone" };
     RequestBuilder builder = RequestBuilder.post(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics", "service_name=tone_analyzer;service_version=v3;operation_id=tone");
     if (toneOptions.contentType() != null) {
       builder.header("Content-Type", toneOptions.contentType());
     }
@@ -164,6 +165,7 @@ public class ToneAnalyzer extends WatsonService {
     String[] pathSegments = { "v3/tone_chat" };
     RequestBuilder builder = RequestBuilder.post(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics", "service_name=tone_analyzer;service_version=v3;operation_id=toneChat");
     if (toneChatOptions.contentLanguage() != null) {
       builder.header("Content-Language", toneChatOptions.contentLanguage());
     }

--- a/visual-recognition/src/main/java/com/ibm/watson/developer_cloud/visual_recognition/v3/VisualRecognition.java
+++ b/visual-recognition/src/main/java/com/ibm/watson/developer_cloud/visual_recognition/v3/VisualRecognition.java
@@ -152,6 +152,8 @@ public class VisualRecognition extends WatsonService {
     String[] pathSegments = { "v3/classify" };
     RequestBuilder builder = RequestBuilder.post(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=watson_vision_combined;service_version=v3;operation_id=classify");
     if (classifyOptions.acceptLanguage() != null) {
       builder.header("Accept-Language", classifyOptions.acceptLanguage());
     }
@@ -219,6 +221,8 @@ public class VisualRecognition extends WatsonService {
     String[] pathSegments = { "v3/detect_faces" };
     RequestBuilder builder = RequestBuilder.post(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=watson_vision_combined;service_version=v3;operation_id=detectFaces");
     if (detectFacesOptions.acceptLanguage() != null) {
       builder.header("Accept-Language", detectFacesOptions.acceptLanguage());
     }
@@ -278,6 +282,8 @@ public class VisualRecognition extends WatsonService {
     String[] pathSegments = { "v3/classifiers" };
     RequestBuilder builder = RequestBuilder.post(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=watson_vision_combined;service_version=v3;operation_id=createClassifier");
     MultipartBody.Builder multipartBuilder = new MultipartBody.Builder();
     multipartBuilder.setType(MultipartBody.FORM);
     multipartBuilder.addFormDataPart("name", createClassifierOptions.name());
@@ -311,6 +317,8 @@ public class VisualRecognition extends WatsonService {
     RequestBuilder builder = RequestBuilder.delete(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=watson_vision_combined;service_version=v3;operation_id=deleteClassifier");
     return createServiceCall(builder.build(), ResponseConverterUtils.getVoid());
   }
 
@@ -329,6 +337,8 @@ public class VisualRecognition extends WatsonService {
     RequestBuilder builder = RequestBuilder.get(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=watson_vision_combined;service_version=v3;operation_id=getClassifier");
     return createServiceCall(builder.build(), ResponseConverterUtils.getObject(Classifier.class));
   }
 
@@ -342,6 +352,8 @@ public class VisualRecognition extends WatsonService {
     String[] pathSegments = { "v3/classifiers" };
     RequestBuilder builder = RequestBuilder.get(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=watson_vision_combined;service_version=v3;operation_id=listClassifiers");
     if (listClassifiersOptions != null) {
       if (listClassifiersOptions.verbose() != null) {
         builder.query("verbose", String.valueOf(listClassifiersOptions.verbose()));
@@ -386,6 +398,8 @@ public class VisualRecognition extends WatsonService {
     RequestBuilder builder = RequestBuilder.post(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=watson_vision_combined;service_version=v3;operation_id=updateClassifier");
     MultipartBody.Builder multipartBuilder = new MultipartBody.Builder();
     multipartBuilder.setType(MultipartBody.FORM);
     if (updateClassifierOptions.positiveExamples() != null) {
@@ -423,6 +437,8 @@ public class VisualRecognition extends WatsonService {
     RequestBuilder builder = RequestBuilder.get(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments,
         pathParameters));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=watson_vision_combined;service_version=v3;operation_id=getCoreMlModel");
     return createServiceCall(builder.build(), ResponseConverterUtils.getInputStream());
   }
 
@@ -444,6 +460,8 @@ public class VisualRecognition extends WatsonService {
     String[] pathSegments = { "v3/user_data" };
     RequestBuilder builder = RequestBuilder.delete(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments));
     builder.query(VERSION, versionDate);
+    builder.header("X-IBMCloud-SDK-Analytics",
+        "service_name=watson_vision_combined;service_version=v3;operation_id=deleteUserData");
     builder.query("customer_id", deleteUserDataOptions.customerId());
     return createServiceCall(builder.build(), ResponseConverterUtils.getVoid());
   }


### PR DESCRIPTION
This PR adds a header for each method call which sends analytics information about the service, version, and endpoint called. It also tweaks the format of the `User-Agent` header to match that of the other SDKs, with one small difference. Here's an example of the new `User-Agent`:

`watson-apis-java-sdk-6.13.2 Mac OS X 10.14.1 Oracle Corporation 1.8.0_144`

The Java vendor is added before the Java version (both the last values in the string), because I think this will also help guide us in terms of what vendors to support.