### PR TITLE
Add common project

### DIFF
--- a/assistant/build.gradle
+++ b/assistant/build.gradle
@@ -55,6 +55,7 @@ checkstyle {
 }
 
 dependencies {
+    compile project(':common')
     compile 'com.ibm.cloud:sdk-core:1.2.1'
     testCompile group: 'com.ibm.cloud', name:'sdk-core', version: '1.2.1', classifier: 'tests'
     signature 'org.codehaus.mojo.signature:java17:1.0@signature'

--- a/assistant/build.gradle
+++ b/assistant/build.gradle
@@ -56,8 +56,8 @@ checkstyle {
 
 dependencies {
     compile project(':common')
-    compile 'com.ibm.cloud:sdk-core:1.2.1'
-    testCompile group: 'com.ibm.cloud', name:'sdk-core', version: '1.2.1', classifier: 'tests'
+    compile 'com.ibm.cloud:sdk-core:1.2.2'
+    testCompile group: 'com.ibm.cloud', name:'sdk-core', version: '1.2.2', classifier: 'tests'
     signature 'org.codehaus.mojo.signature:java17:1.0@signature'
 }
 

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -7,8 +7,8 @@ repositories {
 }
 
 dependencies {
-    compile 'com.ibm.cloud:sdk-core:1.2.1'
-    testCompile group: 'com.ibm.cloud', name:'sdk-core', version: '1.2.1', classifier: 'tests'
+    compile 'com.ibm.cloud:sdk-core:1.2.2'
+    testCompile group: 'com.ibm.cloud', name:'sdk-core', version: '1.2.2', classifier: 'tests'
 }
 
 processResources {

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -1,0 +1,16 @@
+import org.apache.tools.ant.filters.*
+
+apply plugin: 'java'
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    compile 'com.ibm.cloud:sdk-core:1.2.1'
+    testCompile group: 'com.ibm.cloud', name:'sdk-core', version: '1.2.1', classifier: 'tests'
+}
+
+processResources {
+    filter ReplaceTokens, tokens: ["pom.version": project.version]
+}

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -1,6 +1,12 @@
 import org.apache.tools.ant.filters.*
 
+apply plugin: 'checkstyle'
 apply plugin: 'java'
+
+checkstyle {
+    configFile = rootProject.file('checkstyle.xml')
+    ignoreFailures = false
+}
 
 repositories {
     mavenCentral()

--- a/common/src/main/java/com/ibm/watson/common/SdkCommon.java
+++ b/common/src/main/java/com/ibm/watson/common/SdkCommon.java
@@ -14,6 +14,8 @@ public class SdkCommon {
   private static final Logger LOG = Logger.getLogger(SdkCommon.class.getName());
   private static String userAgent;
 
+  private SdkCommon() { }
+
   private static String loadSdkVersion() {
     ClassLoader classLoader = SdkCommon.class.getClassLoader();
     InputStream inputStream = classLoader.getResourceAsStream("java-sdk-version.properties");

--- a/common/src/main/java/com/ibm/watson/common/SdkCommon.java
+++ b/common/src/main/java/com/ibm/watson/common/SdkCommon.java
@@ -1,0 +1,48 @@
+package com.ibm.watson.common;
+
+import com.ibm.cloud.sdk.core.http.HttpHeaders;
+import com.ibm.cloud.sdk.core.util.RequestUtils;
+
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class SdkCommon {
+  private static final Logger LOG = Logger.getLogger(SdkCommon.class.getName());
+
+  private static String loadSdkVersion() {
+    ClassLoader classLoader = SdkCommon.class.getClassLoader();
+    InputStream inputStream = classLoader.getResourceAsStream("java-sdk-version.properties");
+    Properties properties = new Properties();
+
+    try {
+      properties.load(inputStream);
+    } catch (Exception e) {
+      LOG.log(Level.WARNING, "Could not load java-sdk-version.properties", e);
+    }
+
+    return properties.getProperty("version", "unknown-version");
+  }
+
+  private static String getUserAgent() {
+    return "watson-apis-java-sdk/" + loadSdkVersion() + "; " + RequestUtils.getUserAgent();
+  }
+
+  public static Map<String, String> getDefaultHeaders(String serviceName, String serviceVersion, String operationId) {
+    Map<String, String> headers = new HashMap<>();
+
+    String sdkAnalyticsHeaderValue = String.format(
+        "service_name=%s;service_version=%s;operation_id=%s",
+        serviceName,
+        serviceVersion,
+        operationId
+    );
+
+    headers.put(HttpHeaders.X_IBMCLOUD_SDK_ANALYTICS, sdkAnalyticsHeaderValue);
+    headers.put(HttpHeaders.USER_AGENT, getUserAgent());
+    return headers;
+  }
+}

--- a/common/src/main/java/com/ibm/watson/common/SdkCommon.java
+++ b/common/src/main/java/com/ibm/watson/common/SdkCommon.java
@@ -12,6 +12,7 @@ import java.util.logging.Logger;
 
 public class SdkCommon {
   private static final Logger LOG = Logger.getLogger(SdkCommon.class.getName());
+  private static String userAgent;
 
   private static String loadSdkVersion() {
     ClassLoader classLoader = SdkCommon.class.getClassLoader();
@@ -28,7 +29,10 @@ public class SdkCommon {
   }
 
   private static String getUserAgent() {
-    return "watson-apis-java-sdk/" + loadSdkVersion() + "; " + RequestUtils.getUserAgent();
+    if (userAgent == null) {
+      userAgent = "watson-apis-java-sdk/" + loadSdkVersion() + "; " + RequestUtils.getUserAgent();
+    }
+    return userAgent;
   }
 
   public static Map<String, String> getDefaultHeaders(String serviceName, String serviceVersion, String operationId) {

--- a/common/src/main/java/com/ibm/watson/common/SdkCommon.java
+++ b/common/src/main/java/com/ibm/watson/common/SdkCommon.java
@@ -45,7 +45,7 @@ public class SdkCommon {
         operationId
     );
 
-    headers.put(HttpHeaders.X_IBMCLOUD_SDK_ANALYTICS, sdkAnalyticsHeaderValue);
+    headers.put(WatsonHttpHeaders.X_IBMCLOUD_SDK_ANALYTICS, sdkAnalyticsHeaderValue);
     headers.put(HttpHeaders.USER_AGENT, getUserAgent());
     return headers;
   }

--- a/common/src/main/java/com/ibm/watson/common/WatsonHttpHeaders.java
+++ b/common/src/main/java/com/ibm/watson/common/WatsonHttpHeaders.java
@@ -1,0 +1,6 @@
+package com.ibm.watson.common;
+
+public interface HttpHeaders {
+  /** Header containing analytics info. */
+  String X_IBMCLOUD_SDK_ANALYTICS = "X-IBMCloud-SDK-Analytics";
+}

--- a/common/src/main/java/com/ibm/watson/common/WatsonHttpHeaders.java
+++ b/common/src/main/java/com/ibm/watson/common/WatsonHttpHeaders.java
@@ -1,6 +1,6 @@
 package com.ibm.watson.common;
 
-public interface HttpHeaders {
+public interface WatsonHttpHeaders {
   /** Header containing analytics info. */
   String X_IBMCLOUD_SDK_ANALYTICS = "X-IBMCloud-SDK-Analytics";
 }

--- a/common/src/main/resources/java-sdk-version.properties
+++ b/common/src/main/resources/java-sdk-version.properties
@@ -1,0 +1,1 @@
+version=@pom.version@

--- a/common/src/test/java/com/ibm/watson/common/SdkCommonTest.java
+++ b/common/src/test/java/com/ibm/watson/common/SdkCommonTest.java
@@ -1,4 +1,27 @@
 package com.ibm.watson.common;
 
-public class SdkCommonTest {
+import com.ibm.cloud.sdk.core.http.HttpHeaders;
+import com.ibm.cloud.sdk.core.test.WatsonServiceUnitTest;
+import org.junit.Test;
+
+import java.util.Map;
+
+import static org.junit.Assert.assertTrue;
+
+public class SdkCommonTest extends WatsonServiceUnitTest {
+  @Test
+  public void testGetDefaultHeaders() {
+    String serviceName = "test_name";
+    String serviceVersion = "v1";
+    String operationId = "test_method";
+    Map<String, String> defaultHeaders = SdkCommon.getDefaultHeaders(serviceName, serviceVersion, operationId);
+
+    assertTrue(defaultHeaders.containsKey(HttpHeaders.X_IBMCLOUD_SDK_ANALYTICS));
+    String analyticsHeaderValue = defaultHeaders.get(HttpHeaders.X_IBMCLOUD_SDK_ANALYTICS);
+    assertTrue(analyticsHeaderValue.contains(serviceName));
+    assertTrue(analyticsHeaderValue.contains(serviceVersion));
+    assertTrue(analyticsHeaderValue.contains(operationId));
+    assertTrue(defaultHeaders.containsKey(HttpHeaders.USER_AGENT));
+    assertTrue(defaultHeaders.get(HttpHeaders.USER_AGENT).startsWith("watson-apis-java-sdk/"));
+  }
 }

--- a/common/src/test/java/com/ibm/watson/common/SdkCommonTest.java
+++ b/common/src/test/java/com/ibm/watson/common/SdkCommonTest.java
@@ -1,0 +1,4 @@
+package com.ibm.watson.common;
+
+public class SdkCommonTest {
+}

--- a/common/src/test/java/com/ibm/watson/common/SdkCommonTest.java
+++ b/common/src/test/java/com/ibm/watson/common/SdkCommonTest.java
@@ -1,14 +1,13 @@
 package com.ibm.watson.common;
 
 import com.ibm.cloud.sdk.core.http.HttpHeaders;
-import com.ibm.cloud.sdk.core.test.WatsonServiceUnitTest;
 import org.junit.Test;
 
 import java.util.Map;
 
 import static org.junit.Assert.assertTrue;
 
-public class SdkCommonTest extends WatsonServiceUnitTest {
+public class SdkCommonTest {
   @Test
   public void testGetDefaultHeaders() {
     String serviceName = "test_name";
@@ -16,8 +15,8 @@ public class SdkCommonTest extends WatsonServiceUnitTest {
     String operationId = "test_method";
     Map<String, String> defaultHeaders = SdkCommon.getDefaultHeaders(serviceName, serviceVersion, operationId);
 
-    assertTrue(defaultHeaders.containsKey(HttpHeaders.X_IBMCLOUD_SDK_ANALYTICS));
-    String analyticsHeaderValue = defaultHeaders.get(HttpHeaders.X_IBMCLOUD_SDK_ANALYTICS);
+    assertTrue(defaultHeaders.containsKey(WatsonHttpHeaders.X_IBMCLOUD_SDK_ANALYTICS));
+    String analyticsHeaderValue = defaultHeaders.get(WatsonHttpHeaders.X_IBMCLOUD_SDK_ANALYTICS);
     assertTrue(analyticsHeaderValue.contains(serviceName));
     assertTrue(analyticsHeaderValue.contains(serviceVersion));
     assertTrue(analyticsHeaderValue.contains(operationId));

--- a/compare-comply/build.gradle
+++ b/compare-comply/build.gradle
@@ -55,6 +55,7 @@ checkstyle {
 }
 
 dependencies {
+    compile project(':common')
     compile 'com.ibm.cloud:sdk-core:1.2.1'
     testCompile group: 'com.ibm.cloud', name:'sdk-core', version: '1.2.1', classifier: 'tests'
     signature 'org.codehaus.mojo.signature:java17:1.0@signature'

--- a/compare-comply/build.gradle
+++ b/compare-comply/build.gradle
@@ -56,8 +56,8 @@ checkstyle {
 
 dependencies {
     compile project(':common')
-    compile 'com.ibm.cloud:sdk-core:1.2.1'
-    testCompile group: 'com.ibm.cloud', name:'sdk-core', version: '1.2.1', classifier: 'tests'
+    compile 'com.ibm.cloud:sdk-core:1.2.2'
+    testCompile group: 'com.ibm.cloud', name:'sdk-core', version: '1.2.2', classifier: 'tests'
     signature 'org.codehaus.mojo.signature:java17:1.0@signature'
 }
 

--- a/discovery/build.gradle
+++ b/discovery/build.gradle
@@ -59,6 +59,7 @@ checkstyle {
 }
 
 dependencies {
+    compile project(':common')
     compile 'com.ibm.cloud:sdk-core:1.2.1'
     testCompile group: 'com.ibm.cloud', name:'sdk-core', version: '1.2.1', classifier: 'tests'
     signature 'org.codehaus.mojo.signature:java17:1.0@signature'

--- a/discovery/build.gradle
+++ b/discovery/build.gradle
@@ -60,8 +60,8 @@ checkstyle {
 
 dependencies {
     compile project(':common')
-    compile 'com.ibm.cloud:sdk-core:1.2.1'
-    testCompile group: 'com.ibm.cloud', name:'sdk-core', version: '1.2.1', classifier: 'tests'
+    compile 'com.ibm.cloud:sdk-core:1.2.2'
+    testCompile group: 'com.ibm.cloud', name:'sdk-core', version: '1.2.2', classifier: 'tests'
     signature 'org.codehaus.mojo.signature:java17:1.0@signature'
 }
 

--- a/language-translator/build.gradle
+++ b/language-translator/build.gradle
@@ -55,6 +55,7 @@ checkstyle {
 }
 
 dependencies {
+    compile project(':common')
     compile 'com.ibm.cloud:sdk-core:1.2.1'
     testCompile group: 'com.ibm.cloud', name:'sdk-core', version: '1.2.1', classifier: 'tests'
     signature 'org.codehaus.mojo.signature:java17:1.0@signature'

--- a/language-translator/build.gradle
+++ b/language-translator/build.gradle
@@ -56,8 +56,8 @@ checkstyle {
 
 dependencies {
     compile project(':common')
-    compile 'com.ibm.cloud:sdk-core:1.2.1'
-    testCompile group: 'com.ibm.cloud', name:'sdk-core', version: '1.2.1', classifier: 'tests'
+    compile 'com.ibm.cloud:sdk-core:1.2.2'
+    testCompile group: 'com.ibm.cloud', name:'sdk-core', version: '1.2.2', classifier: 'tests'
     signature 'org.codehaus.mojo.signature:java17:1.0@signature'
 }
 

--- a/natural-language-classifier/build.gradle
+++ b/natural-language-classifier/build.gradle
@@ -59,6 +59,7 @@ checkstyle {
 }
 
 dependencies {
+    compile project(':common')
     compile 'com.ibm.cloud:sdk-core:1.2.1'
     testCompile group: 'com.ibm.cloud', name:'sdk-core', version: '1.2.1', classifier: 'tests'
     signature 'org.codehaus.mojo.signature:java17:1.0@signature'

--- a/natural-language-classifier/build.gradle
+++ b/natural-language-classifier/build.gradle
@@ -60,8 +60,8 @@ checkstyle {
 
 dependencies {
     compile project(':common')
-    compile 'com.ibm.cloud:sdk-core:1.2.1'
-    testCompile group: 'com.ibm.cloud', name:'sdk-core', version: '1.2.1', classifier: 'tests'
+    compile 'com.ibm.cloud:sdk-core:1.2.2'
+    testCompile group: 'com.ibm.cloud', name:'sdk-core', version: '1.2.2', classifier: 'tests'
     signature 'org.codehaus.mojo.signature:java17:1.0@signature'
 }
 

--- a/natural-language-understanding/build.gradle
+++ b/natural-language-understanding/build.gradle
@@ -55,6 +55,7 @@ checkstyle {
 }
 
 dependencies {
+    compile project(':common')
     compile 'com.ibm.cloud:sdk-core:1.2.1'
     testCompile group: 'com.ibm.cloud', name:'sdk-core', version: '1.2.1', classifier: 'tests'
     signature 'org.codehaus.mojo.signature:java17:1.0@signature'

--- a/natural-language-understanding/build.gradle
+++ b/natural-language-understanding/build.gradle
@@ -56,8 +56,8 @@ checkstyle {
 
 dependencies {
     compile project(':common')
-    compile 'com.ibm.cloud:sdk-core:1.2.1'
-    testCompile group: 'com.ibm.cloud', name:'sdk-core', version: '1.2.1', classifier: 'tests'
+    compile 'com.ibm.cloud:sdk-core:1.2.2'
+    testCompile group: 'com.ibm.cloud', name:'sdk-core', version: '1.2.2', classifier: 'tests'
     signature 'org.codehaus.mojo.signature:java17:1.0@signature'
 }
 

--- a/personality-insights/build.gradle
+++ b/personality-insights/build.gradle
@@ -55,6 +55,7 @@ checkstyle {
 }
 
 dependencies {
+    compile project(':common')
     compile 'com.ibm.cloud:sdk-core:1.2.1'
     testCompile group: 'com.ibm.cloud', name:'sdk-core', version: '1.2.1', classifier: 'tests'
     signature 'org.codehaus.mojo.signature:java17:1.0@signature'

--- a/personality-insights/build.gradle
+++ b/personality-insights/build.gradle
@@ -56,8 +56,8 @@ checkstyle {
 
 dependencies {
     compile project(':common')
-    compile 'com.ibm.cloud:sdk-core:1.2.1'
-    testCompile group: 'com.ibm.cloud', name:'sdk-core', version: '1.2.1', classifier: 'tests'
+    compile 'com.ibm.cloud:sdk-core:1.2.2'
+    testCompile group: 'com.ibm.cloud', name:'sdk-core', version: '1.2.2', classifier: 'tests'
     signature 'org.codehaus.mojo.signature:java17:1.0@signature'
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,4 @@
 rootProject.name = 'ibm-watson'
 include ':assistant', ':compare-comply', ':discovery', ':language-translator', ':natural-language-classifier',
         ':natural-language-understanding', ':personality-insights', ':speech-to-text', ':text-to-speech',
-        ':tone-analyzer', ':visual-recognition', ':ibm-watson'
+        ':tone-analyzer', ':visual-recognition', ':ibm-watson', ':common'

--- a/speech-to-text/build.gradle
+++ b/speech-to-text/build.gradle
@@ -59,6 +59,7 @@ checkstyle {
 }
 
 dependencies {
+    compile project(':common')
     compile 'com.ibm.cloud:sdk-core:1.2.1'
     testCompile group: 'com.ibm.cloud', name:'sdk-core', version: '1.2.1', classifier: 'tests'
     signature 'org.codehaus.mojo.signature:java17:1.0@signature'

--- a/speech-to-text/build.gradle
+++ b/speech-to-text/build.gradle
@@ -60,8 +60,8 @@ checkstyle {
 
 dependencies {
     compile project(':common')
-    compile 'com.ibm.cloud:sdk-core:1.2.1'
-    testCompile group: 'com.ibm.cloud', name:'sdk-core', version: '1.2.1', classifier: 'tests'
+    compile 'com.ibm.cloud:sdk-core:1.2.2'
+    testCompile group: 'com.ibm.cloud', name:'sdk-core', version: '1.2.2', classifier: 'tests'
     signature 'org.codehaus.mojo.signature:java17:1.0@signature'
 }
 

--- a/text-to-speech/build.gradle
+++ b/text-to-speech/build.gradle
@@ -55,6 +55,7 @@ checkstyle {
 }
 
 dependencies {
+    compile project(':common')
     compile 'com.ibm.cloud:sdk-core:1.2.1'
     testCompile group: 'com.ibm.cloud', name:'sdk-core', version: '1.2.1', classifier: 'tests'
     signature 'org.codehaus.mojo.signature:java17:1.0@signature'

--- a/text-to-speech/build.gradle
+++ b/text-to-speech/build.gradle
@@ -56,8 +56,8 @@ checkstyle {
 
 dependencies {
     compile project(':common')
-    compile 'com.ibm.cloud:sdk-core:1.2.1'
-    testCompile group: 'com.ibm.cloud', name:'sdk-core', version: '1.2.1', classifier: 'tests'
+    compile 'com.ibm.cloud:sdk-core:1.2.2'
+    testCompile group: 'com.ibm.cloud', name:'sdk-core', version: '1.2.2', classifier: 'tests'
     signature 'org.codehaus.mojo.signature:java17:1.0@signature'
 }
 

--- a/tone-analyzer/build.gradle
+++ b/tone-analyzer/build.gradle
@@ -55,6 +55,7 @@ checkstyle {
 }
 
 dependencies {
+    compile project(':common')
     compile 'com.ibm.cloud:sdk-core:1.2.1'
     testCompile group: 'com.ibm.cloud', name:'sdk-core', version: '1.2.1', classifier: 'tests'
     signature 'org.codehaus.mojo.signature:java17:1.0@signature'

--- a/tone-analyzer/build.gradle
+++ b/tone-analyzer/build.gradle
@@ -56,8 +56,8 @@ checkstyle {
 
 dependencies {
     compile project(':common')
-    compile 'com.ibm.cloud:sdk-core:1.2.1'
-    testCompile group: 'com.ibm.cloud', name:'sdk-core', version: '1.2.1', classifier: 'tests'
+    compile 'com.ibm.cloud:sdk-core:1.2.2'
+    testCompile group: 'com.ibm.cloud', name:'sdk-core', version: '1.2.2', classifier: 'tests'
     signature 'org.codehaus.mojo.signature:java17:1.0@signature'
 }
 

--- a/visual-recognition/build.gradle
+++ b/visual-recognition/build.gradle
@@ -59,6 +59,7 @@ checkstyle {
 }
 
 dependencies {
+    compile project(':common')
     compile 'com.ibm.cloud:sdk-core:1.2.1'
     testCompile group: 'com.ibm.cloud', name:'sdk-core', version: '1.2.1', classifier: 'tests'
     signature 'org.codehaus.mojo.signature:java17:1.0@signature'

--- a/visual-recognition/build.gradle
+++ b/visual-recognition/build.gradle
@@ -60,8 +60,8 @@ checkstyle {
 
 dependencies {
     compile project(':common')
-    compile 'com.ibm.cloud:sdk-core:1.2.1'
-    testCompile group: 'com.ibm.cloud', name:'sdk-core', version: '1.2.1', classifier: 'tests'
+    compile 'com.ibm.cloud:sdk-core:1.2.2'
+    testCompile group: 'com.ibm.cloud', name:'sdk-core', version: '1.2.2', classifier: 'tests'
     signature 'org.codehaus.mojo.signature:java17:1.0@signature'
 }
 


### PR DESCRIPTION
This PR adds a new `common` project with an `SdkCommon` class to handle logic that's common to the services, but doesn't belong in the core since it's project-specific. Currently, that means it handles building the `User-Agent` and `X-IBMCloud-SDK-Analytics` values that will be added to each service request.

This PR won't contain the changes to the service methods, but for reference, the code will look something like this:
```java
public ServiceCall<QueryResponse> query(QueryOptions queryOptions) {
  ...
  RequestBuilder builder = RequestBuilder.post(RequestBuilder.constructHttpUrl(getEndPoint(), pathSegments, pathParameters));
  builder.query(VERSION, versionDate);
  if (queryOptions.loggingOptOut() != null) {
    builder.header("X-Watson-Logging-Opt-Out", queryOptions.loggingOptOut());
  }

  // Add any SDK-specific "default" headers.
  Map<String, String> defaultHeaders = SdkCommon.getDefaultHeaders("discovery", "v1", "query");
  for (Entry<String, String> header : defaultHeaders.entrySet()) {
    builder.header(header.getKey(), header.getValue());
  }
  ...
  final JsonObject contentJson = new JsonObject();
  ...
  builder.bodyJson(contentJson);
  return createServiceCall(builder.build(), ResponseConverterUtils.getObject(QueryResponse.class));
}
```