### PR TITLE
Fix KeyValuePair model definition

### DIFF
--- a/compare-comply/src/main/java/com/ibm/watson/compare_comply/v1/model/KeyValuePair.java
+++ b/compare-comply/src/main/java/com/ibm/watson/compare_comply/v1/model/KeyValuePair.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 IBM Corp. All Rights Reserved.
+ * (C) Copyright IBM Corp. 2019.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -12,6 +12,8 @@
  */
 package com.ibm.watson.compare_comply.v1.model;
 
+import java.util.List;
+
 import com.ibm.cloud.sdk.core.service.model.GenericModel;
 
 /**
@@ -20,7 +22,7 @@ import com.ibm.cloud.sdk.core.service.model.GenericModel;
 public class KeyValuePair extends GenericModel {
 
   private Key key;
-  private Value value;
+  private List<Value> value;
 
   /**
    * Gets the key.
@@ -36,11 +38,11 @@ public class KeyValuePair extends GenericModel {
   /**
    * Gets the value.
    *
-   * A value in a key-value pair.
+   * A list of values in a key-value pair.
    *
    * @return the value
    */
-  public Value getValue() {
+  public List<Value> getValue() {
     return value;
   }
 }

--- a/compare-comply/src/test/java/com/ibm/watson/compare_comply/v1/CompareComplyTest.java
+++ b/compare-comply/src/test/java/com/ibm/watson/compare_comply/v1/CompareComplyTest.java
@@ -636,10 +636,11 @@ public class CompareComplyTest extends WatsonServiceUnitTest {
     assertEquals(BEGIN, response.getTables().get(0).getKeyValuePairs().get(0).getKey().getLocation().getBegin());
     assertEquals(END, response.getTables().get(0).getKeyValuePairs().get(0).getKey().getLocation().getEnd());
     assertEquals(TEXT, response.getTables().get(0).getKeyValuePairs().get(0).getKey().getText());
-    assertEquals(CELL_ID, response.getTables().get(0).getKeyValuePairs().get(0).getValue().getCellId());
-    assertEquals(BEGIN, response.getTables().get(0).getKeyValuePairs().get(0).getValue().getLocation().getBegin());
-    assertEquals(END, response.getTables().get(0).getKeyValuePairs().get(0).getValue().getLocation().getEnd());
-    assertEquals(TEXT, response.getTables().get(0).getKeyValuePairs().get(0).getValue().getText());
+    assertEquals(CELL_ID, response.getTables().get(0).getKeyValuePairs().get(0).getValue().get(0).getCellId());
+    assertEquals(BEGIN, response.getTables().get(0).getKeyValuePairs().get(0).getValue().get(0).getLocation()
+        .getBegin());
+    assertEquals(END, response.getTables().get(0).getKeyValuePairs().get(0).getValue().get(0).getLocation().getEnd());
+    assertEquals(TEXT, response.getTables().get(0).getKeyValuePairs().get(0).getValue().get(0).getText());
     assertEquals(TEXT, response.getTables().get(0).getTitle().getText());
     assertEquals(BEGIN, response.getTables().get(0).getTitle().getLocation().getBegin());
     assertEquals(END, response.getTables().get(0).getTitle().getLocation().getEnd());
@@ -795,10 +796,11 @@ public class CompareComplyTest extends WatsonServiceUnitTest {
     assertEquals(BEGIN, response.getTables().get(0).getKeyValuePairs().get(0).getKey().getLocation().getBegin());
     assertEquals(END, response.getTables().get(0).getKeyValuePairs().get(0).getKey().getLocation().getEnd());
     assertEquals(TEXT, response.getTables().get(0).getKeyValuePairs().get(0).getKey().getText());
-    assertEquals(CELL_ID, response.getTables().get(0).getKeyValuePairs().get(0).getValue().getCellId());
-    assertEquals(BEGIN, response.getTables().get(0).getKeyValuePairs().get(0).getValue().getLocation().getBegin());
-    assertEquals(END, response.getTables().get(0).getKeyValuePairs().get(0).getValue().getLocation().getEnd());
-    assertEquals(TEXT, response.getTables().get(0).getKeyValuePairs().get(0).getValue().getText());
+    assertEquals(CELL_ID, response.getTables().get(0).getKeyValuePairs().get(0).getValue().get(0).getCellId());
+    assertEquals(BEGIN, response.getTables().get(0).getKeyValuePairs().get(0).getValue().get(0).getLocation()
+        .getBegin());
+    assertEquals(END, response.getTables().get(0).getKeyValuePairs().get(0).getValue().get(0).getLocation().getEnd());
+    assertEquals(TEXT, response.getTables().get(0).getKeyValuePairs().get(0).getValue().get(0).getText());
   }
 
   @Test

--- a/compare-comply/src/test/resources/compare_comply/classify-return.json
+++ b/compare-comply/src/test/resources/compare_comply/classify-return.json
@@ -166,14 +166,16 @@
             },
             "text": "text"
           },
-          "value": {
-            "cell_id": "cell_id",
-            "location": {
-              "begin": 0,
-              "end": 1
-            },
-            "text": "text"
-          }
+          "value": [
+            {
+              "cell_id": "cell_id",
+              "location": {
+                "begin": 0,
+                "end": 1
+              },
+              "text": "text"
+            }
+          ]
         }
       ],
       "title": {

--- a/compare-comply/src/test/resources/compare_comply/table-return.json
+++ b/compare-comply/src/test/resources/compare_comply/table-return.json
@@ -127,14 +127,16 @@
             },
             "text": "text"
           },
-          "value": {
-            "cell_id": "cell_id",
-            "location": {
-              "begin": 0,
-              "end": 1
-            },
-            "text": "text"
-          }
+          "value": [
+            {
+              "cell_id": "cell_id",
+              "location": {
+                "begin": 0,
+                "end": 1
+              },
+              "text": "text"
+            }
+          ]
         }
       ]
     }


### PR DESCRIPTION
This PR fixes the model definition for `KeyValuePair` in the Compare and Comply service to match the API specification [here](https://cloud.ibm.com/docs/services/compare-comply?topic=compare-comply-understanding_tables#table-schema-arrangement). The previous definition was resulting in serialization errors.