### PR TITLE
feat(discovery-v2): add collectionId to QueryNoticesOptions and updat…

### DIFF
--- a/discovery/src/main/java/com/ibm/watson/discovery/v2/Discovery.java
+++ b/discovery/src/main/java/com/ibm/watson/discovery/v2/Discovery.java
@@ -508,10 +508,13 @@ public class Discovery extends BaseService {
         queryNoticesOptions, "queryNoticesOptions cannot be null");
     Map<String, String> pathParamsMap = new HashMap<String, String>();
     pathParamsMap.put("project_id", queryNoticesOptions.projectId());
+    pathParamsMap.put("collection_id", queryNoticesOptions.collectionId());
     RequestBuilder builder =
         RequestBuilder.get(
             RequestBuilder.resolveRequestUrl(
-                getServiceUrl(), "/v2/projects/{project_id}/notices", pathParamsMap));
+                getServiceUrl(),
+                "/v2/projects/{project_id}/collections/{collection_id}/notices",
+                pathParamsMap));
     Map<String, String> sdkHeaders = SdkCommon.getSdkHeaders("discovery", "v2", "queryNotices");
     for (Entry<String, String> header : sdkHeaders.entrySet()) {
       builder.header(header.getKey(), header.getValue());

--- a/discovery/src/main/java/com/ibm/watson/discovery/v2/model/QueryNoticesOptions.java
+++ b/discovery/src/main/java/com/ibm/watson/discovery/v2/model/QueryNoticesOptions.java
@@ -18,6 +18,7 @@ import com.ibm.cloud.sdk.core.service.model.GenericModel;
 public class QueryNoticesOptions extends GenericModel {
 
   protected String projectId;
+  protected String collectionId;
   protected String filter;
   protected String query;
   protected String naturalLanguageQuery;
@@ -27,6 +28,7 @@ public class QueryNoticesOptions extends GenericModel {
   /** Builder. */
   public static class Builder {
     private String projectId;
+    private String collectionId;
     private String filter;
     private String query;
     private String naturalLanguageQuery;
@@ -35,6 +37,7 @@ public class QueryNoticesOptions extends GenericModel {
 
     private Builder(QueryNoticesOptions queryNoticesOptions) {
       this.projectId = queryNoticesOptions.projectId;
+      this.collectionId = queryNoticesOptions.collectionId;
       this.filter = queryNoticesOptions.filter;
       this.query = queryNoticesOptions.query;
       this.naturalLanguageQuery = queryNoticesOptions.naturalLanguageQuery;
@@ -49,9 +52,11 @@ public class QueryNoticesOptions extends GenericModel {
      * Instantiates a new builder with required properties.
      *
      * @param projectId the projectId
+     * @param collectionId the collectionId
      */
-    public Builder(String projectId) {
+    public Builder(String projectId, String collectionId) {
       this.projectId = projectId;
+      this.collectionId = collectionId;
     }
 
     /**
@@ -71,6 +76,17 @@ public class QueryNoticesOptions extends GenericModel {
      */
     public Builder projectId(String projectId) {
       this.projectId = projectId;
+      return this;
+    }
+
+    /**
+     * Set the collectionId.
+     *
+     * @param collectionId the collectionId
+     * @return the QueryNoticesOptions builder
+     */
+    public Builder collectionId(String collectionId) {
+      this.collectionId = collectionId;
       return this;
     }
 
@@ -131,8 +147,12 @@ public class QueryNoticesOptions extends GenericModel {
   }
 
   protected QueryNoticesOptions(Builder builder) {
-    com.ibm.cloud.sdk.core.util.Validator.notEmpty(builder.projectId, "projectId cannot be empty");
+    com.ibm.cloud.sdk.core.util.Validator.notEmpty(
+        builder.projectId, "projectId cannot be empty");
+    com.ibm.cloud.sdk.core.util.Validator.notEmpty(
+        builder.collectionId, "collectionId cannot be empty");
     projectId = builder.projectId;
+    collectionId = builder.collectionId;
     filter = builder.filter;
     query = builder.query;
     naturalLanguageQuery = builder.naturalLanguageQuery;
@@ -159,6 +179,17 @@ public class QueryNoticesOptions extends GenericModel {
    */
   public String projectId() {
     return projectId;
+  }
+
+  /**
+   * Gets the collectionId.
+   *
+   * <p>The ID of the collection.
+   *
+   * @return the collectionId
+   */
+  public String collectionId() {
+    return collectionId;
   }
 
   /**

--- a/discovery/src/test/java/com/ibm/watson/discovery/v2/DiscoveryTest.java
+++ b/discovery/src/test/java/com/ibm/watson/discovery/v2/DiscoveryTest.java
@@ -581,7 +581,7 @@ public class DiscoveryTest {
     // Schedule some responses.
     String mockResponseBody =
         "{\"matching_results\": 15, \"notices\": [{\"notice_id\": \"noticeId\", \"created\": \"2019-01-01T12:00:00\", \"document_id\": \"documentId\", \"collection_id\": \"collectionId\", \"query_id\": \"queryId\", \"severity\": \"warning\", \"step\": \"step\", \"description\": \"description\"}]}";
-    String queryNoticesPath = "/v2/projects/testString/notices";
+    String queryNoticesPath = "/v2/projects/testString/collections/testString/notices";
 
     server.enqueue(
         new MockResponse()
@@ -595,6 +595,7 @@ public class DiscoveryTest {
     QueryNoticesOptions queryNoticesOptionsModel =
         new QueryNoticesOptions.Builder()
             .projectId("testString")
+            .collectionId("testString")
             .filter("testString")
             .query("testString")
             .naturalLanguageQuery("testString")

--- a/discovery/src/test/java/com/ibm/watson/discovery/v2/model/QueryNoticesOptionsTest.java
+++ b/discovery/src/test/java/com/ibm/watson/discovery/v2/model/QueryNoticesOptionsTest.java
@@ -33,6 +33,7 @@ public class QueryNoticesOptionsTest {
     QueryNoticesOptions queryNoticesOptionsModel =
         new QueryNoticesOptions.Builder()
             .projectId("testString")
+            .collectionId("testString")
             .filter("testString")
             .query("testString")
             .naturalLanguageQuery("testString")
@@ -40,6 +41,7 @@ public class QueryNoticesOptionsTest {
             .offset(Long.valueOf("26"))
             .build();
     assertEquals(queryNoticesOptionsModel.projectId(), "testString");
+    assertEquals(queryNoticesOptionsModel.collectionId(), "testString");
     assertEquals(queryNoticesOptionsModel.filter(), "testString");
     assertEquals(queryNoticesOptionsModel.query(), "testString");
     assertEquals(queryNoticesOptionsModel.naturalLanguageQuery(), "testString");


### PR DESCRIPTION
### Summary

Updated the QueryNoticesOptions model to include collectionId field. Updated the queryNotices service call to include the collectionId as a path param.