### PR TITLE
fix(Discovery v1): environment document count should use 'available'

### DIFF
--- a/discovery/src/main/java/com/ibm/watson/discovery/v1/model/EnvironmentDocuments.java
+++ b/discovery/src/main/java/com/ibm/watson/discovery/v1/model/EnvironmentDocuments.java
@@ -20,19 +20,19 @@ import com.ibm.cloud.sdk.core.service.model.GenericModel;
  */
 public class EnvironmentDocuments extends GenericModel {
 
-  protected Long indexed;
+  protected Long available;
   @SerializedName("maximum_allowed")
   protected Long maximumAllowed;
 
   /**
-   * Gets the indexed.
+   * Gets the available documents.
    *
    * Number of documents indexed for the environment.
    *
-   * @return the indexed
+   * @return the available
    */
-  public Long getIndexed() {
-    return indexed;
+  public Long getAvailable() {
+    return available;
   }
 
   /**


### PR DESCRIPTION
### Summary

The Discovery service returns 'available' as the total number of documents for an environment.
This was previously using 'indexed' which is not what the service returns.


