### PR TITLE
Fix missing option assignments

### DIFF
--- a/speech-to-text/src/main/java/com/ibm/watson/speech_to_text/v1/model/RecognizeOptions.java
+++ b/speech-to-text/src/main/java/com/ibm/watson/speech_to_text/v1/model/RecognizeOptions.java
@@ -642,6 +642,9 @@ public class RecognizeOptions extends GenericModel {
     splitTranscriptAtPhraseEnd = builder.splitTranscriptAtPhraseEnd;
     speechDetectorSensitivity = builder.speechDetectorSensitivity;
     backgroundAudioSuppression = builder.backgroundAudioSuppression;
+    interimResults = builder.interimResults;
+    processingMetrics = builder.processingMetrics;
+    processingMetricsInterval = builder.processingMetricsInterval;
   }
 
   /**


### PR DESCRIPTION
The `RecognizeOptions` constructor doesn't really apply the `interimResults`, so the client app can't receive non-final results as stated in the document.
This patch adds the missing `interimResults` assignment (and also the missing `processingMetrics` and `processingMetricsInterval`) back to the constructor.