### PR TITLE
Various post-release changes

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -5,7 +5,11 @@
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
     "@semantic-release/git",
-    "@semantic-release/github",
+    ["@semantic-release/github", {
+      "assets": [
+        {"path": "ibm-watson/build/libs/ibm-watson-${nextRelease.version}-jar-with-dependencies.jar"}
+      ]
+    }],
     ["@semantic-release/exec", {
       "prepareCmd": "bumpversion --current-version ${lastRelease.version} --new-version ${nextRelease.version} --verbose --allow-dirty patch"
     }]

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ after_success:
 deploy:
 - provider: script
   skip_cleanup: true
-  script: "travis_wait 30 ./gradlew bintrayUpload"
+  script: "./gradlew bintrayUpload"
   on:
     tags: true
     jdk: openjdk7

--- a/README.md
+++ b/README.md
@@ -49,72 +49,12 @@ Java client library to use the [Watson APIs][wdc].
 
 </details>
 
-:speaking_head: :speaking_head: :speaking_head:
-## Heads up!
-`v7.1.0` is out! Be sure to check out the [migration guide](https://github.com/watson-developer-cloud/java-sdk/blob/java-sdk-7.1.0/MIGRATION.md) for major breaking changes and the [release notes](https://github.com/watson-developer-cloud/java-sdk/releases/tag/java-sdk-7.1.0) for extra info.
-:speaking_head: :speaking_head: :speaking_head:
-
 ## Before you begin
 * You need an [IBM Cloud][ibm-cloud-onboarding] account.
 
 ## Installation
 
 ##### Maven
-First, you'll need to edit your `settings.xml` file to target the right repository. Here's an example file configured to use the library:
-```xml
-<settings xmlns='http://maven.apache.org/SETTINGS/1.0.0' xsi:schemaLocation='http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'>
-  <profiles>
-    <profile>
-      <repositories>
-        <repository>
-          <snapshots>
-            <enabled>
-              false
-            </enabled>
-          </snapshots>
-          <id>
-            bintray-ibm-cloud-sdks-ibm-cloud-sdk-repo
-          </id>
-          <name>
-            bintray
-          </name>
-          <url>
-            https://dl.bintray.com/ibm-cloud-sdks/ibm-cloud-sdk-repo
-          </url>
-        </repository>
-      </repositories>
-      <pluginRepositories>
-        <pluginRepository>
-          <snapshots>
-            <enabled>
-              false
-            </enabled>
-          </snapshots>
-          <id>
-            bintray-ibm-cloud-sdks-ibm-cloud-sdk-repo
-          </id>
-          <name>
-            bintray-plugins
-          </name>
-          <url>
-            https://dl.bintray.com/ibm-cloud-sdks/ibm-cloud-sdk-repo
-          </url>
-        </pluginRepository>
-      </pluginRepositories>
-      <id>
-        bintray
-      </id>
-    </profile>
-  </profiles>
-  <activeProfiles>
-    <activeProfile>
-      bintray
-    </activeProfile>
-  </activeProfiles>
-</settings>
-```
-Then, you can add the dependencies in your project POM.
-
 All the services:
 
 ```xml
@@ -136,17 +76,6 @@ Only Discovery:
 ```
 
 ##### Gradle
-First, edit your repositories in your `build.gradle` file to target the right repository:
-```gradle
-repositories {
-	maven {
-		url  "https://dl.bintray.com/ibm-cloud-sdks/ibm-cloud-sdk-repo"
-	}
-}
-```
-
-Then, you can add the actual dependencies.
-
 All the services:
 
 ```gradle

--- a/ibm-watson/build.gradle
+++ b/ibm-watson/build.gradle
@@ -78,6 +78,7 @@ artifacts {
 
 dependencies {
     compile project(':assistant')
+    compile project(':common')
     compile project(':compare-comply')
     compile project(':discovery')
     compile project(':language-translator')


### PR DESCRIPTION
This PR changes/fixes some things that have come up post-7.1.0 release.

First, the JAR wasn't being included in the release assets, so I added that.

Next, the release didn't work properly in CI, apparently due to the `travis_wait` command per [this discussion](https://github.com/travis-ci/travis-ci/issues/7961). I've removed that so things should work fine next time.

Finally, I made some revisions to the README, removing the section promoting the v7 release and the temporary installation steps required by some issues that came up when we originally switched to automatic releases through Bintray.