### PR TITLE
fix(pom.xml): update java-sdk-core version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <sdk-core-version>9.5.4</sdk-core-version>
+        <sdk-core-version>9.12.1</sdk-core-version>
 
         <!-- >>> Replace this with the name of your SDK's github repository -->
         <git-repository-name>java-sdk</git-repository-name>


### PR DESCRIPTION
Updating the version of the core to `9.12.1` so we can allow users to use username and apikey auth for cpd