### PR TITLE
Update readme to change version to `7.x.x` and link directly to releases page

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Java client library to use the [Watson APIs][wdc].
 
 :speaking_head: :speaking_head: :speaking_head:
 ## Heads up!
-`v7.0.0` is out! Be sure to check out the [migration guide](https://github.com/watson-developer-cloud/java-sdk/blob/java-sdk-7.0.0/MIGRATION.md) for major breaking changes and the [release notes](https://github.com/watson-developer-cloud/java-sdk/releases/tag/java-sdk-7.0.0) for extra info.
+`v7.x.x` is out! Be sure to check out the [migration guide](https://github.com/watson-developer-cloud/java-sdk/blob/java-sdk-7.0.0/MIGRATION.md) for major breaking changes and the [release notes](https://github.com/watson-developer-cloud/java-sdk/releases) for extra info.
 :speaking_head: :speaking_head: :speaking_head:
 
 ## Before you begin


### PR DESCRIPTION
### Summary
This pull request updates the version listed in the readme to `7.x.x` and links directly to the releases page for release notes. I'm not sure if we want to say `7.x.x` here or the current version, `7.1.0`. Maybe we can use bumpversion for this?