### PR TITLE
Update core dependency to allow for proxy authentication

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,10 +49,12 @@ script:
 - "./gradlew docs > /dev/null"
 after_success:
 - bash <(curl -s https://codecov.io/bash)
+before_deploy:
+- pip install travis-wait-improved
 deploy:
 - provider: script
   skip_cleanup: true
-  script: "./gradlew bintrayUpload"
+  script: travis-wait-improved --timeout=30m ./gradlew bintrayUpload
   on:
     tags: true
     jdk: openjdk7

--- a/assistant/build.gradle
+++ b/assistant/build.gradle
@@ -60,7 +60,7 @@ checkstyle {
 dependencies {
     compile project(':common')
     testCompile project(':common').sourceSets.test.output
-    compile 'com.ibm.cloud:sdk-core:4.4.0'
+    compile 'com.ibm.cloud:sdk-core:4.5.0'
     signature 'org.codehaus.mojo.signature:java17:1.0@signature'
 }
 

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -58,7 +58,7 @@ checkstyle {
 }
 
 dependencies {
-    compile 'com.ibm.cloud:sdk-core:4.4.0'
+    compile 'com.ibm.cloud:sdk-core:4.5.0'
     signature 'org.codehaus.mojo.signature:java17:1.0@signature'
 }
 

--- a/compare-comply/build.gradle
+++ b/compare-comply/build.gradle
@@ -60,7 +60,7 @@ checkstyle {
 dependencies {
     compile project(':common')
     testCompile project(':common').sourceSets.test.output
-    compile 'com.ibm.cloud:sdk-core:4.4.0'
+    compile 'com.ibm.cloud:sdk-core:4.5.0'
     signature 'org.codehaus.mojo.signature:java17:1.0@signature'
 }
 

--- a/discovery/build.gradle
+++ b/discovery/build.gradle
@@ -64,7 +64,7 @@ checkstyle {
 dependencies {
     compile project(':common')
     testCompile project(':common').sourceSets.test.output
-    compile 'com.ibm.cloud:sdk-core:4.4.0'
+    compile 'com.ibm.cloud:sdk-core:4.5.0'
     signature 'org.codehaus.mojo.signature:java17:1.0@signature'
 }
 

--- a/language-translator/build.gradle
+++ b/language-translator/build.gradle
@@ -60,7 +60,7 @@ checkstyle {
 dependencies {
     compile project(':common')
     testCompile project(':common').sourceSets.test.output
-    compile 'com.ibm.cloud:sdk-core:4.4.0'
+    compile 'com.ibm.cloud:sdk-core:4.5.0'
     signature 'org.codehaus.mojo.signature:java17:1.0@signature'
 }
 

--- a/natural-language-classifier/build.gradle
+++ b/natural-language-classifier/build.gradle
@@ -64,7 +64,7 @@ checkstyle {
 dependencies {
     compile project(':common')
     testCompile project(':common').sourceSets.test.output
-    compile 'com.ibm.cloud:sdk-core:4.4.0'
+    compile 'com.ibm.cloud:sdk-core:4.5.0'
     signature 'org.codehaus.mojo.signature:java17:1.0@signature'
 }
 

--- a/natural-language-understanding/build.gradle
+++ b/natural-language-understanding/build.gradle
@@ -60,7 +60,7 @@ checkstyle {
 dependencies {
     compile project(':common')
     testCompile project(':common').sourceSets.test.output
-    compile 'com.ibm.cloud:sdk-core:4.4.0'
+    compile 'com.ibm.cloud:sdk-core:4.5.0'
     signature 'org.codehaus.mojo.signature:java17:1.0@signature'
 }
 

--- a/personality-insights/build.gradle
+++ b/personality-insights/build.gradle
@@ -60,7 +60,7 @@ checkstyle {
 dependencies {
     compile project(':common')
     testCompile project(':common').sourceSets.test.output
-    compile 'com.ibm.cloud:sdk-core:4.4.0'
+    compile 'com.ibm.cloud:sdk-core:4.5.0'
     signature 'org.codehaus.mojo.signature:java17:1.0@signature'
 }
 

--- a/speech-to-text/build.gradle
+++ b/speech-to-text/build.gradle
@@ -64,7 +64,7 @@ checkstyle {
 dependencies {
     compile project(':common')
     testCompile project(':common').sourceSets.test.output
-    compile 'com.ibm.cloud:sdk-core:4.4.0'
+    compile 'com.ibm.cloud:sdk-core:4.5.0'
     signature 'org.codehaus.mojo.signature:java17:1.0@signature'
 }
 

--- a/text-to-speech/build.gradle
+++ b/text-to-speech/build.gradle
@@ -60,7 +60,7 @@ checkstyle {
 dependencies {
     compile project(':common')
     testCompile project(':common').sourceSets.test.output
-    compile 'com.ibm.cloud:sdk-core:4.4.0'
+    compile 'com.ibm.cloud:sdk-core:4.5.0'
     signature 'org.codehaus.mojo.signature:java17:1.0@signature'
 }
 

--- a/tone-analyzer/build.gradle
+++ b/tone-analyzer/build.gradle
@@ -60,7 +60,7 @@ checkstyle {
 dependencies {
     compile project(':common')
     testCompile project(':common').sourceSets.test.output
-    compile 'com.ibm.cloud:sdk-core:4.4.0'
+    compile 'com.ibm.cloud:sdk-core:4.5.0'
     signature 'org.codehaus.mojo.signature:java17:1.0@signature'
 }
 

--- a/visual-recognition/build.gradle
+++ b/visual-recognition/build.gradle
@@ -64,7 +64,7 @@ checkstyle {
 dependencies {
     compile project(':common')
     testCompile project(':common').sourceSets.test.output
-    compile 'com.ibm.cloud:sdk-core:4.4.0'
+    compile 'com.ibm.cloud:sdk-core:4.5.0'
     signature 'org.codehaus.mojo.signature:java17:1.0@signature'
 }
 


### PR DESCRIPTION
Related to https://github.com/watson-developer-cloud/java-sdk/issues/1071

This PR updates the core dependency to allow for setting up authentication when configuring a proxy. This means setting a `proxyAuthenticator` value on the `HttpConfigOptions` builder.

Additionally, a wait has been added on the deployment step in Travis since the uploading and syncing takes a while and has timed out in the past.

Thanks again @marloncarvalho for the feature!