### PR TITLE
Update gateway urls

### DIFF
--- a/compare-comply/src/main/java/com/ibm/watson/compare_comply/v1/CompareComply.java
+++ b/compare-comply/src/main/java/com/ibm/watson/compare_comply/v1/CompareComply.java
@@ -61,7 +61,7 @@ public class CompareComply extends BaseService {
   private static final String DEFAULT_SERVICE_NAME = "compare_comply";
 
   private static final String DEFAULT_SERVICE_URL =
-      "https://gateway.watsonplatform.net/compare-comply/api";
+      "https://api.us-south.compare-comply.watson.cloud.ibm.com";
 
   private String versionDate;
 

--- a/discovery/src/test/java/com/ibm/watson/discovery/v1/DiscoveryServiceIT.java
+++ b/discovery/src/test/java/com/ibm/watson/discovery/v1/DiscoveryServiceIT.java
@@ -198,7 +198,7 @@ public class DiscoveryServiceIT extends WatsonServiceTest {
   @Test
   public void exampleIsSuccessful() {
     //    Discovery discovery = new Discovery("2016-12-15");
-    //    discovery.setServiceUrl("https://gateway.watsonplatform.net/discovery/api");
+    //    discovery.setServiceUrl("https://api.us-south.discovery.watson.cloud.ibm.com");
     //    discovery.setUsernameAndPassword("<username>", "<password");
     String environmentId = null;
     String configurationId = null;
@@ -363,7 +363,7 @@ public class DiscoveryServiceIT extends WatsonServiceTest {
   /** Ping bad url throws exception. */
   @Test(expected = NotFoundException.class)
   public void pingBadUrlThrowsException() {
-    discovery.setServiceUrl("https://gateway.watsonplatform.net/discovery-foo/api");
+    discovery.setServiceUrl("https://api.us-south.discovery-foo.watson.cloud.ibm.com");
     ping();
   }
 

--- a/discovery/src/test/java/com/ibm/watson/discovery/v1/DiscoveryServiceIT.java
+++ b/discovery/src/test/java/com/ibm/watson/discovery/v1/DiscoveryServiceIT.java
@@ -363,7 +363,7 @@ public class DiscoveryServiceIT extends WatsonServiceTest {
   /** Ping bad url throws exception. */
   @Test(expected = NotFoundException.class)
   public void pingBadUrlThrowsException() {
-    discovery.setServiceUrl("https://api.us-south.discovery-foo.watson.cloud.ibm.com");
+    discovery.setServiceUrl("https://api.us-south.discovery.watson.cloud.ibm.com/discovery-foo");
     ping();
   }
 

--- a/natural-language-classifier/src/test/resources/natural_language_classifier/classification.json
+++ b/natural-language-classifier/src/test/resources/natural_language_classifier/classification.json
@@ -1,6 +1,6 @@
 {
   "classifier_id": "47C164-nlc-243",
-  "url": "https://gateway.watsonplatform.net/natural-language-classifier/api/v1/classifiers/47C164-nlc-243",
+  "url": "https://api.us-south.natural-language-classifier.watson.cloud.ibm.com/v1/classifiers/47C164-nlc-243",
   "text": "is it hot ?",
   "top_class": "temperature",
   "classes": [

--- a/natural-language-classifier/src/test/resources/natural_language_classifier/classification_collection.json
+++ b/natural-language-classifier/src/test/resources/natural_language_classifier/classification_collection.json
@@ -1,6 +1,6 @@
 {
   "classifier_id" : "10D41B-nlc-1",
-  "url" : "https://gateway.watsonplatform.net/natural-language-classifier/api/v1/classifiers/10D41B-nlc-1",
+  "url" : "https://api.us-south.natural-language-classifier.watson.cloud.ibm.com/v1/classifiers/10D41B-nlc-1",
   "collection" : [ {
     "text" : "How hot will it be today?",
     "top_class" : "temperature",

--- a/natural-language-classifier/src/test/resources/natural_language_classifier/classifier.json
+++ b/natural-language-classifier/src/test/resources/natural_language_classifier/classifier.json
@@ -1,6 +1,6 @@
 {
   "classifier_id": "5E00F7x2-nlc-507",
-  "url": "https://gateway.watsonplatform.net/natural-language-classifier/api/v1/classifiers/5E00F7x2-nlc-507",
+  "url": "https://api.us-south.natural-language-classifier.watson.cloud.ibm.com/v1/classifiers/5E00F7x2-nlc-507",
   "name": "Music controls",
   "language": "en",
   "created": "2015-10-17T20:56:29.974Z"

--- a/natural-language-classifier/src/test/resources/natural_language_classifier/classifiers.json
+++ b/natural-language-classifier/src/test/resources/natural_language_classifier/classifiers.json
@@ -2,14 +2,14 @@
   "classifiers": [
     {
       "classifier_id": "47C164-nlc-243",
-      "url": "https://gateway.watsonplatform.net/natural-language-classifier/api/v1/classifiers/47C164-nlc-243",
+      "url": "https://api.us-south.natural-language-classifier.watson.cloud.ibm.com/v1/classifiers/47C164-nlc-243",
       "name": "weather",
       "language": "en",
       "created": "2015-08-24T18:42:25.324Z"
     },
     {
       "classifier_id": "5E00F7x2-nlc-507",
-      "url": "https://gateway.watsonplatform.net/natural-language-classifier/api/v1/classifiers/5E00F7x2-nlc-507",
+      "url": "https://api.us-south.natural-language-classifier.watson.cloud.ibm.com/v1/classifiers/5E00F7x2-nlc-507",
       "name": "Music controls",
       "language": "en",
       "created": "2015-10-17T20:56:29.974Z"

--- a/speech-to-text/README.md
+++ b/speech-to-text/README.md
@@ -39,7 +39,7 @@ System.out.println(transcript);
 
 #### WebSocket support
 
-Speech to Text supports WebSocket, the url is: `wss://stream.watsonplatform.net/speech-to-text/api/v1/recognize`
+Speech to Text supports WebSocket, the url is: `wss://api.us-south.speech-to-text.watson.cloud.ibm.com/v1/recognize`
 
 ```java
 Authenticator authenticator = new IamAuthenticator("<iam_api_key>");

--- a/speech-to-text/src/test/resources/speech_to_text/jobs.json
+++ b/speech-to-text/src/test/resources/speech_to_text/jobs.json
@@ -8,7 +8,7 @@
     "id": "2d0ef860-872e-11e6-90d3-5f28bc58ceb2",
     "status": "processing",
     "created": "2016-09-30T16:51:47.558",
-    "url": "https://stream.watsonplatform.net/speech-to-text/api/v1/recognitions/2d0ef860-872e-11e6-90d3-5f28bc58ceb2"
+    "url": "https://api.us-south.speech-to-text.watson.cloud.ibm.com/v1/recognitions/2d0ef860-872e-11e6-90d3-5f28bc58ceb2"
   }, {
     "id": "2d0ef860-872e-11e6-90d3-5f28bc58ceb2",
     "results": [{


### PR DESCRIPTION
### Summary
watsonplatform.net urls will cease to function 12 feb 2021. This pull request updates the urls with corresponding onecloud urls.