### PR TITLE
fix(examples-discovery-v2) fix compile errors in DiscoveryV2Example

### DIFF
--- a/examples/src/main/java/com/ibm/watson/discovery/v2/DiscoveryV2Example.java
+++ b/examples/src/main/java/com/ibm/watson/discovery/v2/DiscoveryV2Example.java
@@ -1,3 +1,5 @@
+package com.ibm.watson.discovery.v2;
+
 import com.ibm.cloud.sdk.core.security.Authenticator;
 import com.ibm.cloud.sdk.core.security.BearerTokenAuthenticator;
 import com.ibm.watson.discovery.v2.Discovery;
@@ -39,14 +41,14 @@ public class DiscoveryV2Example {
     String documentId = addResponse.getDocumentId();
 
     // Query your collection with the new document inside.
-    QueryOptions queryOptoins =
+    QueryOptions queryOptions =
         new QueryOptions.Builder()
             .projectId(projectId)
             .addCollectionIds(collectionId)
             .naturalLanguageQuery(
                 "Watson") // Feel free to replace this to query something different.
             .build();
-    QueryResponse queryResponse = service.query(options).execute().getResult();
+    QueryResponse queryResponse = service.query(queryOptions).execute().getResult();
 
     System.out.println(queryResponse.getMatchingResults() + " results were returned by the query!");
 


### PR DESCRIPTION
### Summary

Fixed compile errors in `DiscoveryV2Example.java`. 

- Add package definition
- Fix typo
- Pass `queryOptions` to query caller

### Other Information

If there's anything else that's important and relevant to your pull
request, mention that information here.


Thanks for contributing to the Watson Developer Cloud!